### PR TITLE
[machine] 세탁기/건조기 등록 서비스 추가

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/machine/controller/AdminMachineController.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/controller/AdminMachineController.java
@@ -10,12 +10,19 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.machine.dto.request.CreateMachineReqDto;
+import team.washer.server.v2.domain.machine.dto.request.UpdateMachineReqDto;
 import team.washer.server.v2.domain.machine.dto.request.UpdateMachineStatusReqDto;
+import team.washer.server.v2.domain.machine.dto.response.DeleteMachineResDto;
 import team.washer.server.v2.domain.machine.dto.response.MachineListResDto;
+import team.washer.server.v2.domain.machine.dto.response.MachineResDto;
 import team.washer.server.v2.domain.machine.dto.response.MachineStatusUpdateResDto;
 import team.washer.server.v2.domain.machine.enums.MachineStatus;
 import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.service.CreateMachineService;
+import team.washer.server.v2.domain.machine.service.DeleteMachineService;
 import team.washer.server.v2.domain.machine.service.QueryAllMachinesService;
+import team.washer.server.v2.domain.machine.service.UpdateMachineService;
 import team.washer.server.v2.domain.machine.service.UpdateMachineStatusService;
 
 @RestController
@@ -27,6 +34,9 @@ public class AdminMachineController {
 
     private final QueryAllMachinesService queryAllMachinesService;
     private final UpdateMachineStatusService updateMachineStatusService;
+    private final CreateMachineService createMachineService;
+    private final UpdateMachineService updateMachineService;
+    private final DeleteMachineService deleteMachineService;
 
     @GetMapping
     @Operation(summary = "전체 기기 조회", description = "필터링 옵션으로 기기 목록을 조회합니다 (페이지네이션 지원)")
@@ -45,5 +55,24 @@ public class AdminMachineController {
             @Parameter(description = "기기 ID") @PathVariable @NotNull Long id,
             @Valid @RequestBody UpdateMachineStatusReqDto request) {
         return updateMachineStatusService.execute(id, request.status());
+    }
+
+    @PostMapping
+    @Operation(summary = "기기 등록", description = "새로운 기기를 등록합니다")
+    public MachineResDto createMachine(@Valid @RequestBody CreateMachineReqDto request) {
+        return createMachineService.execute(request);
+    }
+
+    @PatchMapping("/{id}")
+    @Operation(summary = "기기 정보 수정", description = "기기의 deviceId, 위치, 유형 정보를 수정합니다")
+    public MachineResDto updateMachine(@Parameter(description = "기기 ID") @PathVariable @NotNull Long id,
+            @Valid @RequestBody UpdateMachineReqDto request) {
+        return updateMachineService.execute(id, request);
+    }
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "기기 삭제", description = "기기를 삭제합니다. 활성 예약이 있는 경우 삭제할 수 없습니다")
+    public DeleteMachineResDto deleteMachine(@Parameter(description = "기기 ID") @PathVariable @NotNull Long id) {
+        return deleteMachineService.execute(id);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/machine/dto/request/CreateMachineReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/dto/request/CreateMachineReqDto.java
@@ -1,0 +1,18 @@
+package team.washer.server.v2.domain.machine.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.enums.Position;
+
+@Schema(description = "기기 등록 요청 DTO")
+public record CreateMachineReqDto(
+        @Schema(description = "기기 유형", example = "WASHER", requiredMode = Schema.RequiredMode.REQUIRED) @NotNull(message = "기기 유형은 필수입니다") MachineType type,
+        @Schema(description = "층", example = "2", requiredMode = Schema.RequiredMode.REQUIRED) @NotNull(message = "층은 필수입니다") @Min(value = 1, message = "층은 1 이상이어야 합니다") Integer floor,
+        @Schema(description = "위치", example = "LEFT", requiredMode = Schema.RequiredMode.REQUIRED) @NotNull(message = "위치는 필수입니다") Position position,
+        @Schema(description = "번호", example = "1", requiredMode = Schema.RequiredMode.REQUIRED) @NotNull(message = "번호는 필수입니다") @Min(value = 1, message = "번호는 1 이상이어야 합니다") Integer number,
+        @Schema(description = "SmartThings Device ID", example = "abc-123-def-456", requiredMode = Schema.RequiredMode.REQUIRED) @NotBlank(message = "SmartThings Device ID는 필수입니다") @Size(max = 100, message = "Device ID는 100자를 초과할 수 없습니다") String deviceId) {
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/dto/request/UpdateMachineReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/dto/request/UpdateMachineReqDto.java
@@ -1,0 +1,15 @@
+package team.washer.server.v2.domain.machine.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.enums.Position;
+
+@Schema(description = "기기 수정 요청 DTO")
+public record UpdateMachineReqDto(@Schema(description = "기기 유형 (null이면 유지)", example = "WASHER") MachineType type,
+        @Schema(description = "층 (null이면 유지)", example = "2") @Min(value = 1, message = "층은 1 이상이어야 합니다") Integer floor,
+        @Schema(description = "위치 (null이면 유지)", example = "LEFT") Position position,
+        @Schema(description = "번호 (null이면 유지)", example = "1") @Min(value = 1, message = "번호는 1 이상이어야 합니다") Integer number,
+        @Schema(description = "SmartThings Device ID (null이면 유지)", example = "abc-123-def-456") @Size(max = 100, message = "Device ID는 100자를 초과할 수 없습니다") String deviceId) {
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/dto/response/DeleteMachineResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/dto/response/DeleteMachineResDto.java
@@ -1,0 +1,8 @@
+package team.washer.server.v2.domain.machine.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "기기 삭제 응답 DTO")
+public record DeleteMachineResDto(@Schema(description = "삭제된 기기 ID", example = "1") Long id,
+        @Schema(description = "삭제된 기기명", example = "W-2F-L1") String name) {
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/entity/Machine.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/entity/Machine.java
@@ -120,4 +120,17 @@ public class Machine extends BaseEntity {
     public boolean isDryer() {
         return this.type == MachineType.DRYER;
     }
+
+    /** DeviceId를 업데이트합니다. */
+    public void updateDeviceId(String deviceId) {
+        this.deviceId = deviceId;
+    }
+
+    /** 위치 정보 및 기기 유형을 업데이트합니다. */
+    public void updateLocation(MachineType type, Integer floor, Position position, Integer number) {
+        this.type = type;
+        this.floor = floor;
+        this.position = position;
+        this.number = number;
+    }
 }

--- a/src/main/java/team/washer/server/v2/domain/machine/service/CreateMachineService.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/CreateMachineService.java
@@ -1,0 +1,8 @@
+package team.washer.server.v2.domain.machine.service;
+
+import team.washer.server.v2.domain.machine.dto.request.CreateMachineReqDto;
+import team.washer.server.v2.domain.machine.dto.response.MachineResDto;
+
+public interface CreateMachineService {
+    MachineResDto execute(CreateMachineReqDto request);
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/service/DeleteMachineService.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/DeleteMachineService.java
@@ -1,0 +1,7 @@
+package team.washer.server.v2.domain.machine.service;
+
+import team.washer.server.v2.domain.machine.dto.response.DeleteMachineResDto;
+
+public interface DeleteMachineService {
+    DeleteMachineResDto execute(Long machineId);
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/service/UpdateMachineService.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/UpdateMachineService.java
@@ -1,0 +1,8 @@
+package team.washer.server.v2.domain.machine.service;
+
+import team.washer.server.v2.domain.machine.dto.request.UpdateMachineReqDto;
+import team.washer.server.v2.domain.machine.dto.response.MachineResDto;
+
+public interface UpdateMachineService {
+    MachineResDto execute(Long machineId, UpdateMachineReqDto request);
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/CreateMachineServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/CreateMachineServiceImpl.java
@@ -1,0 +1,52 @@
+package team.washer.server.v2.domain.machine.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.machine.dto.request.CreateMachineReqDto;
+import team.washer.server.v2.domain.machine.dto.response.MachineResDto;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.machine.service.CreateMachineService;
+
+@Service
+@RequiredArgsConstructor
+public class CreateMachineServiceImpl implements CreateMachineService {
+
+    private final MachineRepository machineRepository;
+
+    @Transactional
+    @Override
+    public MachineResDto execute(CreateMachineReqDto request) {
+        if (machineRepository.existsByDeviceId(request.deviceId())) {
+            throw new ExpectedException("이미 등록된 Device ID입니다", HttpStatus.CONFLICT);
+        }
+
+        if (machineRepository.findByLocation(request.type(), request.floor(), request.position(), request.number())
+                .isPresent()) {
+            throw new ExpectedException("해당 위치에 이미 기기가 등록되어 있습니다", HttpStatus.CONFLICT);
+        }
+
+        final var name = Machine.generateName(request.type(), request.floor(), request.position(), request.number());
+        final var machine = Machine.builder().name(name).type(request.type()).floor(request.floor())
+                .position(request.position()).number(request.number()).deviceId(request.deviceId()).build();
+        final var saved = machineRepository.save(machine);
+
+        return toResDto(saved);
+    }
+
+    private MachineResDto toResDto(Machine machine) {
+        return new MachineResDto(machine.getId(),
+                machine.getName(),
+                machine.getType(),
+                machine.getFloor(),
+                machine.getPosition(),
+                machine.getNumber(),
+                machine.getStatus(),
+                machine.getAvailability(),
+                machine.getDeviceId());
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/DeleteMachineServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/DeleteMachineServiceImpl.java
@@ -1,0 +1,37 @@
+package team.washer.server.v2.domain.machine.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.machine.dto.response.DeleteMachineResDto;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.machine.service.DeleteMachineService;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteMachineServiceImpl implements DeleteMachineService {
+
+    private final MachineRepository machineRepository;
+    private final ReservationRepository reservationRepository;
+
+    @Transactional
+    @Override
+    public DeleteMachineResDto execute(Long machineId) {
+        final var machine = machineRepository.findById(machineId)
+                .orElseThrow(() -> new ExpectedException("기기를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        if (reservationRepository.findActiveReservationByMachineId(machineId).isPresent()) {
+            throw new ExpectedException("활성 예약이 존재하는 기기는 삭제할 수 없습니다", HttpStatus.BAD_REQUEST);
+        }
+
+        final var id = machine.getId();
+        final var name = machine.getName();
+        machineRepository.delete(machine);
+
+        return new DeleteMachineResDto(id, name);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/UpdateMachineServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/UpdateMachineServiceImpl.java
@@ -42,8 +42,7 @@ public class UpdateMachineServiceImpl implements UpdateMachineService {
             machine.updateName();
         }
 
-        final var saved = machineRepository.save(machine);
-        return toResDto(saved);
+        return toResDto(machine);
     }
 
     private boolean hasLocationChange(UpdateMachineReqDto request) {

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/UpdateMachineServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/UpdateMachineServiceImpl.java
@@ -1,0 +1,85 @@
+package team.washer.server.v2.domain.machine.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.machine.dto.request.UpdateMachineReqDto;
+import team.washer.server.v2.domain.machine.dto.response.MachineResDto;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.enums.Position;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.machine.service.UpdateMachineService;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateMachineServiceImpl implements UpdateMachineService {
+
+    private final MachineRepository machineRepository;
+
+    @Transactional
+    @Override
+    public MachineResDto execute(Long machineId, UpdateMachineReqDto request) {
+        final var machine = machineRepository.findById(machineId)
+                .orElseThrow(() -> new ExpectedException("기기를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        if (request.deviceId() != null) {
+            validateDeviceIdUnique(machine, request.deviceId());
+            machine.updateDeviceId(request.deviceId());
+        }
+
+        if (hasLocationChange(request)) {
+            final var newType = request.type() != null ? request.type() : machine.getType();
+            final var newFloor = request.floor() != null ? request.floor() : machine.getFloor();
+            final var newPosition = request.position() != null ? request.position() : machine.getPosition();
+            final var newNumber = request.number() != null ? request.number() : machine.getNumber();
+
+            validateLocationUnique(machine, newType, newFloor, newPosition, newNumber);
+            machine.updateLocation(newType, newFloor, newPosition, newNumber);
+            machine.updateName();
+        }
+
+        final var saved = machineRepository.save(machine);
+        return toResDto(saved);
+    }
+
+    private boolean hasLocationChange(UpdateMachineReqDto request) {
+        return request.type() != null || request.floor() != null || request.position() != null
+                || request.number() != null;
+    }
+
+    private void validateDeviceIdUnique(Machine machine, String newDeviceId) {
+        machineRepository.findByDeviceId(newDeviceId).ifPresent(existing -> {
+            if (!existing.getId().equals(machine.getId())) {
+                throw new ExpectedException("이미 다른 기기에서 사용 중인 Device ID입니다", HttpStatus.CONFLICT);
+            }
+        });
+    }
+
+    private void validateLocationUnique(Machine machine,
+            MachineType type,
+            Integer floor,
+            Position position,
+            Integer number) {
+        machineRepository.findByLocation(type, floor, position, number).ifPresent(existing -> {
+            if (!existing.getId().equals(machine.getId())) {
+                throw new ExpectedException("해당 위치에 이미 다른 기기가 등록되어 있습니다", HttpStatus.CONFLICT);
+            }
+        });
+    }
+
+    private MachineResDto toResDto(Machine machine) {
+        return new MachineResDto(machine.getId(),
+                machine.getName(),
+                machine.getType(),
+                machine.getFloor(),
+                machine.getPosition(),
+                machine.getNumber(),
+                machine.getStatus(),
+                machine.getAvailability(),
+                machine.getDeviceId());
+    }
+}


### PR DESCRIPTION
## 개요

관리자가 세탁기 및 건조기 기기를 직접 관리할 수 있는 기능을 구현하였습니다. 기존 기기 조회 및 상태 변경 기능에 더해 기기 등록, 정보 수정, 삭제 기능을 추가하여 관리 효율성을 높였습니다.

## 본문

### 작업 이유
세탁실 운영 중 발생하는 신규 기기 도입, 기기 위치 변경, 노후 기기 교체 등 관리자가 실시간으로 기기 정보를 제어하고 시스템 정보를 최신화해야 하는 상황에 대응하기 위해 관리 기능 확장이 필요했습니다.

### 구현 방식
- **API 확장**: `AdminMachineController`에 기기 등록(`POST`), 상세 정보 수정(`PATCH`), 기기 삭제(`DELETE`)를 위한 API 엔드포인트를 추가하였습니다.
- **서비스 레이어 분리**: 각 작업에 대한 비즈니스 로직을 `CreateMachineService`, `UpdateMachineService`, `DeleteMachineService` 인터페이스와 구현체로 분리하여 코드의 단일 책임 원칙을 준수하였습니다.
- **엔티티 무결성**: `Machine` 엔티티 내부에 정보 수정 메서드를 추가하여 캡슐화를 유지하였으며, 삭제 시 활성 예약 존재 여부를 검증하여 데이터 무결성을 보장하도록 설계하였습니다.
- **데이터 유효성 검증**: 기기 등록 및 정보 수정 시 필요한 데이터를 정의한 `CreateMachineReqDto`와 `UpdateMachineReqDto`를 추가하고 Jakarta Validation을 통해 입력값을 검증합니다.

### 현재 상태
관리자 권한을 가진 사용자가 `/api/v2/admin/machines` 엔드포인트를 통해 시스템 내 모든 기기를 직접 등록, 수정 및 삭제할 수 있는 상태입니다.
