### PR TITLE
[global] 개발환경에서 누락된 프로퍼티 설정 추가

### DIFF
--- a/src/main/java/team/washer/server/v2/global/thirdparty/smartthings/config/SmartThingsEnvironment.java
+++ b/src/main/java/team/washer/server/v2/global/thirdparty/smartthings/config/SmartThingsEnvironment.java
@@ -9,7 +9,7 @@ public record SmartThingsEnvironment(String apiUrl, String oauthUrl, String clie
             apiUrl = "https://api.smartthings.com";
         }
         if (oauthUrl == null || oauthUrl.isBlank()) {
-            oauthUrl = "https://auth-global.api.smartthings.com/oauth/token";
+            oauthUrl = "https://api.smartthings.com/oauth/token";
         }
     }
 }

--- a/src/main/resources/application-stage.yml
+++ b/src/main/resources/application-stage.yml
@@ -37,6 +37,11 @@ server:
 third-party:
   discord:
     webhook-url: ${THIRD_PARTY_DISCORD_WEBHOOK_URL}
+  smartthings:
+    api-url: ${THIRD_PARTY_SMARTTHINGS_API_URL:https://api.smartthings.com}
+    oauth-url: ${THIRD_PARTY_SMARTTHINGS_OAUTH_URL:https://api.smartthings.com/oauth/token}
+    client-id: ${THIRD_PARTY_SMARTTHINGS_CLIENT_ID}
+    client-secret: ${THIRD_PARTY_SMARTTHINGS_CLIENT_SECRET}
 springdoc:
   swagger-ui:
     config-url: "/v3/api-docs/swagger-config"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,7 +37,7 @@ third-party:
     webhook-url: ${DISCORD_WEBHOOK_URL:https://discord.com/api/webhooks/your-webhook-url}
   smartthings:
     api-url: ${SMARTTHINGS_API_URL:https://api.smartthings.com}
-    oauth-url: ${SMARTTHINGS_OAUTH_URL:https://auth-global.api.smartthings.com/oauth/token}
+    oauth-url: ${SMARTTHINGS_OAUTH_URL:https://api.smartthings.com/oauth/token}
     client-id: ${SMARTTHINGS_CLIENT_ID:your-client-id}
     client-secret: ${SMARTTHINGS_CLIENT_SECRET:your-client-secret}
 springdoc:


### PR DESCRIPTION
## 개요

SmartThings 연동을 위한 스테이징 환경 설정 추가 및 기본 OAuth 인증 URL 수정 작업을 수행했습니다.

## 본문

### 작업 이유
스테이징 환경(application-stage.yml)에 SmartThings 관련 필수 설정값이 누락되어 있었으며, 기본 설정(application.yml)의 OAuth 인증 URL이 구형 주소를 가리키고 있어 수정이 필요했습니다.

### 구현 방식
- `application-stage.yml`: `api-url`, `oauth-url`, `client-id`, `client-secret` 속성을 추가하여 환경 변수와 매핑되도록 설정했습니다.
- `application.yml`: `smartthings.oauth-url` 값을 최신 API 엔드포인트로 변경했습니다.

### 현재 상태
스테이징 환경에서 SmartThings 연동 설정이 정상적으로 로드되며, OAuth 인증 요청 시 올바른 URL을 사용합니다.
