### PR TITLE
[global] 개발환경 배포 시 포맷터 설정 파일 누락 문제 수정

### DIFF
--- a/stage.dockerfile
+++ b/stage.dockerfile
@@ -6,6 +6,7 @@ COPY gradlew .
 COPY gradle gradle
 COPY build.gradle.kts .
 COPY settings.gradle.kts .
+COPY eclipse-formatter.xml .
 
 RUN chmod +x ./gradlew
 RUN ./gradlew dependencies --no-daemon

--- a/stage.dockerfile
+++ b/stage.dockerfile
@@ -1,33 +1,16 @@
 FROM gradle:jdk25-alpine AS build
-
 WORKDIR /app
-
-COPY gradlew .
+COPY gradlew build.gradle.kts settings.gradle.kts eclipse-formatter.xml ./
 COPY gradle gradle
-COPY build.gradle.kts .
-COPY settings.gradle.kts .
-COPY eclipse-formatter.xml .
-
 RUN chmod +x ./gradlew
 RUN ./gradlew dependencies --no-daemon
-
 COPY src src
-
 RUN ./gradlew bootJar --no-daemon
-
-
 FROM amazoncorretto:25-alpine
-
 WORKDIR /app
-
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
-
 COPY --from=build /app/build/libs/*.jar app.jar
-
 RUN chown appuser:appgroup app.jar
-
 USER appuser
-
 EXPOSE 8080
-
 CMD ["java", "-jar", "-Dspring.profiles.active=stage", "app.jar"]


### PR DESCRIPTION
## 개요

Docker 빌드 과정에서 Spotless 플러그인 실행 실패 문제를 해결하기 위해 포맷터 설정 파일을 이미지에 포함시켰습니다.

## 본문

### 작업 이유
CI/CD 파이프라인에서 Docker 이미지를 빌드할 때, `./gradlew bootJar` 실행 시 Spotless 플러그인이 `eclipse-formatter.xml` 파일을 찾지 못해 빌드가 실패하는 문제가 발생했습니다.

### 구현 방식
`stage.dockerfile`에 `COPY eclipse-formatter.xml .` 명령을 추가하여 빌드 컨테이너 내부로 포맷터 설정 파일을 복사하도록 수정했습니다.
