### PR TITLE
[global] Bean 명칭 충돌 문제 해결

### DIFF
--- a/src/main/java/team/washer/server/v2/global/config/SchedulerConfig.java
+++ b/src/main/java/team/washer/server/v2/global/config/SchedulerConfig.java
@@ -16,11 +16,11 @@ public class SchedulerConfig implements SchedulingConfigurer {
 
     @Override
     public void configureTasks(final ScheduledTaskRegistrar taskRegistrar) {
-        taskRegistrar.setScheduler(taskScheduler());
+        taskRegistrar.setScheduler(customTaskScheduler());
     }
 
-    @Bean(name = "taskScheduler")
-    public Executor taskScheduler() {
+    @Bean(name = "customTaskScheduler")
+    public Executor customTaskScheduler() {
         final var scheduler = new ThreadPoolTaskScheduler();
         scheduler.setPoolSize(5);
         scheduler.setThreadNamePrefix("Scheduler-");

--- a/src/main/java/team/washer/server/v2/global/config/SchedulerConfig.java
+++ b/src/main/java/team/washer/server/v2/global/config/SchedulerConfig.java
@@ -1,14 +1,14 @@
 package team.washer.server.v2.global.config;
 
-import java.util.concurrent.Executor;
-import java.util.concurrent.ThreadPoolExecutor;
-
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+
+import java.util.concurrent.ThreadPoolExecutor;
 
 @Configuration
 @EnableScheduling
@@ -20,7 +20,7 @@ public class SchedulerConfig implements SchedulingConfigurer {
     }
 
     @Bean(name = "customTaskScheduler")
-    public Executor customTaskScheduler() {
+    public TaskExecutor customTaskScheduler() {
         final var scheduler = new ThreadPoolTaskScheduler();
         scheduler.setPoolSize(5);
         scheduler.setThreadNamePrefix("Scheduler-");

--- a/src/main/java/team/washer/server/v2/global/config/SchedulerConfig.java
+++ b/src/main/java/team/washer/server/v2/global/config/SchedulerConfig.java
@@ -2,7 +2,7 @@ package team.washer.server.v2.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.task.TaskExecutor;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -20,7 +20,7 @@ public class SchedulerConfig implements SchedulingConfigurer {
     }
 
     @Bean(name = "customTaskScheduler")
-    public TaskExecutor customTaskScheduler() {
+    public TaskScheduler customTaskScheduler() {
         final var scheduler = new ThreadPoolTaskScheduler();
         scheduler.setPoolSize(5);
         scheduler.setThreadNamePrefix("Scheduler-");


### PR DESCRIPTION
## 개요

Spring Boot 4.0.1 업데이트로 인한 스케줄러 빈 충돌 문제 해결

## 본문

### 작업 이유

Spring Boot 4.0.1로 업데이트하면서 자동 설정에서 생성하는 `taskScheduler` 빈과 커스텀 `SchedulerConfig`에서 정의한 `taskScheduler` 빈이 중복 정의되어 애플리케이션이 시작되지 않는 문제가 발생했습니다.

### 구현 방식

`SchedulerConfig`에서 정의하던 빈 이름을 `taskScheduler`에서 `customTaskScheduler`로 변경하여 Spring Boot 자동 설정과의 이름 충돌을 해소했습니다. `configureTasks` 메서드에서도 변경된 메서드명을 참조하도록 수정했습니다.

### 현재 상태

Spring Boot 4.0.1 환경에서 애플리케이션이 정상적으로 시작되며, 커스텀 스케줄러 설정이 정상적으로 작동합니다.