### PR TITLE
[global] `ConfigurationProperties` Bean 등록 문제 해결 

### DIFF
--- a/src/main/java/team/washer/server/v2/global/config/PropertiesConfig.java
+++ b/src/main/java/team/washer/server/v2/global/config/PropertiesConfig.java
@@ -1,9 +1,0 @@
-package team.washer.server.v2.global.config;
-
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-@ConfigurationPropertiesScan("team.washer.server.v2")
-public class PropertiesConfig {
-}

--- a/src/main/java/team/washer/server/v2/global/config/PropertiesConfig.java
+++ b/src/main/java/team/washer/server/v2/global/config/PropertiesConfig.java
@@ -1,0 +1,9 @@
+package team.washer.server.v2.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationPropertiesScan("team.washer.server.v2")
+public class PropertiesConfig {
+}

--- a/src/main/java/team/washer/server/v2/global/config/PropertiesScanConfig.java
+++ b/src/main/java/team/washer/server/v2/global/config/PropertiesScanConfig.java
@@ -3,9 +3,7 @@ package team.washer.server.v2.global.config;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.Configuration;
 
-import team.washer.server.v2.global.security.data.CorsEnvironment;
-
 @Configuration
-@ConfigurationPropertiesScan(basePackageClasses = CorsEnvironment.class)
+@ConfigurationPropertiesScan("team.washer.server.v2")
 public class PropertiesScanConfig {
 }

--- a/src/main/java/team/washer/server/v2/global/config/SchedulerConfig.java
+++ b/src/main/java/team/washer/server/v2/global/config/SchedulerConfig.java
@@ -1,5 +1,7 @@
 package team.washer.server.v2.global.config;
 
+import java.util.concurrent.ThreadPoolExecutor;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
@@ -7,8 +9,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
-
-import java.util.concurrent.ThreadPoolExecutor;
 
 @Configuration
 @EnableScheduling


### PR DESCRIPTION
## 개요

ConfigurationProperties 빈 등록 문제 해결

## 본문

### 작업 이유

`@ConfigurationProperties`로 선언된 `SmartThingsEnvironment`가 빈으로 등록되지 않아 `RefreshSmartThingsTokenServiceImpl`에서 의존성 주입이 실패하고 애플리케이션이 시작되지 않는 문제가 발생했습니다.

### 구현 방식

`PropertiesConfig` 클래스를 추가하여 `@ConfigurationPropertiesScan` 애노테이션으로 애플리케이션 전체의 ConfigurationProperties 클래스를 자동으로 스캔하도록 설정했습니다. 이를 통해 `SmartThingsEnvironment`를 포함한 모든 ConfigurationProperties 클래스가 빈으로 등록됩니다.
