### PR TITLE
[machine] 예약 이후에도 기기가 사용가능 상태로 표시되던 문제 수정

### DIFF
--- a/.claude/skills/plan-deep-dive/SKILL.md
+++ b/.claude/skills/plan-deep-dive/SKILL.md
@@ -1,0 +1,7 @@
+---
+argument-hint: [instructions]
+description: Interview user in-depth to create a detailed spec
+allowed-tools: AskUserQuestion, Write
+---
+
+Follow the user instructions and interview me in detail using the AskUserQuestionTool about literally anything: technical implementation, UI & UX, concerns, tradeoffs, etc. but make sure the questions are not obvious. be very in-depth and continue interviewing me continually until it's complete. then, write the spec to a file. <instructions>$ARGUMENTS</instructions>

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
@@ -101,7 +101,7 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
         return switch (reservation.getStatus()) {
             case RUNNING -> MachineAvailability.IN_USE;
             case RESERVED, CONFIRMED -> MachineAvailability.RESERVED;
-            default -> MachineAvailability.AVAILABLE;
+            default -> throw new IllegalStateException("활성 예약의 상태가 유효하지 않습니다: " + reservation.getStatus());
         };
     }
 

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.machine.dto.response.MachineStatusResDto;
 import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.machine.service.QueryAllMachinesStatusService;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
@@ -75,7 +76,7 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
                 machine.getName(),
                 machine.getType(),
                 machine.getStatus(),
-                machine.getAvailability(),
+                computeAvailability(machine, reservation),
                 operatingState,
                 jobState,
                 switchStatus,
@@ -84,6 +85,24 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
                 reservation != null ? reservation.getId() : null,
                 reservation != null ? reservation.getUser().getId() : null,
                 reservation != null ? reservation.getUser().getRoomNumber() : null);
+    }
+
+    /**
+     * 예약 정보를 기반으로 기기의 가용성을 동적으로 계산한다. machine.availability 필드 대신 예약 상태를 source of
+     * truth로 사용한다.
+     */
+    private MachineAvailability computeAvailability(Machine machine, Reservation reservation) {
+        if (machine.getAvailability() == MachineAvailability.UNAVAILABLE) {
+            return MachineAvailability.UNAVAILABLE;
+        }
+        if (reservation == null) {
+            return MachineAvailability.AVAILABLE;
+        }
+        return switch (reservation.getStatus()) {
+            case RUNNING -> MachineAvailability.IN_USE;
+            case RESERVED, CONFIRMED -> MachineAvailability.RESERVED;
+            default -> MachineAvailability.AVAILABLE;
+        };
     }
 
     private String getOperatingState(Machine machine, SmartThingsDeviceStatusResDto deviceStatus) {

--- a/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
@@ -24,9 +24,11 @@ import team.washer.server.v2.domain.machine.enums.Position;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.machine.service.impl.QueryAllMachinesStatusServiceImpl;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.domain.smartthings.service.QueryAllDevicesStatusService;
+import team.washer.server.v2.domain.user.entity.User;
 
 @ExtendWith(MockitoExtension.class)
 class QueryAllMachinesStatusServiceTest {
@@ -45,6 +47,9 @@ class QueryAllMachinesStatusServiceTest {
 
     @Mock
     private Reservation reservation;
+
+    @Mock
+    private User user;
 
     @Nested
     @DisplayName("전체 기기 상태 조회")
@@ -106,6 +111,98 @@ class QueryAllMachinesStatusServiceTest {
 
             // Then
             assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("기기 가용성 동적 계산")
+    class ComputeAvailabilityTest {
+
+        private Machine buildMachine(MachineAvailability availability) {
+            return Machine.builder().name("W-3F-L1").type(MachineType.WASHER).deviceId("device-1").floor(3)
+                    .position(Position.LEFT).number(1).status(MachineStatus.NORMAL).availability(availability).build();
+        }
+
+        private void givenMachineWithReservation(Machine machine, Reservation reservationOrNull) {
+            when(machineRepository.findAll()).thenReturn(List.of(machine));
+            when(queryAllDevicesStatusService.execute(any())).thenReturn(Map.of());
+            when(reservationRepository.findActiveReservationByMachineId(any()))
+                    .thenReturn(Optional.ofNullable(reservationOrNull));
+        }
+
+        @Test
+        @DisplayName("예약이 없으면 AVAILABLE을 반환한다")
+        void computeAvailability_ShouldReturnAvailable_WhenNoReservation() {
+            // Given
+            givenMachineWithReservation(buildMachine(MachineAvailability.AVAILABLE), null);
+
+            // When
+            var result = queryAllMachinesStatusService.execute();
+
+            // Then
+            assertThat(result.getFirst().availability()).isEqualTo(MachineAvailability.AVAILABLE);
+        }
+
+        @Test
+        @DisplayName("예약 상태가 RESERVED이면 RESERVED를 반환한다")
+        void computeAvailability_ShouldReturnReserved_WhenReservationStatusIsReserved() {
+            // Given
+            when(reservation.getStatus()).thenReturn(ReservationStatus.RESERVED);
+            when(reservation.getUser()).thenReturn(null);
+            when(reservation.getId()).thenReturn(null);
+            givenMachineWithReservation(buildMachine(MachineAvailability.AVAILABLE), reservation);
+
+            // When
+            var result = queryAllMachinesStatusService.execute();
+
+            // Then
+            assertThat(result.getFirst().availability()).isEqualTo(MachineAvailability.RESERVED);
+        }
+
+        @Test
+        @DisplayName("예약 상태가 CONFIRMED이면 RESERVED를 반환한다")
+        void computeAvailability_ShouldReturnReserved_WhenReservationStatusIsConfirmed() {
+            // Given
+            when(reservation.getStatus()).thenReturn(ReservationStatus.CONFIRMED);
+            when(reservation.getUser()).thenReturn(null);
+            when(reservation.getId()).thenReturn(null);
+            givenMachineWithReservation(buildMachine(MachineAvailability.AVAILABLE), reservation);
+
+            // When
+            var result = queryAllMachinesStatusService.execute();
+
+            // Then
+            assertThat(result.getFirst().availability()).isEqualTo(MachineAvailability.RESERVED);
+        }
+
+        @Test
+        @DisplayName("예약 상태가 RUNNING이면 IN_USE를 반환한다")
+        void computeAvailability_ShouldReturnInUse_WhenReservationStatusIsRunning() {
+            // Given
+            when(reservation.getStatus()).thenReturn(ReservationStatus.RUNNING);
+            when(reservation.getUser()).thenReturn(null);
+            when(reservation.getId()).thenReturn(null);
+            givenMachineWithReservation(buildMachine(MachineAvailability.AVAILABLE), reservation);
+
+            // When
+            var result = queryAllMachinesStatusService.execute();
+
+            // Then
+            assertThat(result.getFirst().availability()).isEqualTo(MachineAvailability.IN_USE);
+        }
+
+        @Test
+        @DisplayName("기기가 UNAVAILABLE이면 예약과 무관하게 UNAVAILABLE을 반환한다")
+        void computeAvailability_ShouldReturnUnavailable_WhenMachineIsUnavailable() {
+            // Given
+            when(reservation.getStatus()).thenReturn(ReservationStatus.RESERVED);
+            givenMachineWithReservation(buildMachine(MachineAvailability.UNAVAILABLE), reservation);
+
+            // When
+            var result = queryAllMachinesStatusService.execute();
+
+            // Then
+            assertThat(result.getFirst().availability()).isEqualTo(MachineAvailability.UNAVAILABLE);
         }
     }
 }

--- a/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
@@ -148,8 +148,7 @@ class QueryAllMachinesStatusServiceTest {
         void computeAvailability_ShouldReturnReserved_WhenReservationStatusIsReserved() {
             // Given
             when(reservation.getStatus()).thenReturn(ReservationStatus.RESERVED);
-            when(reservation.getUser()).thenReturn(null);
-            when(reservation.getId()).thenReturn(null);
+            when(reservation.getUser()).thenReturn(user);
             givenMachineWithReservation(buildMachine(MachineAvailability.AVAILABLE), reservation);
 
             // When
@@ -164,8 +163,7 @@ class QueryAllMachinesStatusServiceTest {
         void computeAvailability_ShouldReturnReserved_WhenReservationStatusIsConfirmed() {
             // Given
             when(reservation.getStatus()).thenReturn(ReservationStatus.CONFIRMED);
-            when(reservation.getUser()).thenReturn(null);
-            when(reservation.getId()).thenReturn(null);
+            when(reservation.getUser()).thenReturn(user);
             givenMachineWithReservation(buildMachine(MachineAvailability.AVAILABLE), reservation);
 
             // When
@@ -180,8 +178,7 @@ class QueryAllMachinesStatusServiceTest {
         void computeAvailability_ShouldReturnInUse_WhenReservationStatusIsRunning() {
             // Given
             when(reservation.getStatus()).thenReturn(ReservationStatus.RUNNING);
-            when(reservation.getUser()).thenReturn(null);
-            when(reservation.getId()).thenReturn(null);
+            when(reservation.getUser()).thenReturn(user);
             givenMachineWithReservation(buildMachine(MachineAvailability.AVAILABLE), reservation);
 
             // When
@@ -195,7 +192,7 @@ class QueryAllMachinesStatusServiceTest {
         @DisplayName("기기가 UNAVAILABLE이면 예약과 무관하게 UNAVAILABLE을 반환한다")
         void computeAvailability_ShouldReturnUnavailable_WhenMachineIsUnavailable() {
             // Given
-            when(reservation.getStatus()).thenReturn(ReservationStatus.RESERVED);
+            when(reservation.getUser()).thenReturn(user);
             givenMachineWithReservation(buildMachine(MachineAvailability.UNAVAILABLE), reservation);
 
             // When


### PR DESCRIPTION
## 개요

기기 가용성 상태를 활성화된 예약 정보와 연동하여 동적으로 계산하도록 조회 로직을 수정하고, 관련 단위 테스트를 추가하였습니다.

## 본문

### 작업 이유
- 기존에는 기기 엔티티의 가용성 필드에만 의존하여 정보를 제공했으나, 실제 예약 상태와의 정합성을 보장하기 위해 예약 정보를 가용성 판단의 소스 오브 트루스(Source of Truth)로 활용할 필요가 있었습니다.

### 구현 방식
- QueryAllMachinesStatusServiceImpl 클래스에 computeAvailability 프라이빗 메서드를 추가하여 기기 가용성을 결정합니다.
- 기기가 점검 중(UNAVAILABLE)인 경우를 최우선으로 판단하며, 그 외의 경우에는 현재 예약 상태(RUNNING, RESERVED, CONFIRMED)에 따라 IN_USE 또는 RESERVED 상태를 반환합니다.
- 활성화된 예약이 없는 경우에만 AVAILABLE 상태로 표시되도록 구현했습니다.
- QueryAllMachinesStatusServiceTest에 각 케이스별 가용성 계산 검증 테스트를 추가하고, 안정적인 테스트 수행을 위해 모킹 설정을 보강했습니다.

### 현재 상태
- 기기 목록 조회 시 실시간 예약 현황이 가용성 정보에 즉각 반영되어 조회됩니다.
- 관련 로직에 대한 단위 테스트가 추가되어 의도한 대로 동작함이 검증되었습니다.
- 프로젝트 관리를 위한 Claude 심층 계획 수립 스킬 정의 파일이 추가되었습니다.
