### PR TITLE
[global] Swagger 페이지 접속 불가 문제 수정

### DIFF
--- a/src/main/java/team/washer/server/v2/global/common/response/wrapper/ApiResponseWrapper.java
+++ b/src/main/java/team/washer/server/v2/global/common/response/wrapper/ApiResponseWrapper.java
@@ -19,7 +19,8 @@ import team.washer.server.v2.global.common.response.data.response.CommonApiResDt
 @RestControllerAdvice
 public class ApiResponseWrapper implements ResponseBodyAdvice<Object> {
 
-    private static final String[] NOT_WRAPPING_URL = {"/api-docs/**"};
+    private static final String[] NOT_WRAPPING_URL = {"/api-docs/**", "/v3/api-docs/**", "/swagger-ui/**",
+            "/swagger-resources/**"};
 
     private final AntPathMatcher matcher = new AntPathMatcher();
 

--- a/src/main/java/team/washer/server/v2/global/config/SwaggerConfig.java
+++ b/src/main/java/team/washer/server/v2/global/config/SwaggerConfig.java
@@ -28,29 +28,26 @@ public class SwaggerConfig {
     }
 
     private void wrapResponseWithCommonApiResDto(final Operation operation) {
-        final var response = operation.getResponses().get("200");
-        if (response == null) {
-            return;
-        }
+        operation.getResponses().forEach((statusCode, response) -> {
+            if (statusCode.startsWith("2")) {
+                if (response == null || response.getContent() == null) {
+                    return;
+                }
 
-        final var content = response.getContent();
-        if (content == null) {
-            return;
-        }
-
-        content.keySet().forEach(mediaTypeKey -> {
-            final var mediaType = content.get(mediaTypeKey);
-            final var originalSchema = mediaType.getSchema();
-            mediaType.schema(createWrappedSchema(originalSchema));
+                response.getContent().forEach((mediaTypeKey, mediaType) -> {
+                    final var originalSchema = mediaType.getSchema();
+                    mediaType.schema(createWrappedSchema(originalSchema));
+                });
+            }
         });
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     private Schema<?> createWrappedSchema(final Schema<?> originalSchema) {
         final var wrapperSchema = new Schema<>();
-        wrapperSchema.addProperty("status", new Schema<>().type("string").example("OK"));
-        wrapperSchema.addProperty("code", new Schema<>().type("integer").example(200));
-        wrapperSchema.addProperty("message", new Schema<>().type("string").example("정상 처리되었습니다."));
+        wrapperSchema.addProperty("status", new Schema<String>().type("string").example("OK"));
+        wrapperSchema.addProperty("code", new Schema<Integer>().type("integer").format("int32").example(200));
+        wrapperSchema.addProperty("message", new Schema<String>().type("string").example("정상 처리되었습니다."));
         if (originalSchema != null) {
             wrapperSchema.addProperty("data", originalSchema);
         }

--- a/src/main/java/team/washer/server/v2/global/config/SwaggerConfig.java
+++ b/src/main/java/team/washer/server/v2/global/config/SwaggerConfig.java
@@ -1,0 +1,59 @@
+package team.washer.server.v2.global.config;
+
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Schema;
+import team.washer.server.v2.global.common.response.data.response.CommonApiResDto;
+
+@OpenAPIDefinition(info = @Info(title = "Washer API", description = "기숙사 세탁기 예약 관리 시스템", version = "v2"))
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OperationCustomizer operationCustomizer() {
+        return (operation, handlerMethod) -> {
+            final var returnType = handlerMethod.getMethod().getReturnType();
+            final var isAlreadyWrapped = CommonApiResDto.class.isAssignableFrom(returnType);
+            if (!isAlreadyWrapped) {
+                wrapResponseWithCommonApiResDto(operation);
+            }
+
+            return operation;
+        };
+    }
+
+    private void wrapResponseWithCommonApiResDto(final Operation operation) {
+        final var response = operation.getResponses().get("200");
+        if (response == null) {
+            return;
+        }
+
+        final var content = response.getContent();
+        if (content == null) {
+            return;
+        }
+
+        content.keySet().forEach(mediaTypeKey -> {
+            final var mediaType = content.get(mediaTypeKey);
+            final var originalSchema = mediaType.getSchema();
+            mediaType.schema(createWrappedSchema(originalSchema));
+        });
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private Schema<?> createWrappedSchema(final Schema<?> originalSchema) {
+        final var wrapperSchema = new Schema<>();
+        wrapperSchema.addProperty("status", new Schema<>().type("string").example("OK"));
+        wrapperSchema.addProperty("code", new Schema<>().type("integer").example(200));
+        wrapperSchema.addProperty("message", new Schema<>().type("string").example("정상 처리되었습니다."));
+        if (originalSchema != null) {
+            wrapperSchema.addProperty("data", originalSchema);
+        }
+        return wrapperSchema;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,14 +41,13 @@ third-party:
     client-id: ${SMARTTHINGS_CLIENT_ID:your-client-id}
     client-secret: ${SMARTTHINGS_CLIENT_SECRET:your-client-secret}
 springdoc:
+  api-docs:
+    path: /v3/api-docs
   swagger-ui:
-    config-url: "/v3/api-docs/swagger-config"
-    urls:
-      - name: "Washer-Backend-v2 API"
-        url: "/v3/api-docs"
-    operationsSorter: "method"
+    path: /swagger-ui.html
+    operationsSorter: method
     defaultModelsExpandDepth: -1
-    docExpansion: "none"
+    docExpansion: list
     displayRequestDuration: true
     filter: true
     showCommonExtensions: true
@@ -56,6 +55,5 @@ springdoc:
     deepLinking: true
     persistAuthorization: true
     tryItOutEnabled: true
-    validatorUrl: ""
     csrf:
       enabled: false


### PR DESCRIPTION
## 개요

SpringDoc을 이용한 Swagger API 문서 설정을 추가하고, 공통 응답 규격인 CommonApiResDto가 문서상에 자동으로 반영되도록 구현하였습니다. 또한 Swagger UI 접근 시 응답 래핑으로 인한 오류를 방지하기 위해 예외 경로 설정을 수행하였습니다.

## 본문

### 작업 이유
API 문서의 가독성을 높이고 실제 응답 규격인 CommonApiResDto가 Swagger 문서에 자동으로 반영되도록 하여 문서와 실제 API 간의 정합성을 확보하기 위함입니다. 또한, 전역 응답 래핑 처리가 Swagger UI 내부 API 호출에 영향을 주어 화면이 정상적으로 표시되지 않는 문제를 해결하기 위해 작업하였습니다.

### 구현 방식
- SwaggerConfig 클래스에서 OperationCustomizer를 정의하여 컨트롤러의 반환 타입이 CommonApiResDto가 아닐 경우 OpenAPI 문서상에서 자동으로 해당 규격으로 래핑하여 표시되도록 구현하였습니다.
- application.yml 파일에 SpringDoc 관련 설정을 추가하여 API 문서 경로 및 UI 동작 방식을 정의하였습니다.
- ApiResponseWrapper 클래스의 제외 경로 목록에 Swagger UI 및 API Docs 관련 경로(/v3/api-docs/**, /swagger-ui/** 등)를 추가하여 ResponseBodyAdvice가 해당 응답을 가공하지 않도록 설정하였습니다.

### 현재 상태
Swagger UI를 통해 API 명세를 확인할 수 있으며, 모든 API 응답이 CommonApiResDto 규격으로 문서화되어 표시됩니다. Swagger UI 접속 및 문서 확인이 정상적으로 이루어지는 상태입니다.