### PR TITLE
[smarttgings] 기기 자동 등록 기능 구현

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsDeviceListResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsDeviceListResDto.java
@@ -1,0 +1,21 @@
+package team.washer.server.v2.domain.smartthings.dto.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * SmartThings 기기 목록 조회 응답 DTO
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SmartThingsDeviceListResDto(@JsonProperty("items") List<DeviceItem> items) {
+
+    /**
+     * SmartThings 개별 기기 항목
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record DeviceItem(@JsonProperty("deviceId") String deviceId, @JsonProperty("label") String label,
+            @JsonProperty("name") String name) {
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/scheduler/SmartThingsDeviceSyncScheduler.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/scheduler/SmartThingsDeviceSyncScheduler.java
@@ -1,0 +1,30 @@
+package team.washer.server.v2.domain.smartthings.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.smartthings.service.SyncSmartThingsDevicesService;
+
+/**
+ * SmartThings 기기 목록 자동 동기화 스케줄러 매일 오후 3시에 SmartThings API를 호출하여 Machine DB를 동기화
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SmartThingsDeviceSyncScheduler {
+
+    private final SyncSmartThingsDevicesService syncDevicesService;
+
+    @Scheduled(cron = "0 0 15 * * *")
+    public void syncDevices() {
+        try {
+            log.info("SmartThings 기기 목록 동기화 스케줄러 시작");
+            syncDevicesService.execute();
+            log.info("SmartThings 기기 목록 동기화 스케줄러 완료");
+        } catch (Exception e) {
+            log.error("SmartThings 기기 목록 동기화 스케줄러 실패", e);
+        }
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/service/SyncSmartThingsDevicesService.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/service/SyncSmartThingsDevicesService.java
@@ -1,0 +1,9 @@
+package team.washer.server.v2.domain.smartthings.service;
+
+/**
+ * SmartThings 기기 목록을 조회하여 Machine DB와 동기화하는 서비스
+ */
+public interface SyncSmartThingsDevicesService {
+
+    void execute();
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/SyncSmartThingsDevicesServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/SyncSmartThingsDevicesServiceImpl.java
@@ -58,6 +58,12 @@ public class SyncSmartThingsDevicesServiceImpl implements SyncSmartThingsDevices
             processDeviceItem(item);
         }
 
+        // API 오류로 빈 목록이 반환된 경우 전체 비활성화 방지
+        if (smartThingsDeviceIds.isEmpty()) {
+            log.warn("SmartThings 기기 목록이 비어있습니다. 비활성화 처리를 건너뜁니다.");
+            return;
+        }
+
         // SmartThings에서 사라진 기기 비활성화
         deactivateMissingDevices(smartThingsDeviceIds);
     }
@@ -114,6 +120,9 @@ public class SyncSmartThingsDevicesServiceImpl implements SyncSmartThingsDevices
      * @return 파싱 결과, 형식 불일치 시 {@code Optional.empty()}
      */
     private Optional<ParsedLabel> parseLabel(String label) {
+        if (label == null) {
+            return Optional.empty();
+        }
         var matcher = LABEL_PATTERN.matcher(label);
         if (!matcher.matches()) {
             return Optional.empty();

--- a/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/SyncSmartThingsDevicesServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/SyncSmartThingsDevicesServiceImpl.java
@@ -1,0 +1,132 @@
+package team.washer.server.v2.domain.smartthings.service.impl;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.enums.Position;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceListResDto.DeviceItem;
+import team.washer.server.v2.domain.smartthings.repository.SmartThingsTokenRepository;
+import team.washer.server.v2.domain.smartthings.service.SyncSmartThingsDevicesService;
+import team.washer.server.v2.global.thirdparty.smartthings.feign.SmartThingsFeignClient;
+
+/**
+ * SmartThings 기기 목록 동기화 서비스 구현체
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SyncSmartThingsDevicesServiceImpl implements SyncSmartThingsDevicesService {
+
+    private static final Pattern LABEL_PATTERN = Pattern.compile("^(Washer|Dryer)-(\\d+)F-(L|R)(\\d+)$");
+
+    private final SmartThingsFeignClient feignClient;
+    private final SmartThingsTokenRepository tokenRepository;
+    private final MachineRepository machineRepository;
+
+    @Override
+    @Transactional
+    public void execute() {
+        var token = tokenRepository.findSingletonToken()
+                .orElseThrow(() -> new ExpectedException("SmartThings 토큰이 존재하지 않습니다", HttpStatus.NOT_FOUND));
+
+        if (!token.isValid()) {
+            throw new ExpectedException("SmartThings 토큰이 만료되었거나 유효하지 않습니다", HttpStatus.UNAUTHORIZED);
+        }
+
+        var authorization = "Bearer " + token.getAccessToken();
+        var items = feignClient.getDeviceList(authorization).items();
+
+        // SmartThings에서 조회된 deviceId 집합
+        var smartThingsDeviceIds = items.stream().map(DeviceItem::deviceId).collect(Collectors.toSet());
+
+        // 각 기기 항목 처리 (생성 또는 갱신)
+        for (var item : items) {
+            processDeviceItem(item);
+        }
+
+        // SmartThings에서 사라진 기기 비활성화
+        deactivateMissingDevices(smartThingsDeviceIds);
+    }
+
+    /**
+     * 개별 SmartThings 기기 항목을 처리합니다. label을 파싱하여 Machine을 생성하거나 갱신합니다.
+     */
+    private void processDeviceItem(DeviceItem item) {
+        var parsedLabelOpt = parseLabel(item.label());
+        if (parsedLabelOpt.isEmpty()) {
+            log.warn("SmartThings 기기 label 형식 불일치: {}", item.label());
+            return;
+        }
+
+        var parsedLabel = parsedLabelOpt.get();
+        var machineName = Machine
+                .generateName(parsedLabel.type(), parsedLabel.floor(), parsedLabel.position(), parsedLabel.number());
+
+        var existingMachine = machineRepository.findByName(machineName);
+        if (existingMachine.isPresent()) {
+            var machine = existingMachine.get();
+            if (!item.deviceId().equals(machine.getDeviceId())) {
+                machine.updateDeviceId(item.deviceId());
+                log.info("Machine deviceId 갱신: name={}, deviceId={}", machineName, item.deviceId());
+            }
+        } else {
+            var newMachine = Machine.builder().deviceId(item.deviceId()).name(machineName).type(parsedLabel.type())
+                    .floor(parsedLabel.floor()).position(parsedLabel.position()).number(parsedLabel.number())
+                    .status(MachineStatus.NORMAL).availability(MachineAvailability.AVAILABLE).build();
+            machineRepository.save(newMachine);
+            log.info("신규 Machine 생성: name={}, deviceId={}", machineName, item.deviceId());
+        }
+    }
+
+    /**
+     * SmartThings에 더 이상 존재하지 않는 deviceId를 가진 Machine을 비활성화합니다.
+     */
+    private void deactivateMissingDevices(Set<String> smartThingsDeviceIds) {
+        var allMachines = machineRepository.findAll();
+        for (var machine : allMachines) {
+            if (!smartThingsDeviceIds.contains(machine.getDeviceId())) {
+                machine.markAsUnavailable();
+                log.info("SmartThings에서 제거된 기기 비활성화: name={}, deviceId={}", machine.getName(), machine.getDeviceId());
+            }
+        }
+    }
+
+    /**
+     * SmartThings device label을 파싱합니다. 패턴:
+     * {@code ^(Washer|Dryer)-(\d+)F-(L|R)(\d+)$}
+     *
+     * @param label
+     *            SmartThings device label (예: {@code Washer-1F-L1})
+     * @return 파싱 결과, 형식 불일치 시 {@code Optional.empty()}
+     */
+    private Optional<ParsedLabel> parseLabel(String label) {
+        var matcher = LABEL_PATTERN.matcher(label);
+        if (!matcher.matches()) {
+            return Optional.empty();
+        }
+
+        var type = matcher.group(1).equals("Washer") ? MachineType.WASHER : MachineType.DRYER;
+        var floor = Integer.parseInt(matcher.group(2));
+        var position = matcher.group(3).equals("L") ? Position.LEFT : Position.RIGHT;
+        var number = Integer.parseInt(matcher.group(4));
+
+        return Optional.of(new ParsedLabel(type, floor, position, number));
+    }
+
+    private record ParsedLabel(MachineType type, int floor, Position position, int number) {
+    }
+}

--- a/src/main/java/team/washer/server/v2/global/thirdparty/smartthings/feign/SmartThingsFeignClient.java
+++ b/src/main/java/team/washer/server/v2/global/thirdparty/smartthings/feign/SmartThingsFeignClient.java
@@ -5,11 +5,15 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 import team.washer.server.v2.domain.smartthings.dto.request.SmartThingsCommandReqDto;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceListResDto;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.global.thirdparty.smartthings.config.SmartThingsFeignConfig;
 
 @FeignClient(name = "smartthings-api", url = "${third-party.smartthings.api-url}", configuration = SmartThingsFeignConfig.class)
 public interface SmartThingsFeignClient {
+
+    @GetMapping(value = "/v1/devices", produces = MediaType.APPLICATION_JSON_VALUE)
+    SmartThingsDeviceListResDto getDeviceList(@RequestHeader("Authorization") String authorization);
 
     @GetMapping(value = "/v1/devices/{deviceId}/status", produces = MediaType.APPLICATION_JSON_VALUE)
     SmartThingsDeviceStatusResDto getDeviceStatus(@RequestHeader("Authorization") String authorization,


### PR DESCRIPTION
## 개요

SmartThings API를 통한 세탁기/건조기 기기 목록 자동 동기화 기능을 구현하였습니다.

## 본문

### 작업 이유
SmartThings 플랫폼에 등록된 기기 정보와 서버 데이터베이스의 Machine 정보를 일치시키기 위해 자동 동기화 로직이 필요하였습니다. 수동으로 기기 정보를 관리하는 번거로움을 줄이고, 기기 교체나 추가 시 발생하는 데이터 불일치 문제를 해결하고자 하였습니다.

### 구현 방식
SmartThings Feign 클라이언트에 기기 목록 조회 메서드를 추가하고, 조회된 기기의 label을 정규표현식으로 파싱하여 Machine 엔티티의 속성으로 변환하는 로직을 서비스 레이어에 구현하였습니다. 기존 DB에 없는 기기는 신규 등록하고, SmartThings 목록에서 제외된 기기는 비활성화 처리하며, 매일 오후 3시에 스케줄러를 통해 동기화가 수행되도록 하였습니다.

### 현재 상태
기기 목록 조회용 DTO, 동기화 서비스 인터페이스 및 구현체, 그리고 주기적 실행을 위한 스케줄러 구현이 완료되었습니다. SmartThings API와의 연동을 통해 기기 정보를 자동으로 갱신할 수 있는 기반이 마련되었습니다.