### PR TITLE
[machine] 관리자 대시보드 API 전체 구현

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/machine/controller/AdminMachineController.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/controller/AdminMachineController.java
@@ -1,0 +1,47 @@
+package team.washer.server.v2.domain.machine.controller;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.machine.dto.request.UpdateMachineStatusReqDto;
+import team.washer.server.v2.domain.machine.dto.response.MachineListResDto;
+import team.washer.server.v2.domain.machine.dto.response.MachineStatusUpdateResDto;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.service.QueryAllMachinesService;
+import team.washer.server.v2.domain.machine.service.UpdateMachineStatusService;
+
+@RestController
+@RequestMapping("/api/v2/admin/machines")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "Admin Machine Management", description = "기기 관리 API (관리자용)")
+public class AdminMachineController {
+
+    private final QueryAllMachinesService queryAllMachinesService;
+    private final UpdateMachineStatusService updateMachineStatusService;
+
+    @GetMapping
+    @Operation(summary = "전체 기기 조회", description = "필터링 옵션으로 기기 목록을 조회합니다")
+    public MachineListResDto getMachines(
+            @Parameter(description = "기기명 (부분 검색)") @RequestParam(required = false) String name,
+            @Parameter(description = "기기 유형") @RequestParam(required = false) MachineType type,
+            @Parameter(description = "층") @RequestParam(required = false) Integer floor,
+            @Parameter(description = "기기 상태") @RequestParam(required = false) MachineStatus status) {
+        return queryAllMachinesService.execute(name, type, floor, status);
+    }
+
+    @PutMapping("/{id}/status")
+    @Operation(summary = "기기 상태 변경", description = "기기의 상태(NORMAL/MALFUNCTION)를 변경합니다")
+    public MachineStatusUpdateResDto updateMachineStatus(
+            @Parameter(description = "기기 ID") @PathVariable @NotNull Long id,
+            @Valid @RequestBody UpdateMachineStatusReqDto request) {
+        return updateMachineStatusService.execute(id, request.status());
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/controller/AdminMachineController.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/controller/AdminMachineController.java
@@ -1,5 +1,6 @@
 package team.washer.server.v2.domain.machine.controller;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,13 +29,14 @@ public class AdminMachineController {
     private final UpdateMachineStatusService updateMachineStatusService;
 
     @GetMapping
-    @Operation(summary = "전체 기기 조회", description = "필터링 옵션으로 기기 목록을 조회합니다")
+    @Operation(summary = "전체 기기 조회", description = "필터링 옵션으로 기기 목록을 조회합니다 (페이지네이션 지원)")
     public MachineListResDto getMachines(
             @Parameter(description = "기기명 (부분 검색)") @RequestParam(required = false) String name,
             @Parameter(description = "기기 유형") @RequestParam(required = false) MachineType type,
             @Parameter(description = "층") @RequestParam(required = false) Integer floor,
-            @Parameter(description = "기기 상태") @RequestParam(required = false) MachineStatus status) {
-        return queryAllMachinesService.execute(name, type, floor, status);
+            @Parameter(description = "기기 상태") @RequestParam(required = false) MachineStatus status,
+            Pageable pageable) {
+        return queryAllMachinesService.execute(name, type, floor, status, pageable);
     }
 
     @PutMapping("/{id}/status")

--- a/src/main/java/team/washer/server/v2/domain/machine/dto/request/UpdateMachineStatusReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/dto/request/UpdateMachineStatusReqDto.java
@@ -1,0 +1,10 @@
+package team.washer.server.v2.domain.machine.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+
+@Schema(description = "기기 상태 변경 요청 DTO")
+public record UpdateMachineStatusReqDto(
+        @Schema(description = "기기 상태", example = "NORMAL", requiredMode = Schema.RequiredMode.REQUIRED) @NotNull(message = "기기 상태는 필수입니다") MachineStatus status) {
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/dto/response/MachineListResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/dto/response/MachineListResDto.java
@@ -1,0 +1,10 @@
+package team.washer.server.v2.domain.machine.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "기기 목록 응답 DTO")
+public record MachineListResDto(@Schema(description = "기기 목록") List<MachineResDto> machines,
+        @Schema(description = "총 개수", example = "10") int totalCount) {
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/dto/response/MachineListResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/dto/response/MachineListResDto.java
@@ -6,5 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "기기 목록 응답 DTO")
 public record MachineListResDto(@Schema(description = "기기 목록") List<MachineResDto> machines,
-        @Schema(description = "총 개수", example = "10") int totalCount) {
+        @Schema(description = "총 기기 개수", example = "100") long totalCount,
+        @Schema(description = "총 페이지 수", example = "10") int totalPages,
+        @Schema(description = "현재 페이지 번호", example = "0") int currentPage) {
 }

--- a/src/main/java/team/washer/server/v2/domain/machine/dto/response/MachineResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/dto/response/MachineResDto.java
@@ -1,0 +1,19 @@
+package team.washer.server.v2.domain.machine.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.enums.Position;
+
+@Schema(description = "기기 응답 DTO")
+public record MachineResDto(@Schema(description = "기기 ID", example = "1") Long id,
+        @Schema(description = "기기명", example = "W-2F-L1") String name,
+        @Schema(description = "기기 유형", example = "WASHER") MachineType type,
+        @Schema(description = "층", example = "2") Integer floor,
+        @Schema(description = "위치", example = "LEFT") Position position,
+        @Schema(description = "번호", example = "1") Integer number,
+        @Schema(description = "기기 상태", example = "NORMAL") MachineStatus status,
+        @Schema(description = "사용 가능 여부", example = "AVAILABLE") MachineAvailability availability,
+        @Schema(description = "SmartThings Device ID", example = "abc-123") String deviceId) {
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/dto/response/MachineStatusUpdateResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/dto/response/MachineStatusUpdateResDto.java
@@ -1,0 +1,12 @@
+package team.washer.server.v2.domain.machine.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+
+@Schema(description = "기기 상태 변경 응답 DTO")
+public record MachineStatusUpdateResDto(@Schema(description = "기기 ID", example = "1") Long id,
+        @Schema(description = "기기명", example = "W-2F-L1") String name,
+        @Schema(description = "변경된 상태", example = "NORMAL") MachineStatus status,
+        @Schema(description = "변경된 사용 가능 여부", example = "AVAILABLE") MachineAvailability availability) {
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/repository/MachineRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/repository/MachineRepository.java
@@ -10,9 +10,10 @@ import org.springframework.stereotype.Repository;
 
 import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.machine.enums.*;
+import team.washer.server.v2.domain.machine.repository.custom.MachineRepositoryCustom;
 
 @Repository
-public interface MachineRepository extends JpaRepository<Machine, Long> {
+public interface MachineRepository extends JpaRepository<Machine, Long>, MachineRepositoryCustom {
 
     Optional<Machine> findByDeviceId(String deviceId);
 

--- a/src/main/java/team/washer/server/v2/domain/machine/repository/custom/MachineRepositoryCustom.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/repository/custom/MachineRepositoryCustom.java
@@ -1,0 +1,11 @@
+package team.washer.server.v2.domain.machine.repository.custom;
+
+import java.util.List;
+
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+
+public interface MachineRepositoryCustom {
+    List<Machine> findAllWithFilters(String name, MachineType type, Integer floor, MachineStatus status);
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/repository/custom/MachineRepositoryCustom.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/repository/custom/MachineRepositoryCustom.java
@@ -1,11 +1,16 @@
 package team.washer.server.v2.domain.machine.repository.custom;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.machine.enums.MachineStatus;
 import team.washer.server.v2.domain.machine.enums.MachineType;
 
 public interface MachineRepositoryCustom {
-    List<Machine> findAllWithFilters(String name, MachineType type, Integer floor, MachineStatus status);
+    Page<Machine> findAllWithFilters(String name,
+            MachineType type,
+            Integer floor,
+            MachineStatus status,
+            Pageable pageable);
 }

--- a/src/main/java/team/washer/server/v2/domain/machine/repository/custom/impl/MachineRepositoryCustomImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/repository/custom/impl/MachineRepositoryCustomImpl.java
@@ -1,0 +1,46 @@
+package team.washer.server.v2.domain.machine.repository.custom.impl;
+
+import java.util.List;
+
+import org.springframework.util.StringUtils;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.entity.QMachine;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.repository.custom.MachineRepositoryCustom;
+
+@RequiredArgsConstructor
+public class MachineRepositoryCustomImpl implements MachineRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Machine> findAllWithFilters(String name, MachineType type, Integer floor, MachineStatus status) {
+        final var machine = QMachine.machine;
+
+        return queryFactory.selectFrom(machine)
+                .where(nameContains(name), typeEquals(type), floorEquals(floor), statusEquals(status))
+                .orderBy(machine.floor.asc(), machine.type.asc(), machine.number.asc()).fetch();
+    }
+
+    private BooleanExpression nameContains(String name) {
+        return StringUtils.hasText(name) ? QMachine.machine.name.contains(name) : null;
+    }
+
+    private BooleanExpression typeEquals(MachineType type) {
+        return type != null ? QMachine.machine.type.eq(type) : null;
+    }
+
+    private BooleanExpression floorEquals(Integer floor) {
+        return floor != null ? QMachine.machine.floor.eq(floor) : null;
+    }
+
+    private BooleanExpression statusEquals(MachineStatus status) {
+        return status != null ? QMachine.machine.status.eq(status) : null;
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesService.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesService.java
@@ -1,0 +1,9 @@
+package team.washer.server.v2.domain.machine.service;
+
+import team.washer.server.v2.domain.machine.dto.response.MachineListResDto;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+
+public interface QueryAllMachinesService {
+    MachineListResDto execute(String name, MachineType type, Integer floor, MachineStatus status);
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesService.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesService.java
@@ -1,9 +1,11 @@
 package team.washer.server.v2.domain.machine.service;
 
+import org.springframework.data.domain.Pageable;
+
 import team.washer.server.v2.domain.machine.dto.response.MachineListResDto;
 import team.washer.server.v2.domain.machine.enums.MachineStatus;
 import team.washer.server.v2.domain.machine.enums.MachineType;
 
 public interface QueryAllMachinesService {
-    MachineListResDto execute(String name, MachineType type, Integer floor, MachineStatus status);
+    MachineListResDto execute(String name, MachineType type, Integer floor, MachineStatus status, Pageable pageable);
 }

--- a/src/main/java/team/washer/server/v2/domain/machine/service/UpdateMachineStatusService.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/UpdateMachineStatusService.java
@@ -1,0 +1,8 @@
+package team.washer.server.v2.domain.machine.service;
+
+import team.washer.server.v2.domain.machine.dto.response.MachineStatusUpdateResDto;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+
+public interface UpdateMachineStatusService {
+    MachineStatusUpdateResDto execute(Long machineId, MachineStatus status);
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesServiceImpl.java
@@ -1,5 +1,6 @@
 package team.washer.server.v2.domain.machine.service.impl;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,11 +21,18 @@ public class QueryAllMachinesServiceImpl implements QueryAllMachinesService {
 
     @Transactional(readOnly = true)
     @Override
-    public MachineListResDto execute(String name, MachineType type, Integer floor, MachineStatus status) {
-        final var machines = machineRepository.findAllWithFilters(name, type, floor, status);
-        final var machineDtos = machines.stream().map(this::toMachineResDto).toList();
+    public MachineListResDto execute(String name,
+            MachineType type,
+            Integer floor,
+            MachineStatus status,
+            Pageable pageable) {
+        final var machinesPage = machineRepository.findAllWithFilters(name, type, floor, status, pageable);
+        final var machineDtos = machinesPage.getContent().stream().map(this::toMachineResDto).toList();
 
-        return new MachineListResDto(machineDtos, machineDtos.size());
+        return new MachineListResDto(machineDtos,
+                machinesPage.getTotalElements(),
+                machinesPage.getTotalPages(),
+                machinesPage.getNumber());
     }
 
     private MachineResDto toMachineResDto(Machine machine) {

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesServiceImpl.java
@@ -1,0 +1,41 @@
+package team.washer.server.v2.domain.machine.service.impl;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.machine.dto.response.MachineListResDto;
+import team.washer.server.v2.domain.machine.dto.response.MachineResDto;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.machine.service.QueryAllMachinesService;
+
+@Service
+@RequiredArgsConstructor
+public class QueryAllMachinesServiceImpl implements QueryAllMachinesService {
+
+    private final MachineRepository machineRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public MachineListResDto execute(String name, MachineType type, Integer floor, MachineStatus status) {
+        final var machines = machineRepository.findAllWithFilters(name, type, floor, status);
+        final var machineDtos = machines.stream().map(this::toMachineResDto).toList();
+
+        return new MachineListResDto(machineDtos, machineDtos.size());
+    }
+
+    private MachineResDto toMachineResDto(Machine machine) {
+        return new MachineResDto(machine.getId(),
+                machine.getName(),
+                machine.getType(),
+                machine.getFloor(),
+                machine.getPosition(),
+                machine.getNumber(),
+                machine.getStatus(),
+                machine.getAvailability(),
+                machine.getDeviceId());
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/UpdateMachineStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/UpdateMachineStatusServiceImpl.java
@@ -1,0 +1,60 @@
+package team.washer.server.v2.domain.machine.service.impl;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.machine.dto.response.MachineStatusUpdateResDto;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.machine.service.UpdateMachineStatusService;
+import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.global.common.error.exception.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateMachineStatusServiceImpl implements UpdateMachineStatusService {
+
+    private final MachineRepository machineRepository;
+    private final ReservationRepository reservationRepository;
+
+    @Transactional
+    @Override
+    public MachineStatusUpdateResDto execute(Long machineId, MachineStatus status) {
+        final var machine = machineRepository.findById(machineId)
+                .orElseThrow(() -> new ExpectedException("기기를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        if (status == MachineStatus.MALFUNCTION) {
+            machine.markAsMalfunction();
+        } else if (status == MachineStatus.NORMAL) {
+            machine.markAsNormal();
+
+            // 활성 예약이 있는지 확인
+            final var activeReservation = findActiveReservation(machine);
+            if (activeReservation != null) {
+                machine.markAsReserved();
+            }
+        }
+
+        final var savedMachine = machineRepository.save(machine);
+
+        return new MachineStatusUpdateResDto(savedMachine.getId(),
+                savedMachine.getName(),
+                savedMachine.getStatus(),
+                savedMachine.getAvailability());
+    }
+
+    private Reservation findActiveReservation(Machine machine) {
+        final var activeStatuses = List
+                .of(ReservationStatus.RESERVED, ReservationStatus.CONFIRMED, ReservationStatus.RUNNING);
+        final var activeReservations = reservationRepository.findByMachineAndStatusIn(machine, activeStatuses);
+
+        return activeReservations.isEmpty() ? null : activeReservations.get(0);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/controller/AdminReservationController.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/controller/AdminReservationController.java
@@ -2,6 +2,7 @@ package team.washer.server.v2.domain.reservation.controller;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -79,15 +80,16 @@ public class AdminReservationController {
     }
 
     @GetMapping
-    @Operation(summary = "전체 예약 조회", description = "필터링 옵션으로 예약 목록을 조회합니다")
+    @Operation(summary = "전체 예약 조회", description = "필터링 옵션으로 예약 목록을 조회합니다 (페이지네이션 지원)")
     public AdminReservationListResDto getReservations(
             @Parameter(description = "사용자 이름 (부분 검색)") @RequestParam(required = false) String userName,
             @Parameter(description = "기기명 (부분 검색)") @RequestParam(required = false) String machineName,
             @Parameter(description = "예약 상태") @RequestParam(required = false) ReservationStatus status,
             @Parameter(description = "시작일") @RequestParam(required = false) LocalDateTime startDate,
-            @Parameter(description = "종료일") @RequestParam(required = false) LocalDateTime endDate) {
+            @Parameter(description = "종료일") @RequestParam(required = false) LocalDateTime endDate,
+            Pageable pageable) {
 
-        return queryAllReservationsService.execute(userName, machineName, status, startDate, endDate);
+        return queryAllReservationsService.execute(userName, machineName, status, startDate, endDate, pageable);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/team/washer/server/v2/domain/reservation/dto/response/AdminCancellationResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/dto/response/AdminCancellationResDto.java
@@ -1,0 +1,13 @@
+package team.washer.server.v2.domain.reservation.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자 예약 강제 취소 응답 DTO")
+public record AdminCancellationResDto(@Schema(description = "취소된 예약 ID", example = "1") Long reservationId,
+        @Schema(description = "사용자 이름", example = "김철수") String userName,
+        @Schema(description = "기기명", example = "W-2F-L1") String machineName,
+        @Schema(description = "취소 시간", example = "2026-01-29T12:30:00") LocalDateTime cancelledAt,
+        @Schema(description = "패널티 부과 여부", example = "false") boolean penaltyApplied) {
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/dto/response/AdminReservationListResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/dto/response/AdminReservationListResDto.java
@@ -6,5 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "관리자용 예약 목록 응답 DTO")
 public record AdminReservationListResDto(@Schema(description = "예약 목록") List<AdminReservationResDto> reservations,
-        @Schema(description = "총 개수", example = "10") int totalCount) {
+        @Schema(description = "총 예약 개수", example = "100") long totalCount,
+        @Schema(description = "총 페이지 수", example = "10") int totalPages,
+        @Schema(description = "현재 페이지 번호", example = "0") int currentPage) {
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/dto/response/AdminReservationListResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/dto/response/AdminReservationListResDto.java
@@ -1,0 +1,10 @@
+package team.washer.server.v2.domain.reservation.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관리자용 예약 목록 응답 DTO")
+public record AdminReservationListResDto(@Schema(description = "예약 목록") List<AdminReservationResDto> reservations,
+        @Schema(description = "총 개수", example = "10") int totalCount) {
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/dto/response/AdminReservationResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/dto/response/AdminReservationResDto.java
@@ -1,0 +1,22 @@
+package team.washer.server.v2.domain.reservation.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+
+@Schema(description = "관리자용 예약 응답 DTO")
+public record AdminReservationResDto(@Schema(description = "예약 ID", example = "1") Long id,
+        @Schema(description = "사용자 ID", example = "1") Long userId,
+        @Schema(description = "사용자 이름", example = "김철수") String userName,
+        @Schema(description = "사용자 호실", example = "301") String userRoomNumber,
+        @Schema(description = "기기 ID", example = "1") Long machineId,
+        @Schema(description = "기기명", example = "W-2F-L1") String machineName,
+        @Schema(description = "예약 시간", example = "2026-01-27T21:30:00") LocalDateTime reservedAt,
+        @Schema(description = "시작 시간", example = "2026-01-27T21:30:00") LocalDateTime startTime,
+        @Schema(description = "예상 완료 시간", example = "2026-01-27T23:00:00") LocalDateTime expectedCompletionTime,
+        @Schema(description = "실제 완료 시간", example = "2026-01-27T23:00:00") LocalDateTime actualCompletionTime,
+        @Schema(description = "예약 상태", example = "RESERVED") ReservationStatus status,
+        @Schema(description = "확인 시간", example = "2026-01-27T21:25:00") LocalDateTime confirmedAt,
+        @Schema(description = "취소 시간", example = "2026-01-27T21:20:00") LocalDateTime cancelledAt) {
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/ReservationRepository.java
@@ -76,4 +76,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
     }
 
     boolean existsByMachineAndStatusIn(Machine machine, List<ReservationStatus> statuses);
+
+    boolean existsByUserAndStatusIn(User user, List<ReservationStatus> statuses);
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/ReservationRepositoryCustom.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/ReservationRepositoryCustom.java
@@ -27,4 +27,25 @@ public interface ReservationRepositoryCustom {
     List<Reservation> findExpiredReservations(ReservationStatus status,
             LocalDateTime threshold,
             LocalDateTime recentCutoff);
+
+    /**
+     * 관리자용 예약 목록 조회 (동적 필터링)
+     *
+     * @param userName
+     *            사용자 이름 (부분 검색, null 가능)
+     * @param machineName
+     *            기기명 (부분 검색, null 가능)
+     * @param status
+     *            예약 상태 (null 가능)
+     * @param startDate
+     *            시작일 (null 가능)
+     * @param endDate
+     *            종료일 (null 가능)
+     * @return 필터링된 예약 목록 (생성일 기준 내림차순)
+     */
+    List<Reservation> findAllWithFilters(String userName,
+            String machineName,
+            ReservationStatus status,
+            LocalDateTime startDate,
+            LocalDateTime endDate);
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/ReservationRepositoryCustom.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/ReservationRepositoryCustom.java
@@ -41,11 +41,14 @@ public interface ReservationRepositoryCustom {
      *            시작일 (null 가능)
      * @param endDate
      *            종료일 (null 가능)
-     * @return 필터링된 예약 목록 (생성일 기준 내림차순)
+     * @param pageable
+     *            페이지네이션 정보
+     * @return 필터링된 예약 페이지 (생성일 기준 내림차순)
      */
-    List<Reservation> findAllWithFilters(String userName,
+    Page<Reservation> findAllWithFilters(String userName,
             String machineName,
             ReservationStatus status,
             LocalDateTime startDate,
-            LocalDateTime endDate);
+            LocalDateTime endDate,
+            Pageable pageable);
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/AdminCancelReservationService.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/AdminCancelReservationService.java
@@ -1,0 +1,18 @@
+package team.washer.server.v2.domain.reservation.service;
+
+import team.washer.server.v2.domain.reservation.dto.response.AdminCancellationResDto;
+
+/**
+ * 관리자 예약 강제 취소 서비스
+ */
+public interface AdminCancelReservationService {
+
+    /**
+     * 관리자가 예약을 강제로 취소 (패널티 없음)
+     *
+     * @param reservationId
+     *            예약 ID
+     * @return 취소된 예약 정보
+     */
+    AdminCancellationResDto execute(Long reservationId);
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/QueryAllReservationsService.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/QueryAllReservationsService.java
@@ -2,6 +2,8 @@ package team.washer.server.v2.domain.reservation.service;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.domain.Pageable;
+
 import team.washer.server.v2.domain.reservation.dto.response.AdminReservationListResDto;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 
@@ -10,5 +12,6 @@ public interface QueryAllReservationsService {
             String machineName,
             ReservationStatus status,
             LocalDateTime startDate,
-            LocalDateTime endDate);
+            LocalDateTime endDate,
+            Pageable pageable);
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/QueryAllReservationsService.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/QueryAllReservationsService.java
@@ -1,0 +1,14 @@
+package team.washer.server.v2.domain.reservation.service;
+
+import java.time.LocalDateTime;
+
+import team.washer.server.v2.domain.reservation.dto.response.AdminReservationListResDto;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+
+public interface QueryAllReservationsService {
+    AdminReservationListResDto execute(String userName,
+            String machineName,
+            ReservationStatus status,
+            LocalDateTime startDate,
+            LocalDateTime endDate);
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/AdminCancelReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/AdminCancelReservationServiceImpl.java
@@ -1,7 +1,5 @@
 package team.washer.server.v2.domain.reservation.service.impl;
 
-import java.time.LocalDateTime;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,7 +35,7 @@ public class AdminCancelReservationServiceImpl implements AdminCancelReservation
         return new AdminCancellationResDto(savedReservation.getId(),
                 savedReservation.getUser().getName(),
                 savedReservation.getMachine().getName(),
-                LocalDateTime.now(),
+                savedReservation.getCancelledAt(),
                 false);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/AdminCancelReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/AdminCancelReservationServiceImpl.java
@@ -1,0 +1,43 @@
+package team.washer.server.v2.domain.reservation.service.impl;
+
+import java.time.LocalDateTime;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.reservation.dto.response.AdminCancellationResDto;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.reservation.service.AdminCancelReservationService;
+import team.washer.server.v2.global.common.error.exception.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+public class AdminCancelReservationServiceImpl implements AdminCancelReservationService {
+
+    private final ReservationRepository reservationRepository;
+
+    @Transactional
+    @Override
+    public AdminCancellationResDto execute(Long reservationId) {
+        final var reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new ExpectedException("예약을 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+        if (reservation.getStatus() == ReservationStatus.COMPLETED) {
+            throw new ExpectedException("이미 완료된 예약은 취소할 수 없습니다", HttpStatus.BAD_REQUEST);
+        }
+        if (reservation.getStatus() == ReservationStatus.CANCELLED) {
+            throw new ExpectedException("이미 취소된 예약입니다", HttpStatus.BAD_REQUEST);
+        }
+        reservation.cancel();
+        final var machine = reservation.getMachine();
+        machine.markAsAvailable();
+        final var savedReservation = reservationRepository.save(reservation);
+        return new AdminCancellationResDto(savedReservation.getId(),
+                savedReservation.getUser().getName(),
+                savedReservation.getMachine().getName(),
+                LocalDateTime.now(),
+                false);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryAllReservationsServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryAllReservationsServiceImpl.java
@@ -2,6 +2,7 @@ package team.washer.server.v2.domain.reservation.service.impl;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,13 +26,17 @@ public class QueryAllReservationsServiceImpl implements QueryAllReservationsServ
             String machineName,
             ReservationStatus status,
             LocalDateTime startDate,
-            LocalDateTime endDate) {
+            LocalDateTime endDate,
+            Pageable pageable) {
 
-        final var reservations = reservationRepository
-                .findAllWithFilters(userName, machineName, status, startDate, endDate);
-        final var reservationDtos = reservations.stream().map(this::toAdminReservationResDto).toList();
+        final var reservationsPage = reservationRepository
+                .findAllWithFilters(userName, machineName, status, startDate, endDate, pageable);
+        final var reservationDtos = reservationsPage.getContent().stream().map(this::toAdminReservationResDto).toList();
 
-        return new AdminReservationListResDto(reservationDtos, reservationDtos.size());
+        return new AdminReservationListResDto(reservationDtos,
+                reservationsPage.getTotalElements(),
+                reservationsPage.getTotalPages(),
+                reservationsPage.getNumber());
     }
 
     private AdminReservationResDto toAdminReservationResDto(Reservation reservation) {

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryAllReservationsServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryAllReservationsServiceImpl.java
@@ -1,0 +1,52 @@
+package team.washer.server.v2.domain.reservation.service.impl;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.reservation.dto.response.AdminReservationListResDto;
+import team.washer.server.v2.domain.reservation.dto.response.AdminReservationResDto;
+import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.reservation.service.QueryAllReservationsService;
+
+@Service
+@RequiredArgsConstructor
+public class QueryAllReservationsServiceImpl implements QueryAllReservationsService {
+
+    private final ReservationRepository reservationRepository;
+
+    @Transactional(readOnly = true)
+    @Override
+    public AdminReservationListResDto execute(String userName,
+            String machineName,
+            ReservationStatus status,
+            LocalDateTime startDate,
+            LocalDateTime endDate) {
+
+        final var reservations = reservationRepository
+                .findAllWithFilters(userName, machineName, status, startDate, endDate);
+        final var reservationDtos = reservations.stream().map(this::toAdminReservationResDto).toList();
+
+        return new AdminReservationListResDto(reservationDtos, reservationDtos.size());
+    }
+
+    private AdminReservationResDto toAdminReservationResDto(Reservation reservation) {
+        return new AdminReservationResDto(reservation.getId(),
+                reservation.getUser().getId(),
+                reservation.getUser().getName(),
+                reservation.getUser().getRoomNumber(),
+                reservation.getMachine().getId(),
+                reservation.getMachine().getName(),
+                reservation.getReservedAt(),
+                reservation.getStartTime(),
+                reservation.getExpectedCompletionTime(),
+                reservation.getActualCompletionTime(),
+                reservation.getStatus(),
+                reservation.getConfirmedAt(),
+                reservation.getCancelledAt());
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/user/controller/AdminUserController.java
+++ b/src/main/java/team/washer/server/v2/domain/user/controller/AdminUserController.java
@@ -1,21 +1,23 @@
 package team.washer.server.v2.domain.user.controller;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.user.dto.request.UpdateUserReqDto;
 import team.washer.server.v2.domain.user.dto.response.UserListResDto;
 import team.washer.server.v2.domain.user.dto.response.UserResDto;
+import team.washer.server.v2.domain.user.dto.response.UserUpdateResDto;
+import team.washer.server.v2.domain.user.service.DeleteUserService;
 import team.washer.server.v2.domain.user.service.QueryUserByIdService;
 import team.washer.server.v2.domain.user.service.SearchUserService;
+import team.washer.server.v2.domain.user.service.UpdateUserInfoService;
 
 @RestController
 @RequestMapping("/api/v2/admin/users")
@@ -26,6 +28,8 @@ public class AdminUserController {
 
     private final SearchUserService searchUserService;
     private final QueryUserByIdService queryUserByIdService;
+    private final UpdateUserInfoService updateUserInfoService;
+    private final DeleteUserService deleteUserService;
 
     @GetMapping
     @Operation(summary = "전체 사용자 조회", description = "필터링 옵션으로 사용자 목록을 조회합니다")
@@ -40,5 +44,19 @@ public class AdminUserController {
     @Operation(summary = "사용자 상세 조회", description = "ID로 특정 사용자를 조회합니다")
     public UserResDto getUserById(@Parameter(description = "사용자 ID") @PathVariable @NotNull Long id) {
         return queryUserByIdService.getUserById(id);
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "사용자 정보 수정", description = "사용자의 호실, 학년, 층 정보를 수정합니다")
+    public UserUpdateResDto updateUser(@Parameter(description = "사용자 ID") @PathVariable @NotNull Long id,
+            @Valid @RequestBody UpdateUserReqDto request) {
+        return updateUserInfoService.execute(id, request.roomNumber(), request.grade(), request.floor());
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "사용자 삭제", description = "사용자를 삭제합니다 (활성 예약이 없는 경우에만 가능)")
+    public void deleteUser(@Parameter(description = "사용자 ID") @PathVariable @NotNull Long id) {
+        deleteUserService.execute(id);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/user/dto/request/UpdateUserReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/user/dto/request/UpdateUserReqDto.java
@@ -1,0 +1,11 @@
+package team.washer.server.v2.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+
+@Schema(description = "사용자 정보 수정 요청 DTO")
+public record UpdateUserReqDto(
+        @Schema(description = "호실", example = "301") @Pattern(regexp = "^\\d{3,4}$", message = "호실은 3-4자리 숫자여야 합니다") String roomNumber,
+        @Schema(description = "학년", example = "2") @Min(value = 1, message = "학년은 1 이상이어야 합니다") @Max(value = 4, message = "학년은 4 이하여야 합니다") Integer grade,
+        @Schema(description = "층", example = "3") @Min(value = 1, message = "층은 1 이상이어야 합니다") Integer floor) {
+}

--- a/src/main/java/team/washer/server/v2/domain/user/dto/response/UserUpdateResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/user/dto/response/UserUpdateResDto.java
@@ -1,0 +1,12 @@
+package team.washer.server.v2.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자 수정 응답 DTO")
+public record UserUpdateResDto(@Schema(description = "사용자 ID", example = "1") Long id,
+        @Schema(description = "이름", example = "김철수") String name,
+        @Schema(description = "학번", example = "20241234") String studentId,
+        @Schema(description = "호실", example = "301") String roomNumber,
+        @Schema(description = "학년", example = "2") Integer grade,
+        @Schema(description = "층", example = "3") Integer floor) {
+}

--- a/src/main/java/team/washer/server/v2/domain/user/entity/User.java
+++ b/src/main/java/team/washer/server/v2/domain/user/entity/User.java
@@ -150,4 +150,26 @@ public class User extends BaseEntity {
                     HttpStatus.BAD_REQUEST);
         }
     }
+
+    /**
+     * 사용자 정보 수정
+     *
+     * @param roomNumber
+     *            호실 (null이면 유지)
+     * @param grade
+     *            학년 (null이면 유지)
+     * @param floor
+     *            층 (null이면 유지)
+     */
+    public void updateInfo(String roomNumber, Integer grade, Integer floor) {
+        if (roomNumber != null) {
+            this.roomNumber = roomNumber;
+        }
+        if (grade != null) {
+            this.grade = grade;
+        }
+        if (floor != null) {
+            this.floor = floor;
+        }
+    }
 }

--- a/src/main/java/team/washer/server/v2/domain/user/service/DeleteUserService.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/DeleteUserService.java
@@ -1,0 +1,5 @@
+package team.washer.server.v2.domain.user.service;
+
+public interface DeleteUserService {
+    void execute(Long userId);
+}

--- a/src/main/java/team/washer/server/v2/domain/user/service/UpdateUserInfoService.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/UpdateUserInfoService.java
@@ -1,0 +1,7 @@
+package team.washer.server.v2.domain.user.service;
+
+import team.washer.server.v2.domain.user.dto.response.UserUpdateResDto;
+
+public interface UpdateUserInfoService {
+    UserUpdateResDto execute(Long userId, String roomNumber, Integer grade, Integer floor);
+}

--- a/src/main/java/team/washer/server/v2/domain/user/service/impl/DeleteUserServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/impl/DeleteUserServiceImpl.java
@@ -1,0 +1,44 @@
+package team.washer.server.v2.domain.user.service.impl;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.domain.user.service.DeleteUserService;
+import team.washer.server.v2.global.common.error.exception.ExpectedException;
+
+/**
+ * 사용자 삭제 서비스 구현체
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DeleteUserServiceImpl implements DeleteUserService {
+
+    private final UserRepository userRepository;
+    private final ReservationRepository reservationRepository;
+
+    @Override
+    public void execute(Long userId) {
+        final var user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        // 활성 예약이 있는지 확인
+        final var activeStatuses = List
+                .of(ReservationStatus.RESERVED, ReservationStatus.CONFIRMED, ReservationStatus.RUNNING);
+        final boolean hasActiveReservations = reservationRepository.existsByUserAndStatusIn(user, activeStatuses);
+
+        if (hasActiveReservations) {
+            throw new ExpectedException("활성 예약이 있는 사용자는 삭제할 수 없습니다", HttpStatus.BAD_REQUEST);
+        }
+
+        // Hard delete
+        userRepository.delete(user);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/user/service/impl/UpdateUserInfoServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/impl/UpdateUserInfoServiceImpl.java
@@ -1,0 +1,36 @@
+package team.washer.server.v2.domain.user.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.user.dto.response.UserUpdateResDto;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.domain.user.service.UpdateUserInfoService;
+import team.washer.server.v2.global.common.error.exception.ExpectedException;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateUserInfoServiceImpl implements UpdateUserInfoService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    @Override
+    public UserUpdateResDto execute(Long userId, String roomNumber, Integer grade, Integer floor) {
+        final var user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        user.updateInfo(roomNumber, grade, floor);
+
+        final var savedUser = userRepository.save(user);
+
+        return new UserUpdateResDto(savedUser.getId(),
+                savedUser.getName(),
+                savedUser.getStudentId(),
+                savedUser.getRoomNumber(),
+                savedUser.getGrade(),
+                savedUser.getFloor());
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesServiceTest.java
@@ -1,0 +1,195 @@
+package team.washer.server.v2.domain.machine.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import team.washer.server.v2.domain.machine.dto.response.MachineListResDto;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.enums.Position;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.machine.service.impl.QueryAllMachinesServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("QueryAllMachinesServiceImpl 클래스의")
+class QueryAllMachinesServiceTest {
+
+    @InjectMocks
+    private QueryAllMachinesServiceImpl queryAllMachinesService;
+
+    @Mock
+    private MachineRepository machineRepository;
+
+    private Machine createMachine(String name, MachineType type, Integer floor, MachineStatus status) {
+        return Machine.builder().name(name).type(type).deviceId("device-" + name).floor(floor).position(Position.LEFT)
+                .number(1).status(status).availability(MachineAvailability.AVAILABLE).build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("이름으로 필터링할 때")
+        class Context_with_name_filter {
+
+            @Test
+            @DisplayName("이름을 포함하는 기기 목록을 반환해야 한다")
+            void it_returns_machines_by_name() {
+                // Given
+                String searchName = "W-2F";
+                Machine machine1 = createMachine("W-2F-L1", MachineType.WASHER, 2, MachineStatus.NORMAL);
+                Machine machine2 = createMachine("W-2F-R1", MachineType.WASHER, 2, MachineStatus.NORMAL);
+                List<Machine> machines = Arrays.asList(machine1, machine2);
+
+                given(machineRepository.findAllWithFilters(searchName, null, null, null)).willReturn(machines);
+
+                // When
+                MachineListResDto result = queryAllMachinesService.execute(searchName, null, null, null);
+
+                // Then
+                assertThat(result.totalCount()).isEqualTo(2);
+                assertThat(result.machines()).allMatch(m -> m.name().contains("W-2F"));
+                then(machineRepository).should(times(1)).findAllWithFilters(searchName, null, null, null);
+            }
+        }
+
+        @Nested
+        @DisplayName("기기 유형으로 필터링할 때")
+        class Context_with_type_filter {
+
+            @Test
+            @DisplayName("해당 유형의 기기 목록을 반환해야 한다")
+            void it_returns_machines_by_type() {
+                // Given
+                MachineType type = MachineType.WASHER;
+                Machine machine = createMachine("W-2F-L1", MachineType.WASHER, 2, MachineStatus.NORMAL);
+                List<Machine> machines = List.of(machine);
+
+                given(machineRepository.findAllWithFilters(null, type, null, null)).willReturn(machines);
+
+                // When
+                MachineListResDto result = queryAllMachinesService.execute(null, type, null, null);
+
+                // Then
+                assertThat(result.totalCount()).isEqualTo(1);
+                assertThat(result.machines().get(0).type()).isEqualTo(MachineType.WASHER);
+                then(machineRepository).should(times(1)).findAllWithFilters(null, type, null, null);
+            }
+        }
+
+        @Nested
+        @DisplayName("층으로 필터링할 때")
+        class Context_with_floor_filter {
+
+            @Test
+            @DisplayName("해당 층의 기기 목록을 반환해야 한다")
+            void it_returns_machines_by_floor() {
+                // Given
+                Integer floor = 3;
+                Machine machine = createMachine("W-3F-L1", MachineType.WASHER, 3, MachineStatus.NORMAL);
+                List<Machine> machines = List.of(machine);
+
+                given(machineRepository.findAllWithFilters(null, null, floor, null)).willReturn(machines);
+
+                // When
+                MachineListResDto result = queryAllMachinesService.execute(null, null, floor, null);
+
+                // Then
+                assertThat(result.totalCount()).isEqualTo(1);
+                assertThat(result.machines().get(0).floor()).isEqualTo(3);
+                then(machineRepository).should(times(1)).findAllWithFilters(null, null, floor, null);
+            }
+        }
+
+        @Nested
+        @DisplayName("상태로 필터링할 때")
+        class Context_with_status_filter {
+
+            @Test
+            @DisplayName("해당 상태의 기기 목록을 반환해야 한다")
+            void it_returns_machines_by_status() {
+                // Given
+                MachineStatus status = MachineStatus.MALFUNCTION;
+                Machine machine = createMachine("W-2F-L1", MachineType.WASHER, 2, MachineStatus.MALFUNCTION);
+                List<Machine> machines = List.of(machine);
+
+                given(machineRepository.findAllWithFilters(null, null, null, status)).willReturn(machines);
+
+                // When
+                MachineListResDto result = queryAllMachinesService.execute(null, null, null, status);
+
+                // Then
+                assertThat(result.totalCount()).isEqualTo(1);
+                assertThat(result.machines().get(0).status()).isEqualTo(MachineStatus.MALFUNCTION);
+                then(machineRepository).should(times(1)).findAllWithFilters(null, null, null, status);
+            }
+        }
+
+        @Nested
+        @DisplayName("필터가 없을 때")
+        class Context_without_filter {
+
+            @Test
+            @DisplayName("모든 기기 목록을 반환해야 한다")
+            void it_returns_all_machines() {
+                // Given
+                Machine machine1 = createMachine("W-2F-L1", MachineType.WASHER, 2, MachineStatus.NORMAL);
+                Machine machine2 = createMachine("D-3F-R1", MachineType.DRYER, 3, MachineStatus.NORMAL);
+                List<Machine> machines = Arrays.asList(machine1, machine2);
+
+                given(machineRepository.findAllWithFilters(null, null, null, null)).willReturn(machines);
+
+                // When
+                MachineListResDto result = queryAllMachinesService.execute(null, null, null, null);
+
+                // Then
+                assertThat(result.totalCount()).isEqualTo(2);
+                then(machineRepository).should(times(1)).findAllWithFilters(null, null, null, null);
+            }
+        }
+
+        @Nested
+        @DisplayName("여러 조건으로 동시에 필터링할 때")
+        class Context_with_multiple_filters {
+
+            @Test
+            @DisplayName("모든 조건을 AND로 조합하여 기기를 반환해야 한다")
+            void it_returns_machines_matching_all_conditions() {
+                // Given
+                String name = "W-2F";
+                MachineType type = MachineType.WASHER;
+                Integer floor = 2;
+                MachineStatus status = MachineStatus.NORMAL;
+                Machine machine = createMachine("W-2F-L1", MachineType.WASHER, 2, MachineStatus.NORMAL);
+                List<Machine> machines = List.of(machine);
+
+                given(machineRepository.findAllWithFilters(name, type, floor, status)).willReturn(machines);
+
+                // When
+                MachineListResDto result = queryAllMachinesService.execute(name, type, floor, status);
+
+                // Then
+                assertThat(result.totalCount()).isEqualTo(1);
+                assertThat(result.machines().get(0).name()).contains("W-2F");
+                assertThat(result.machines().get(0).type()).isEqualTo(MachineType.WASHER);
+                assertThat(result.machines().get(0).floor()).isEqualTo(2);
+                assertThat(result.machines().get(0).status()).isEqualTo(MachineStatus.NORMAL);
+                then(machineRepository).should(times(1)).findAllWithFilters(name, type, floor, status);
+            }
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesServiceTest.java
@@ -13,6 +13,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import team.washer.server.v2.domain.machine.dto.response.MachineListResDto;
 import team.washer.server.v2.domain.machine.entity.Machine;
@@ -54,16 +58,21 @@ class QueryAllMachinesServiceTest {
                 Machine machine1 = createMachine("W-2F-L1", MachineType.WASHER, 2, MachineStatus.NORMAL);
                 Machine machine2 = createMachine("W-2F-R1", MachineType.WASHER, 2, MachineStatus.NORMAL);
                 List<Machine> machines = Arrays.asList(machine1, machine2);
+                Page<Machine> machinePage = new PageImpl<>(machines, PageRequest.of(0, 10), machines.size());
 
-                given(machineRepository.findAllWithFilters(searchName, null, null, null)).willReturn(machines);
+                given(machineRepository
+                        .findAllWithFilters(eq(searchName), eq(null), eq(null), eq(null), any(Pageable.class)))
+                        .willReturn(machinePage);
 
                 // When
-                MachineListResDto result = queryAllMachinesService.execute(searchName, null, null, null);
+                MachineListResDto result = queryAllMachinesService
+                        .execute(searchName, null, null, null, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(2);
                 assertThat(result.machines()).allMatch(m -> m.name().contains("W-2F"));
-                then(machineRepository).should(times(1)).findAllWithFilters(searchName, null, null, null);
+                then(machineRepository).should(times(1))
+                        .findAllWithFilters(eq(searchName), eq(null), eq(null), eq(null), any(Pageable.class));
             }
         }
 
@@ -78,16 +87,20 @@ class QueryAllMachinesServiceTest {
                 MachineType type = MachineType.WASHER;
                 Machine machine = createMachine("W-2F-L1", MachineType.WASHER, 2, MachineStatus.NORMAL);
                 List<Machine> machines = List.of(machine);
+                Page<Machine> machinePage = new PageImpl<>(machines, PageRequest.of(0, 10), machines.size());
 
-                given(machineRepository.findAllWithFilters(null, type, null, null)).willReturn(machines);
+                given(machineRepository.findAllWithFilters(eq(null), eq(type), eq(null), eq(null), any(Pageable.class)))
+                        .willReturn(machinePage);
 
                 // When
-                MachineListResDto result = queryAllMachinesService.execute(null, type, null, null);
+                MachineListResDto result = queryAllMachinesService
+                        .execute(null, type, null, null, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(1);
                 assertThat(result.machines().get(0).type()).isEqualTo(MachineType.WASHER);
-                then(machineRepository).should(times(1)).findAllWithFilters(null, type, null, null);
+                then(machineRepository).should(times(1))
+                        .findAllWithFilters(eq(null), eq(type), eq(null), eq(null), any(Pageable.class));
             }
         }
 
@@ -102,16 +115,21 @@ class QueryAllMachinesServiceTest {
                 Integer floor = 3;
                 Machine machine = createMachine("W-3F-L1", MachineType.WASHER, 3, MachineStatus.NORMAL);
                 List<Machine> machines = List.of(machine);
+                Page<Machine> machinePage = new PageImpl<>(machines, PageRequest.of(0, 10), machines.size());
 
-                given(machineRepository.findAllWithFilters(null, null, floor, null)).willReturn(machines);
+                given(machineRepository
+                        .findAllWithFilters(eq(null), eq(null), eq(floor), eq(null), any(Pageable.class)))
+                        .willReturn(machinePage);
 
                 // When
-                MachineListResDto result = queryAllMachinesService.execute(null, null, floor, null);
+                MachineListResDto result = queryAllMachinesService
+                        .execute(null, null, floor, null, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(1);
                 assertThat(result.machines().get(0).floor()).isEqualTo(3);
-                then(machineRepository).should(times(1)).findAllWithFilters(null, null, floor, null);
+                then(machineRepository).should(times(1))
+                        .findAllWithFilters(eq(null), eq(null), eq(floor), eq(null), any(Pageable.class));
             }
         }
 
@@ -126,16 +144,21 @@ class QueryAllMachinesServiceTest {
                 MachineStatus status = MachineStatus.MALFUNCTION;
                 Machine machine = createMachine("W-2F-L1", MachineType.WASHER, 2, MachineStatus.MALFUNCTION);
                 List<Machine> machines = List.of(machine);
+                Page<Machine> machinePage = new PageImpl<>(machines, PageRequest.of(0, 10), machines.size());
 
-                given(machineRepository.findAllWithFilters(null, null, null, status)).willReturn(machines);
+                given(machineRepository
+                        .findAllWithFilters(eq(null), eq(null), eq(null), eq(status), any(Pageable.class)))
+                        .willReturn(machinePage);
 
                 // When
-                MachineListResDto result = queryAllMachinesService.execute(null, null, null, status);
+                MachineListResDto result = queryAllMachinesService
+                        .execute(null, null, null, status, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(1);
                 assertThat(result.machines().get(0).status()).isEqualTo(MachineStatus.MALFUNCTION);
-                then(machineRepository).should(times(1)).findAllWithFilters(null, null, null, status);
+                then(machineRepository).should(times(1))
+                        .findAllWithFilters(eq(null), eq(null), eq(null), eq(status), any(Pageable.class));
             }
         }
 
@@ -150,15 +173,19 @@ class QueryAllMachinesServiceTest {
                 Machine machine1 = createMachine("W-2F-L1", MachineType.WASHER, 2, MachineStatus.NORMAL);
                 Machine machine2 = createMachine("D-3F-R1", MachineType.DRYER, 3, MachineStatus.NORMAL);
                 List<Machine> machines = Arrays.asList(machine1, machine2);
+                Page<Machine> machinePage = new PageImpl<>(machines, PageRequest.of(0, 10), machines.size());
 
-                given(machineRepository.findAllWithFilters(null, null, null, null)).willReturn(machines);
+                given(machineRepository.findAllWithFilters(eq(null), eq(null), eq(null), eq(null), any(Pageable.class)))
+                        .willReturn(machinePage);
 
                 // When
-                MachineListResDto result = queryAllMachinesService.execute(null, null, null, null);
+                MachineListResDto result = queryAllMachinesService
+                        .execute(null, null, null, null, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(2);
-                then(machineRepository).should(times(1)).findAllWithFilters(null, null, null, null);
+                then(machineRepository).should(times(1))
+                        .findAllWithFilters(eq(null), eq(null), eq(null), eq(null), any(Pageable.class));
             }
         }
 
@@ -176,11 +203,15 @@ class QueryAllMachinesServiceTest {
                 MachineStatus status = MachineStatus.NORMAL;
                 Machine machine = createMachine("W-2F-L1", MachineType.WASHER, 2, MachineStatus.NORMAL);
                 List<Machine> machines = List.of(machine);
+                Page<Machine> machinePage = new PageImpl<>(machines, PageRequest.of(0, 10), machines.size());
 
-                given(machineRepository.findAllWithFilters(name, type, floor, status)).willReturn(machines);
+                given(machineRepository
+                        .findAllWithFilters(eq(name), eq(type), eq(floor), eq(status), any(Pageable.class)))
+                        .willReturn(machinePage);
 
                 // When
-                MachineListResDto result = queryAllMachinesService.execute(name, type, floor, status);
+                MachineListResDto result = queryAllMachinesService
+                        .execute(name, type, floor, status, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(1);
@@ -188,7 +219,8 @@ class QueryAllMachinesServiceTest {
                 assertThat(result.machines().get(0).type()).isEqualTo(MachineType.WASHER);
                 assertThat(result.machines().get(0).floor()).isEqualTo(2);
                 assertThat(result.machines().get(0).status()).isEqualTo(MachineStatus.NORMAL);
-                then(machineRepository).should(times(1)).findAllWithFilters(name, type, floor, status);
+                then(machineRepository).should(times(1))
+                        .findAllWithFilters(eq(name), eq(type), eq(floor), eq(status), any(Pageable.class));
             }
         }
     }

--- a/src/test/java/team/washer/server/v2/domain/machine/service/UpdateMachineStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/UpdateMachineStatusServiceTest.java
@@ -1,0 +1,179 @@
+package team.washer.server.v2.domain.machine.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.washer.server.v2.domain.machine.dto.response.MachineStatusUpdateResDto;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.enums.Position;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.machine.service.impl.UpdateMachineStatusServiceImpl;
+import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.global.common.error.exception.ExpectedException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateMachineStatusServiceImpl 클래스의")
+class UpdateMachineStatusServiceTest {
+
+    @InjectMocks
+    private UpdateMachineStatusServiceImpl updateMachineStatusService;
+
+    @Mock
+    private MachineRepository machineRepository;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    private Machine createMachine(MachineStatus status, MachineAvailability availability) {
+        return Machine.builder().name("W-2F-L1").type(MachineType.WASHER).deviceId("device-1").floor(2)
+                .position(Position.LEFT).number(1).status(status).availability(availability).build();
+    }
+
+    private Reservation createReservation(Machine machine, ReservationStatus status) {
+        User user = User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3).penaltyCount(0)
+                .build();
+
+        return Reservation.builder().user(user).machine(machine).reservedAt(LocalDateTime.now())
+                .startTime(LocalDateTime.now().plusMinutes(10)).status(status).build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("기기를 MALFUNCTION 상태로 변경할 때")
+        class Context_with_malfunction_status {
+
+            @Test
+            @DisplayName("기기 상태를 MALFUNCTION, 가용성을 UNAVAILABLE로 변경해야 한다")
+            void it_changes_machine_to_malfunction() {
+                // Given
+                Long machineId = 1L;
+                Machine machine = createMachine(MachineStatus.NORMAL, MachineAvailability.AVAILABLE);
+
+                given(machineRepository.findById(machineId)).willReturn(Optional.of(machine));
+                given(machineRepository.save(any(Machine.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+                // When
+                MachineStatusUpdateResDto result = updateMachineStatusService.execute(machineId,
+                        MachineStatus.MALFUNCTION);
+
+                // Then
+                assertThat(result.status()).isEqualTo(MachineStatus.MALFUNCTION);
+                assertThat(result.availability()).isEqualTo(MachineAvailability.UNAVAILABLE);
+                then(machineRepository).should(times(1)).findById(machineId);
+                then(machineRepository).should(times(1)).save(any(Machine.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("기기를 NORMAL 상태로 변경할 때")
+        class Context_with_normal_status {
+
+            @Nested
+            @DisplayName("활성 예약이 없는 경우")
+            class Context_without_active_reservation {
+
+                @Test
+                @DisplayName("기기 상태를 NORMAL, 가용성을 AVAILABLE로 변경해야 한다")
+                void it_changes_machine_to_normal_and_available() {
+                    // Given
+                    Long machineId = 1L;
+                    Machine machine = createMachine(MachineStatus.MALFUNCTION, MachineAvailability.UNAVAILABLE);
+
+                    given(machineRepository.findById(machineId)).willReturn(Optional.of(machine));
+                    given(reservationRepository.findByMachineAndStatusIn(any(Machine.class), anyList()))
+                            .willReturn(List.of());
+                    given(machineRepository.save(any(Machine.class)))
+                            .willAnswer(invocation -> invocation.getArgument(0));
+
+                    // When
+                    MachineStatusUpdateResDto result = updateMachineStatusService.execute(machineId,
+                            MachineStatus.NORMAL);
+
+                    // Then
+                    assertThat(result.status()).isEqualTo(MachineStatus.NORMAL);
+                    assertThat(result.availability()).isEqualTo(MachineAvailability.AVAILABLE);
+                    then(machineRepository).should(times(1)).findById(machineId);
+                    then(reservationRepository).should(times(1)).findByMachineAndStatusIn(any(Machine.class),
+                            anyList());
+                    then(machineRepository).should(times(1)).save(any(Machine.class));
+                }
+            }
+
+            @Nested
+            @DisplayName("활성 예약이 있는 경우")
+            class Context_with_active_reservation {
+
+                @Test
+                @DisplayName("기기 상태를 NORMAL, 가용성을 RESERVED로 변경해야 한다")
+                void it_changes_machine_to_normal_and_reserved() {
+                    // Given
+                    Long machineId = 1L;
+                    Machine machine = createMachine(MachineStatus.MALFUNCTION, MachineAvailability.UNAVAILABLE);
+                    Reservation reservation = createReservation(machine, ReservationStatus.RESERVED);
+
+                    given(machineRepository.findById(machineId)).willReturn(Optional.of(machine));
+                    given(reservationRepository.findByMachineAndStatusIn(any(Machine.class), anyList()))
+                            .willReturn(List.of(reservation));
+                    given(machineRepository.save(any(Machine.class)))
+                            .willAnswer(invocation -> invocation.getArgument(0));
+
+                    // When
+                    MachineStatusUpdateResDto result = updateMachineStatusService.execute(machineId,
+                            MachineStatus.NORMAL);
+
+                    // Then
+                    assertThat(result.status()).isEqualTo(MachineStatus.NORMAL);
+                    assertThat(result.availability()).isEqualTo(MachineAvailability.RESERVED);
+                    then(machineRepository).should(times(1)).findById(machineId);
+                    then(reservationRepository).should(times(1)).findByMachineAndStatusIn(any(Machine.class),
+                            anyList());
+                    then(machineRepository).should(times(1)).save(any(Machine.class));
+                }
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 기기 ID로 요청할 때")
+        class Context_with_nonexistent_machine_id {
+
+            @Test
+            @DisplayName("ExpectedException을 던져야 한다")
+            void it_throws_expected_exception() {
+                // Given
+                Long machineId = 999L;
+
+                given(machineRepository.findById(machineId)).willReturn(Optional.empty());
+
+                // When & Then
+                assertThatThrownBy(() -> updateMachineStatusService.execute(machineId, MachineStatus.NORMAL))
+                        .isInstanceOf(ExpectedException.class).hasMessage("기기를 찾을 수 없습니다")
+                        .hasFieldOrPropertyWithValue("statusCode", HttpStatus.NOT_FOUND);
+
+                then(machineRepository).should(times(1)).findById(machineId);
+                then(machineRepository).should(never()).save(any(Machine.class));
+            }
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/AdminCancelReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/AdminCancelReservationServiceTest.java
@@ -1,0 +1,229 @@
+package team.washer.server.v2.domain.reservation.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.enums.Position;
+import team.washer.server.v2.domain.reservation.dto.response.AdminCancellationResDto;
+import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.reservation.service.impl.AdminCancelReservationServiceImpl;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.global.common.error.exception.ExpectedException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdminCancelReservationServiceImpl 클래스의")
+class AdminCancelReservationServiceTest {
+
+    @InjectMocks
+    private AdminCancelReservationServiceImpl adminCancelReservationService;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    private User createUser() {
+        return User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3).penaltyCount(0)
+                .build();
+    }
+
+    private Machine createMachine() {
+        return Machine.builder().name("W-2F-L1").type(MachineType.WASHER).deviceId("device-1").floor(2)
+                .position(Position.LEFT).number(1).status(MachineStatus.NORMAL)
+                .availability(MachineAvailability.RESERVED).build();
+    }
+
+    private Reservation createReservation(Long id, ReservationStatus status) {
+        User user = createUser();
+        Machine machine = createMachine();
+
+        Reservation reservation = Reservation.builder().user(user).machine(machine).reservedAt(LocalDateTime.now())
+                .startTime(LocalDateTime.now().plusMinutes(10)).status(status).build();
+
+        // ID 설정 (reflection 사용)
+        try {
+            var idField = reservation.getClass().getSuperclass().getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(reservation, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        return reservation;
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("RESERVED 상태의 예약을 취소할 때")
+        class Context_with_reserved_status {
+
+            @Test
+            @DisplayName("예약을 취소하고 기기를 AVAILABLE 상태로 변경해야 한다")
+            void it_cancels_reservation_and_makes_machine_available() {
+                // Given
+                Long reservationId = 1L;
+                Reservation reservation = createReservation(reservationId, ReservationStatus.RESERVED);
+
+                given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+                given(reservationRepository.save(any(Reservation.class)))
+                        .willAnswer(invocation -> invocation.getArgument(0));
+
+                // When
+                AdminCancellationResDto result = adminCancelReservationService.execute(reservationId);
+
+                // Then
+                assertThat(result.reservationId()).isEqualTo(reservationId);
+                assertThat(result.userName()).isEqualTo("김철수");
+                assertThat(result.machineName()).isEqualTo("W-2F-L1");
+                assertThat(result.penaltyApplied()).isFalse();
+                assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+                assertThat(reservation.getMachine().getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
+                then(reservationRepository).should(times(1)).findById(reservationId);
+                then(reservationRepository).should(times(1)).save(any(Reservation.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("CONFIRMED 상태의 예약을 취소할 때")
+        class Context_with_confirmed_status {
+
+            @Test
+            @DisplayName("예약을 취소하고 기기를 AVAILABLE 상태로 변경해야 한다")
+            void it_cancels_reservation_and_makes_machine_available() {
+                // Given
+                Long reservationId = 1L;
+                Reservation reservation = createReservation(reservationId, ReservationStatus.CONFIRMED);
+
+                given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+                given(reservationRepository.save(any(Reservation.class)))
+                        .willAnswer(invocation -> invocation.getArgument(0));
+
+                // When
+                AdminCancellationResDto result = adminCancelReservationService.execute(reservationId);
+
+                // Then
+                assertThat(result.reservationId()).isEqualTo(reservationId);
+                assertThat(result.penaltyApplied()).isFalse();
+                assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+                assertThat(reservation.getMachine().getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
+                then(reservationRepository).should(times(1)).findById(reservationId);
+                then(reservationRepository).should(times(1)).save(any(Reservation.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("RUNNING 상태의 예약을 취소할 때")
+        class Context_with_running_status {
+
+            @Test
+            @DisplayName("예약을 취소하고 기기를 AVAILABLE 상태로 변경해야 한다")
+            void it_cancels_reservation_and_makes_machine_available() {
+                // Given
+                Long reservationId = 1L;
+                Reservation reservation = createReservation(reservationId, ReservationStatus.RUNNING);
+
+                given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+                given(reservationRepository.save(any(Reservation.class)))
+                        .willAnswer(invocation -> invocation.getArgument(0));
+
+                // When
+                AdminCancellationResDto result = adminCancelReservationService.execute(reservationId);
+
+                // Then
+                assertThat(result.reservationId()).isEqualTo(reservationId);
+                assertThat(result.penaltyApplied()).isFalse();
+                assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+                assertThat(reservation.getMachine().getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
+                then(reservationRepository).should(times(1)).findById(reservationId);
+                then(reservationRepository).should(times(1)).save(any(Reservation.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("COMPLETED 상태의 예약을 취소하려 할 때")
+        class Context_with_completed_status {
+
+            @Test
+            @DisplayName("ExpectedException을 던져야 한다")
+            void it_throws_expected_exception() {
+                // Given
+                Long reservationId = 1L;
+                Reservation reservation = createReservation(reservationId, ReservationStatus.COMPLETED);
+
+                given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+
+                // When & Then
+                assertThatThrownBy(() -> adminCancelReservationService.execute(reservationId))
+                        .isInstanceOf(ExpectedException.class).hasMessage("이미 완료된 예약은 취소할 수 없습니다")
+                        .hasFieldOrPropertyWithValue("statusCode", HttpStatus.BAD_REQUEST);
+
+                then(reservationRepository).should(times(1)).findById(reservationId);
+                then(reservationRepository).should(never()).save(any(Reservation.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("CANCELLED 상태의 예약을 취소하려 할 때")
+        class Context_with_cancelled_status {
+
+            @Test
+            @DisplayName("ExpectedException을 던져야 한다")
+            void it_throws_expected_exception() {
+                // Given
+                Long reservationId = 1L;
+                Reservation reservation = createReservation(reservationId, ReservationStatus.CANCELLED);
+
+                given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+
+                // When & Then
+                assertThatThrownBy(() -> adminCancelReservationService.execute(reservationId))
+                        .isInstanceOf(ExpectedException.class).hasMessage("이미 취소된 예약입니다")
+                        .hasFieldOrPropertyWithValue("statusCode", HttpStatus.BAD_REQUEST);
+
+                then(reservationRepository).should(times(1)).findById(reservationId);
+                then(reservationRepository).should(never()).save(any(Reservation.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 예약 ID로 요청할 때")
+        class Context_with_nonexistent_reservation_id {
+
+            @Test
+            @DisplayName("ExpectedException을 던져야 한다")
+            void it_throws_expected_exception() {
+                // Given
+                Long reservationId = 999L;
+
+                given(reservationRepository.findById(reservationId)).willReturn(Optional.empty());
+
+                // When & Then
+                assertThatThrownBy(() -> adminCancelReservationService.execute(reservationId))
+                        .isInstanceOf(ExpectedException.class).hasMessage("예약을 찾을 수 없습니다")
+                        .hasFieldOrPropertyWithValue("statusCode", HttpStatus.NOT_FOUND);
+
+                then(reservationRepository).should(times(1)).findById(reservationId);
+                then(reservationRepository).should(never()).save(any(Reservation.class));
+            }
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/QueryAllReservationsServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/QueryAllReservationsServiceTest.java
@@ -14,6 +14,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.machine.enums.MachineAvailability;
@@ -72,18 +76,23 @@ class QueryAllReservationsServiceTest {
                 Reservation reservation1 = createReservation(user1, machine, ReservationStatus.RESERVED);
                 Reservation reservation2 = createReservation(user2, machine, ReservationStatus.CONFIRMED);
                 List<Reservation> reservations = Arrays.asList(reservation1, reservation2);
+                Page<Reservation> reservationPage = new PageImpl<>(reservations,
+                        PageRequest.of(0, 10),
+                        reservations.size());
 
-                given(reservationRepository.findAllWithFilters(searchName, null, null, null, null))
-                        .willReturn(reservations);
+                given(reservationRepository.findAllWithFilters(eq(
+                        searchName), eq(null), eq(null), eq(null), eq(null), any(Pageable.class)))
+                        .willReturn(reservationPage);
 
                 // When
                 AdminReservationListResDto result = queryAllReservationsService
-                        .execute(searchName, null, null, null, null);
+                        .execute(searchName, null, null, null, null, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(2);
                 assertThat(result.reservations()).allMatch(r -> r.userName().contains("김"));
-                then(reservationRepository).should(times(1)).findAllWithFilters(searchName, null, null, null, null);
+                then(reservationRepository).should(times(1)).findAllWithFilters(eq(
+                        searchName), eq(null), eq(null), eq(null), eq(null), any(Pageable.class));
             }
         }
 
@@ -100,19 +109,23 @@ class QueryAllReservationsServiceTest {
                 Machine machine = createMachine("W-2F-L1");
                 Reservation reservation = createReservation(user, machine, ReservationStatus.RESERVED);
                 List<Reservation> reservations = List.of(reservation);
+                Page<Reservation> reservationPage = new PageImpl<>(reservations,
+                        PageRequest.of(0, 10),
+                        reservations.size());
 
-                given(reservationRepository.findAllWithFilters(null, searchMachineName, null, null, null))
-                        .willReturn(reservations);
+                given(reservationRepository.findAllWithFilters(eq(
+                        null), eq(searchMachineName), eq(null), eq(null), eq(null), any(Pageable.class)))
+                        .willReturn(reservationPage);
 
                 // When
                 AdminReservationListResDto result = queryAllReservationsService
-                        .execute(null, searchMachineName, null, null, null);
+                        .execute(null, searchMachineName, null, null, null, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(1);
                 assertThat(result.reservations().get(0).machineName()).contains("W-2F");
-                then(reservationRepository).should(times(1))
-                        .findAllWithFilters(null, searchMachineName, null, null, null);
+                then(reservationRepository).should(times(1)).findAllWithFilters(eq(
+                        null), eq(searchMachineName), eq(null), eq(null), eq(null), any(Pageable.class));
             }
         }
 
@@ -129,17 +142,23 @@ class QueryAllReservationsServiceTest {
                 Machine machine = createMachine("W-2F-L1");
                 Reservation reservation = createReservation(user, machine, ReservationStatus.RESERVED);
                 List<Reservation> reservations = List.of(reservation);
+                Page<Reservation> reservationPage = new PageImpl<>(reservations,
+                        PageRequest.of(0, 10),
+                        reservations.size());
 
-                given(reservationRepository.findAllWithFilters(null, null, status, null, null))
-                        .willReturn(reservations);
+                given(reservationRepository
+                        .findAllWithFilters(eq(null), eq(null), eq(status), eq(null), eq(null), any(Pageable.class)))
+                        .willReturn(reservationPage);
 
                 // When
-                AdminReservationListResDto result = queryAllReservationsService.execute(null, null, status, null, null);
+                AdminReservationListResDto result = queryAllReservationsService
+                        .execute(null, null, status, null, null, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(1);
                 assertThat(result.reservations().get(0).status()).isEqualTo(ReservationStatus.RESERVED);
-                then(reservationRepository).should(times(1)).findAllWithFilters(null, null, status, null, null);
+                then(reservationRepository).should(times(1))
+                        .findAllWithFilters(eq(null), eq(null), eq(status), eq(null), eq(null), any(Pageable.class));
             }
         }
 
@@ -157,17 +176,22 @@ class QueryAllReservationsServiceTest {
                 Machine machine = createMachine("W-2F-L1");
                 Reservation reservation = createReservation(user, machine, ReservationStatus.RESERVED);
                 List<Reservation> reservations = List.of(reservation);
+                Page<Reservation> reservationPage = new PageImpl<>(reservations,
+                        PageRequest.of(0, 10),
+                        reservations.size());
 
-                given(reservationRepository.findAllWithFilters(null, null, null, startDate, endDate))
-                        .willReturn(reservations);
+                given(reservationRepository.findAllWithFilters(eq(
+                        null), eq(null), eq(null), eq(startDate), eq(endDate), any(Pageable.class)))
+                        .willReturn(reservationPage);
 
                 // When
                 AdminReservationListResDto result = queryAllReservationsService
-                        .execute(null, null, null, startDate, endDate);
+                        .execute(null, null, null, startDate, endDate, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(1);
-                then(reservationRepository).should(times(1)).findAllWithFilters(null, null, null, startDate, endDate);
+                then(reservationRepository).should(times(1)).findAllWithFilters(eq(
+                        null), eq(null), eq(null), eq(startDate), eq(endDate), any(Pageable.class));
             }
         }
 
@@ -185,15 +209,22 @@ class QueryAllReservationsServiceTest {
                 Reservation reservation1 = createReservation(user1, machine, ReservationStatus.RESERVED);
                 Reservation reservation2 = createReservation(user2, machine, ReservationStatus.CONFIRMED);
                 List<Reservation> reservations = Arrays.asList(reservation1, reservation2);
+                Page<Reservation> reservationPage = new PageImpl<>(reservations,
+                        PageRequest.of(0, 10),
+                        reservations.size());
 
-                given(reservationRepository.findAllWithFilters(null, null, null, null, null)).willReturn(reservations);
+                given(reservationRepository
+                        .findAllWithFilters(eq(null), eq(null), eq(null), eq(null), eq(null), any(Pageable.class)))
+                        .willReturn(reservationPage);
 
                 // When
-                AdminReservationListResDto result = queryAllReservationsService.execute(null, null, null, null, null);
+                AdminReservationListResDto result = queryAllReservationsService
+                        .execute(null, null, null, null, null, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(2);
-                then(reservationRepository).should(times(1)).findAllWithFilters(null, null, null, null, null);
+                then(reservationRepository).should(times(1))
+                        .findAllWithFilters(eq(null), eq(null), eq(null), eq(null), eq(null), any(Pageable.class));
             }
         }
 
@@ -214,21 +245,25 @@ class QueryAllReservationsServiceTest {
                 Machine machine = createMachine("W-2F-L1");
                 Reservation reservation = createReservation(user, machine, ReservationStatus.RESERVED);
                 List<Reservation> reservations = List.of(reservation);
+                Page<Reservation> reservationPage = new PageImpl<>(reservations,
+                        PageRequest.of(0, 10),
+                        reservations.size());
 
-                given(reservationRepository.findAllWithFilters(userName, machineName, status, startDate, endDate))
-                        .willReturn(reservations);
+                given(reservationRepository.findAllWithFilters(eq(
+                        userName), eq(machineName), eq(status), eq(startDate), eq(endDate), any(Pageable.class)))
+                        .willReturn(reservationPage);
 
                 // When
                 AdminReservationListResDto result = queryAllReservationsService
-                        .execute(userName, machineName, status, startDate, endDate);
+                        .execute(userName, machineName, status, startDate, endDate, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(1);
                 assertThat(result.reservations().get(0).userName()).contains("김");
                 assertThat(result.reservations().get(0).machineName()).contains("W-2F");
                 assertThat(result.reservations().get(0).status()).isEqualTo(ReservationStatus.RESERVED);
-                then(reservationRepository).should(times(1))
-                        .findAllWithFilters(userName, machineName, status, startDate, endDate);
+                then(reservationRepository).should(times(1)).findAllWithFilters(eq(
+                        userName), eq(machineName), eq(status), eq(startDate), eq(endDate), any(Pageable.class));
             }
         }
     }

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/QueryAllReservationsServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/QueryAllReservationsServiceTest.java
@@ -1,0 +1,235 @@
+package team.washer.server.v2.domain.reservation.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.enums.Position;
+import team.washer.server.v2.domain.reservation.dto.response.AdminReservationListResDto;
+import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.reservation.service.impl.QueryAllReservationsServiceImpl;
+import team.washer.server.v2.domain.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("QueryAllReservationsServiceImpl 클래스의")
+class QueryAllReservationsServiceTest {
+
+    @InjectMocks
+    private QueryAllReservationsServiceImpl queryAllReservationsService;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    private User createUser(String name, String roomNumber) {
+        return User.builder().name(name).studentId("20210001").roomNumber(roomNumber).grade(3).floor(3).penaltyCount(0)
+                .build();
+    }
+
+    private Machine createMachine(String name) {
+        return Machine.builder().name(name).type(MachineType.WASHER).deviceId("device-1").floor(2)
+                .position(Position.LEFT).number(1).status(MachineStatus.NORMAL)
+                .availability(MachineAvailability.AVAILABLE).build();
+    }
+
+    private Reservation createReservation(User user, Machine machine, ReservationStatus status) {
+        return Reservation.builder().user(user).machine(machine).reservedAt(LocalDateTime.now())
+                .startTime(LocalDateTime.now().plusMinutes(10)).status(status).build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("사용자 이름으로 필터링할 때")
+        class Context_with_user_name_filter {
+
+            @Test
+            @DisplayName("사용자 이름을 포함하는 예약 목록을 반환해야 한다")
+            void it_returns_reservations_by_user_name() {
+                // Given
+                String searchName = "김";
+                User user1 = createUser("김철수", "301");
+                User user2 = createUser("김영희", "302");
+                Machine machine = createMachine("W-2F-L1");
+                Reservation reservation1 = createReservation(user1, machine, ReservationStatus.RESERVED);
+                Reservation reservation2 = createReservation(user2, machine, ReservationStatus.CONFIRMED);
+                List<Reservation> reservations = Arrays.asList(reservation1, reservation2);
+
+                given(reservationRepository.findAllWithFilters(searchName, null, null, null, null))
+                        .willReturn(reservations);
+
+                // When
+                AdminReservationListResDto result = queryAllReservationsService
+                        .execute(searchName, null, null, null, null);
+
+                // Then
+                assertThat(result.totalCount()).isEqualTo(2);
+                assertThat(result.reservations()).allMatch(r -> r.userName().contains("김"));
+                then(reservationRepository).should(times(1)).findAllWithFilters(searchName, null, null, null, null);
+            }
+        }
+
+        @Nested
+        @DisplayName("기기명으로 필터링할 때")
+        class Context_with_machine_name_filter {
+
+            @Test
+            @DisplayName("기기명을 포함하는 예약 목록을 반환해야 한다")
+            void it_returns_reservations_by_machine_name() {
+                // Given
+                String searchMachineName = "W-2F";
+                User user = createUser("김철수", "301");
+                Machine machine = createMachine("W-2F-L1");
+                Reservation reservation = createReservation(user, machine, ReservationStatus.RESERVED);
+                List<Reservation> reservations = List.of(reservation);
+
+                given(reservationRepository.findAllWithFilters(null, searchMachineName, null, null, null))
+                        .willReturn(reservations);
+
+                // When
+                AdminReservationListResDto result = queryAllReservationsService
+                        .execute(null, searchMachineName, null, null, null);
+
+                // Then
+                assertThat(result.totalCount()).isEqualTo(1);
+                assertThat(result.reservations().get(0).machineName()).contains("W-2F");
+                then(reservationRepository).should(times(1))
+                        .findAllWithFilters(null, searchMachineName, null, null, null);
+            }
+        }
+
+        @Nested
+        @DisplayName("예약 상태로 필터링할 때")
+        class Context_with_status_filter {
+
+            @Test
+            @DisplayName("해당 상태의 예약 목록을 반환해야 한다")
+            void it_returns_reservations_by_status() {
+                // Given
+                ReservationStatus status = ReservationStatus.RESERVED;
+                User user = createUser("김철수", "301");
+                Machine machine = createMachine("W-2F-L1");
+                Reservation reservation = createReservation(user, machine, ReservationStatus.RESERVED);
+                List<Reservation> reservations = List.of(reservation);
+
+                given(reservationRepository.findAllWithFilters(null, null, status, null, null))
+                        .willReturn(reservations);
+
+                // When
+                AdminReservationListResDto result = queryAllReservationsService.execute(null, null, status, null, null);
+
+                // Then
+                assertThat(result.totalCount()).isEqualTo(1);
+                assertThat(result.reservations().get(0).status()).isEqualTo(ReservationStatus.RESERVED);
+                then(reservationRepository).should(times(1)).findAllWithFilters(null, null, status, null, null);
+            }
+        }
+
+        @Nested
+        @DisplayName("날짜 범위로 필터링할 때")
+        class Context_with_date_range_filter {
+
+            @Test
+            @DisplayName("해당 날짜 범위의 예약 목록을 반환해야 한다")
+            void it_returns_reservations_by_date_range() {
+                // Given
+                LocalDateTime startDate = LocalDateTime.now();
+                LocalDateTime endDate = LocalDateTime.now().plusDays(7);
+                User user = createUser("김철수", "301");
+                Machine machine = createMachine("W-2F-L1");
+                Reservation reservation = createReservation(user, machine, ReservationStatus.RESERVED);
+                List<Reservation> reservations = List.of(reservation);
+
+                given(reservationRepository.findAllWithFilters(null, null, null, startDate, endDate))
+                        .willReturn(reservations);
+
+                // When
+                AdminReservationListResDto result = queryAllReservationsService
+                        .execute(null, null, null, startDate, endDate);
+
+                // Then
+                assertThat(result.totalCount()).isEqualTo(1);
+                then(reservationRepository).should(times(1)).findAllWithFilters(null, null, null, startDate, endDate);
+            }
+        }
+
+        @Nested
+        @DisplayName("필터가 없을 때")
+        class Context_without_filter {
+
+            @Test
+            @DisplayName("모든 예약 목록을 반환해야 한다")
+            void it_returns_all_reservations() {
+                // Given
+                User user1 = createUser("김철수", "301");
+                User user2 = createUser("이영희", "302");
+                Machine machine = createMachine("W-2F-L1");
+                Reservation reservation1 = createReservation(user1, machine, ReservationStatus.RESERVED);
+                Reservation reservation2 = createReservation(user2, machine, ReservationStatus.CONFIRMED);
+                List<Reservation> reservations = Arrays.asList(reservation1, reservation2);
+
+                given(reservationRepository.findAllWithFilters(null, null, null, null, null)).willReturn(reservations);
+
+                // When
+                AdminReservationListResDto result = queryAllReservationsService.execute(null, null, null, null, null);
+
+                // Then
+                assertThat(result.totalCount()).isEqualTo(2);
+                then(reservationRepository).should(times(1)).findAllWithFilters(null, null, null, null, null);
+            }
+        }
+
+        @Nested
+        @DisplayName("여러 조건으로 동시에 필터링할 때")
+        class Context_with_multiple_filters {
+
+            @Test
+            @DisplayName("모든 조건을 AND로 조합하여 예약을 반환해야 한다")
+            void it_returns_reservations_matching_all_conditions() {
+                // Given
+                String userName = "김";
+                String machineName = "W-2F";
+                ReservationStatus status = ReservationStatus.RESERVED;
+                LocalDateTime startDate = LocalDateTime.now();
+                LocalDateTime endDate = LocalDateTime.now().plusDays(7);
+                User user = createUser("김철수", "301");
+                Machine machine = createMachine("W-2F-L1");
+                Reservation reservation = createReservation(user, machine, ReservationStatus.RESERVED);
+                List<Reservation> reservations = List.of(reservation);
+
+                given(reservationRepository.findAllWithFilters(userName, machineName, status, startDate, endDate))
+                        .willReturn(reservations);
+
+                // When
+                AdminReservationListResDto result = queryAllReservationsService
+                        .execute(userName, machineName, status, startDate, endDate);
+
+                // Then
+                assertThat(result.totalCount()).isEqualTo(1);
+                assertThat(result.reservations().get(0).userName()).contains("김");
+                assertThat(result.reservations().get(0).machineName()).contains("W-2F");
+                assertThat(result.reservations().get(0).status()).isEqualTo(ReservationStatus.RESERVED);
+                then(reservationRepository).should(times(1))
+                        .findAllWithFilters(userName, machineName, status, startDate, endDate);
+            }
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/user/service/DeleteUserServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/service/DeleteUserServiceTest.java
@@ -1,0 +1,228 @@
+package team.washer.server.v2.domain.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.domain.user.service.impl.DeleteUserServiceImpl;
+import team.washer.server.v2.global.common.error.exception.ExpectedException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeleteUserServiceImpl 클래스의")
+class DeleteUserServiceTest {
+
+    @InjectMocks
+    private DeleteUserServiceImpl deleteUserService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    private User createUser() {
+        return User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3).penaltyCount(0)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("활성 예약이 없는 사용자를 삭제할 때")
+        class Context_without_active_reservations {
+
+            @Test
+            @DisplayName("사용자를 삭제해야 한다")
+            void it_deletes_user() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+                List<ReservationStatus> activeStatuses = List
+                        .of(ReservationStatus.RESERVED, ReservationStatus.CONFIRMED, ReservationStatus.RUNNING);
+
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(reservationRepository.existsByUserAndStatusIn(user, activeStatuses)).willReturn(false);
+
+                // When
+                deleteUserService.execute(userId);
+
+                // Then
+                then(userRepository).should(times(1)).findById(userId);
+                then(reservationRepository).should(times(1)).existsByUserAndStatusIn(user, activeStatuses);
+                then(userRepository).should(times(1)).delete(user);
+            }
+        }
+
+        @Nested
+        @DisplayName("RESERVED 상태의 예약이 있는 사용자를 삭제하려 할 때")
+        class Context_with_reserved_reservation {
+
+            @Test
+            @DisplayName("ExpectedException을 던져야 한다")
+            void it_throws_expected_exception() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+                List<ReservationStatus> activeStatuses = List
+                        .of(ReservationStatus.RESERVED, ReservationStatus.CONFIRMED, ReservationStatus.RUNNING);
+
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(reservationRepository.existsByUserAndStatusIn(user, activeStatuses)).willReturn(true);
+
+                // When & Then
+                assertThatThrownBy(() -> deleteUserService.execute(userId)).isInstanceOf(ExpectedException.class)
+                        .hasMessage("활성 예약이 있는 사용자는 삭제할 수 없습니다")
+                        .hasFieldOrPropertyWithValue("statusCode", HttpStatus.BAD_REQUEST);
+
+                then(userRepository).should(times(1)).findById(userId);
+                then(reservationRepository).should(times(1)).existsByUserAndStatusIn(user, activeStatuses);
+                then(userRepository).should(never()).delete(any(User.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("CONFIRMED 상태의 예약이 있는 사용자를 삭제하려 할 때")
+        class Context_with_confirmed_reservation {
+
+            @Test
+            @DisplayName("ExpectedException을 던져야 한다")
+            void it_throws_expected_exception() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+                List<ReservationStatus> activeStatuses = List
+                        .of(ReservationStatus.RESERVED, ReservationStatus.CONFIRMED, ReservationStatus.RUNNING);
+
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(reservationRepository.existsByUserAndStatusIn(user, activeStatuses)).willReturn(true);
+
+                // When & Then
+                assertThatThrownBy(() -> deleteUserService.execute(userId)).isInstanceOf(ExpectedException.class)
+                        .hasMessage("활성 예약이 있는 사용자는 삭제할 수 없습니다")
+                        .hasFieldOrPropertyWithValue("statusCode", HttpStatus.BAD_REQUEST);
+
+                then(userRepository).should(times(1)).findById(userId);
+                then(reservationRepository).should(times(1)).existsByUserAndStatusIn(user, activeStatuses);
+                then(userRepository).should(never()).delete(any(User.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("RUNNING 상태의 예약이 있는 사용자를 삭제하려 할 때")
+        class Context_with_running_reservation {
+
+            @Test
+            @DisplayName("ExpectedException을 던져야 한다")
+            void it_throws_expected_exception() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+                List<ReservationStatus> activeStatuses = List
+                        .of(ReservationStatus.RESERVED, ReservationStatus.CONFIRMED, ReservationStatus.RUNNING);
+
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(reservationRepository.existsByUserAndStatusIn(user, activeStatuses)).willReturn(true);
+
+                // When & Then
+                assertThatThrownBy(() -> deleteUserService.execute(userId)).isInstanceOf(ExpectedException.class)
+                        .hasMessage("활성 예약이 있는 사용자는 삭제할 수 없습니다")
+                        .hasFieldOrPropertyWithValue("statusCode", HttpStatus.BAD_REQUEST);
+
+                then(userRepository).should(times(1)).findById(userId);
+                then(reservationRepository).should(times(1)).existsByUserAndStatusIn(user, activeStatuses);
+                then(userRepository).should(never()).delete(any(User.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("COMPLETED 상태의 예약만 있는 사용자를 삭제할 때")
+        class Context_with_completed_reservations_only {
+
+            @Test
+            @DisplayName("사용자를 삭제해야 한다")
+            void it_deletes_user() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+                List<ReservationStatus> activeStatuses = List
+                        .of(ReservationStatus.RESERVED, ReservationStatus.CONFIRMED, ReservationStatus.RUNNING);
+
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(reservationRepository.existsByUserAndStatusIn(user, activeStatuses)).willReturn(false);
+
+                // When
+                deleteUserService.execute(userId);
+
+                // Then
+                then(userRepository).should(times(1)).findById(userId);
+                then(reservationRepository).should(times(1)).existsByUserAndStatusIn(user, activeStatuses);
+                then(userRepository).should(times(1)).delete(user);
+            }
+        }
+
+        @Nested
+        @DisplayName("CANCELLED 상태의 예약만 있는 사용자를 삭제할 때")
+        class Context_with_cancelled_reservations_only {
+
+            @Test
+            @DisplayName("사용자를 삭제해야 한다")
+            void it_deletes_user() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+                List<ReservationStatus> activeStatuses = List
+                        .of(ReservationStatus.RESERVED, ReservationStatus.CONFIRMED, ReservationStatus.RUNNING);
+
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(reservationRepository.existsByUserAndStatusIn(user, activeStatuses)).willReturn(false);
+
+                // When
+                deleteUserService.execute(userId);
+
+                // Then
+                then(userRepository).should(times(1)).findById(userId);
+                then(reservationRepository).should(times(1)).existsByUserAndStatusIn(user, activeStatuses);
+                then(userRepository).should(times(1)).delete(user);
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 사용자 ID로 요청할 때")
+        class Context_with_nonexistent_user_id {
+
+            @Test
+            @DisplayName("ExpectedException을 던져야 한다")
+            void it_throws_expected_exception() {
+                // Given
+                Long userId = 999L;
+
+                given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+                // When & Then
+                assertThatThrownBy(() -> deleteUserService.execute(userId)).isInstanceOf(ExpectedException.class)
+                        .hasMessage("사용자를 찾을 수 없습니다").hasFieldOrPropertyWithValue("statusCode", HttpStatus.NOT_FOUND);
+
+                then(userRepository).should(times(1)).findById(userId);
+                then(reservationRepository).should(never()).existsByUserAndStatusIn(any(User.class), anyList());
+                then(userRepository).should(never()).delete(any(User.class));
+            }
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/user/service/UpdateUserInfoServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/service/UpdateUserInfoServiceTest.java
@@ -1,0 +1,215 @@
+package team.washer.server.v2.domain.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.washer.server.v2.domain.user.dto.response.UserUpdateResDto;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.domain.user.service.impl.UpdateUserInfoServiceImpl;
+import team.washer.server.v2.global.common.error.exception.ExpectedException;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateUserInfoServiceImpl 클래스의")
+class UpdateUserInfoServiceTest {
+
+    @InjectMocks
+    private UpdateUserInfoServiceImpl updateUserInfoService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User createUser() {
+        return User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3).penaltyCount(0)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("모든 필드를 수정할 때")
+        class Context_with_all_fields {
+
+            @Test
+            @DisplayName("모든 필드가 변경되어야 한다")
+            void it_updates_all_fields() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+                String newRoomNumber = "401";
+                Integer newGrade = 4;
+                Integer newFloor = 4;
+
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+                // When
+                UserUpdateResDto result = updateUserInfoService.execute(userId, newRoomNumber, newGrade, newFloor);
+
+                // Then
+                assertThat(result.roomNumber()).isEqualTo("401");
+                assertThat(result.grade()).isEqualTo(4);
+                assertThat(result.floor()).isEqualTo(4);
+                assertThat(user.getRoomNumber()).isEqualTo("401");
+                assertThat(user.getGrade()).isEqualTo(4);
+                assertThat(user.getFloor()).isEqualTo(4);
+                then(userRepository).should(times(1)).findById(userId);
+                then(userRepository).should(times(1)).save(any(User.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("호실만 수정할 때")
+        class Context_with_room_number_only {
+
+            @Test
+            @DisplayName("호실만 변경되고 나머지는 유지되어야 한다")
+            void it_updates_room_number_only() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+                String newRoomNumber = "401";
+
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+                // When
+                UserUpdateResDto result = updateUserInfoService.execute(userId, newRoomNumber, null, null);
+
+                // Then
+                assertThat(result.roomNumber()).isEqualTo("401");
+                assertThat(result.grade()).isEqualTo(3);
+                assertThat(result.floor()).isEqualTo(3);
+                assertThat(user.getRoomNumber()).isEqualTo("401");
+                assertThat(user.getGrade()).isEqualTo(3);
+                assertThat(user.getFloor()).isEqualTo(3);
+                then(userRepository).should(times(1)).findById(userId);
+                then(userRepository).should(times(1)).save(any(User.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("학년만 수정할 때")
+        class Context_with_grade_only {
+
+            @Test
+            @DisplayName("학년만 변경되고 나머지는 유지되어야 한다")
+            void it_updates_grade_only() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+                Integer newGrade = 4;
+
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+                // When
+                UserUpdateResDto result = updateUserInfoService.execute(userId, null, newGrade, null);
+
+                // Then
+                assertThat(result.roomNumber()).isEqualTo("301");
+                assertThat(result.grade()).isEqualTo(4);
+                assertThat(result.floor()).isEqualTo(3);
+                assertThat(user.getRoomNumber()).isEqualTo("301");
+                assertThat(user.getGrade()).isEqualTo(4);
+                assertThat(user.getFloor()).isEqualTo(3);
+                then(userRepository).should(times(1)).findById(userId);
+                then(userRepository).should(times(1)).save(any(User.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("층만 수정할 때")
+        class Context_with_floor_only {
+
+            @Test
+            @DisplayName("층만 변경되고 나머지는 유지되어야 한다")
+            void it_updates_floor_only() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+                Integer newFloor = 4;
+
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+                // When
+                UserUpdateResDto result = updateUserInfoService.execute(userId, null, null, newFloor);
+
+                // Then
+                assertThat(result.roomNumber()).isEqualTo("301");
+                assertThat(result.grade()).isEqualTo(3);
+                assertThat(result.floor()).isEqualTo(4);
+                assertThat(user.getRoomNumber()).isEqualTo("301");
+                assertThat(user.getGrade()).isEqualTo(3);
+                assertThat(user.getFloor()).isEqualTo(4);
+                then(userRepository).should(times(1)).findById(userId);
+                then(userRepository).should(times(1)).save(any(User.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("모든 필드가 null일 때")
+        class Context_with_all_null {
+
+            @Test
+            @DisplayName("아무것도 변경되지 않아야 한다")
+            void it_updates_nothing() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(userRepository.save(any(User.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+                // When
+                UserUpdateResDto result = updateUserInfoService.execute(userId, null, null, null);
+
+                // Then
+                assertThat(result.roomNumber()).isEqualTo("301");
+                assertThat(result.grade()).isEqualTo(3);
+                assertThat(result.floor()).isEqualTo(3);
+                assertThat(user.getRoomNumber()).isEqualTo("301");
+                assertThat(user.getGrade()).isEqualTo(3);
+                assertThat(user.getFloor()).isEqualTo(3);
+                then(userRepository).should(times(1)).findById(userId);
+                then(userRepository).should(times(1)).save(any(User.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 사용자 ID로 요청할 때")
+        class Context_with_nonexistent_user_id {
+
+            @Test
+            @DisplayName("ExpectedException을 던져야 한다")
+            void it_throws_expected_exception() {
+                // Given
+                Long userId = 999L;
+
+                given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+                // When & Then
+                assertThatThrownBy(() -> updateUserInfoService.execute(userId, "401", 4, 4))
+                        .isInstanceOf(ExpectedException.class).hasMessage("사용자를 찾을 수 없습니다")
+                        .hasFieldOrPropertyWithValue("statusCode", HttpStatus.NOT_FOUND);
+
+                then(userRepository).should(times(1)).findById(userId);
+                then(userRepository).should(never()).save(any(User.class));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

관리자 대시보드를 위한 사용자 관리, 예약 관리, 세탁기 기기 관리 기능을 구현했습니다.
사용자 정보 수정/삭제, 전체 예약 조회(필터링 포함) 및 강제 취소, 기기 목록 조회 및 상태 변경 API를 추가했습니다.

## 본문

### 작업 이유
관리자가 시스템 내 사용자, 예약, 기기 상태를 효율적으로 모니터링하고 제어할 수 있는 기능이 필요했습니다.

### 구현 방식
1. **사용자 관리**
   - 사용자 정보(호실, 학년, 층) 수정 및 계정 삭제 기능을 구현했습니다.
   - 계정 삭제 시 활성 예약이 존재하는 경우 삭제를 방지하는 검증 로직을 포함했습니다.

2. **예약 관리**
   - QueryDSL을 사용하여 사용자명, 기기명, 상태, 날짜 범위 등 다양한 조건으로 예약을 검색할 수 있는 기능을 구현했습니다.
   - 관리자 권한으로 예약을 강제로 취소할 수 있는 기능을 추가했습니다.

3. **기기 관리**
   - 전체 기기 목록을 조회하고, 특정 기기의 상태(고장, 사용 가능 등)를 변경할 수 있는 기능을 구현했습니다.

### 현재 상태
관리자용 API 엔드포인트가 `/api/v2/admin/**` 경로에 추가되었으며, 각 기능에 대한 단위 테스트 작성을 완료했습니다.
