### PR TITLE
[reservation] 만료된 예약이 활성 예약으로 노출되던 문제 수정

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/reservation/entity/Reservation.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/entity/Reservation.java
@@ -73,8 +73,10 @@ public class Reservation extends BaseEntity {
         LocalDateTime now = LocalDateTime.now();
 
         return switch (this.status) {
-            case RESERVED -> Duration.between(this.startTime, now).toMinutes() >= ReservationStatus.RESERVED.getTimeoutMinutes();
-            case CONFIRMED -> this.confirmedAt != null && Duration.between(this.confirmedAt, now).toMinutes() >= ReservationStatus.CONFIRMED.getTimeoutMinutes();
+            case RESERVED ->
+                Duration.between(this.startTime, now).toMinutes() >= ReservationStatus.RESERVED.getTimeoutMinutes();
+            case CONFIRMED -> this.confirmedAt != null && Duration.between(this.confirmedAt, now)
+                    .toMinutes() >= ReservationStatus.CONFIRMED.getTimeoutMinutes();
             default -> false;
         };
     }
@@ -84,13 +86,15 @@ public class Reservation extends BaseEntity {
 
         return switch (this.status) {
             case RESERVED -> {
-                long minutes = ReservationStatus.RESERVED.getTimeoutMinutes() - Duration.between(this.startTime, now).toMinutes();
+                long minutes = ReservationStatus.RESERVED.getTimeoutMinutes()
+                        - Duration.between(this.startTime, now).toMinutes();
                 yield Duration.ofMinutes(Math.max(0, minutes));
             }
             case CONFIRMED -> {
                 if (this.confirmedAt == null)
                     yield Duration.ZERO;
-                long minutes = ReservationStatus.CONFIRMED.getTimeoutMinutes() - Duration.between(this.confirmedAt, now).toMinutes();
+                long minutes = ReservationStatus.CONFIRMED.getTimeoutMinutes()
+                        - Duration.between(this.confirmedAt, now).toMinutes();
                 yield Duration.ofMinutes(Math.max(0, minutes));
             }
             default -> Duration.ZERO;

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryActiveReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryActiveReservationServiceImpl.java
@@ -29,7 +29,7 @@ public class QueryActiveReservationServiceImpl implements QueryActiveReservation
     @Override
     @Transactional(readOnly = true)
     public ReservationResDto execute() {
-        final var userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        final var userId = (Long) Objects.requireNonNull(SecurityContextHolder.getContext().getAuthentication()).getPrincipal();
         final User user = userRepository.findById(Objects.requireNonNull(userId))
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryActiveReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryActiveReservationServiceImpl.java
@@ -34,11 +34,15 @@ public class QueryActiveReservationServiceImpl implements QueryActiveReservation
         final List<Reservation> activeReservations = reservationRepository.findByUserAndStatusIn(user,
                 List.of(ReservationStatus.RESERVED, ReservationStatus.CONFIRMED, ReservationStatus.RUNNING));
 
-        if (activeReservations.isEmpty()) {
+        final List<Reservation> validReservations = activeReservations.stream()
+                .filter(r -> !r.isExpired())
+                .toList();
+
+        if (validReservations.isEmpty()) {
             return null;
         }
 
-        final Reservation latest = activeReservations.stream()
+        final Reservation latest = validReservations.stream()
                 .max((r1, r2) -> r1.getCreatedAt().compareTo(r2.getCreatedAt())).orElse(null);
 
         return new ReservationResDto(latest.getId(),

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryActiveReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryActiveReservationServiceImpl.java
@@ -1,6 +1,8 @@
 package team.washer.server.v2.domain.reservation.service.impl;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -28,22 +30,18 @@ public class QueryActiveReservationServiceImpl implements QueryActiveReservation
     @Transactional(readOnly = true)
     public ReservationResDto execute() {
         final var userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        final User user = userRepository.findById(userId)
+        final User user = userRepository.findById(Objects.requireNonNull(userId))
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
         final List<Reservation> activeReservations = reservationRepository.findByUserAndStatusIn(user,
                 List.of(ReservationStatus.RESERVED, ReservationStatus.CONFIRMED, ReservationStatus.RUNNING));
 
-        final List<Reservation> validReservations = activeReservations.stream()
-                .filter(r -> !r.isExpired())
-                .toList();
+        final Reservation latest = activeReservations.stream().filter(r -> !r.isExpired())
+                .max(Comparator.comparing(Reservation::getCreatedAt)).orElse(null);
 
-        if (validReservations.isEmpty()) {
+        if (latest == null) {
             return null;
         }
-
-        final Reservation latest = validReservations.stream()
-                .max((r1, r2) -> r1.getCreatedAt().compareTo(r2.getCreatedAt())).orElse(null);
 
         return new ReservationResDto(latest.getId(),
                 latest.getUser().getId(),

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/QueryActiveReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/QueryActiveReservationServiceTest.java
@@ -1,0 +1,198 @@
+package team.washer.server.v2.domain.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.reservation.dto.response.ReservationResDto;
+import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.reservation.service.impl.QueryActiveReservationServiceImpl;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class QueryActiveReservationServiceTest {
+
+    @InjectMocks
+    private QueryActiveReservationServiceImpl queryActiveReservationService;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private User user;
+
+    @Mock
+    private Machine machine;
+
+    private static final Long USER_ID = 1L;
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        final SecurityContext securityContext = mock(SecurityContext.class);
+        final Authentication authentication = mock(Authentication.class);
+        when(authentication.getPrincipal()).thenReturn(USER_ID);
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(securityContext);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Nested
+    @DisplayName("활성 예약 조회")
+    class ExecuteTest {
+
+        @Test
+        @DisplayName("만료되지 않은 활성 예약이 있으면 해당 예약을 반환한다")
+        void execute_ShouldReturnReservation_WhenValidActiveReservationExists() {
+            // Given
+            final Reservation reservation = mock(Reservation.class);
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            when(reservationRepository.findByUserAndStatusIn(eq(user), anyList())).thenReturn(List.of(reservation));
+            when(reservation.isExpired()).thenReturn(false);
+            when(reservation.getCreatedAt()).thenReturn(LocalDateTime.now());
+            stubReservationDtoFields(reservation, 1L);
+
+            // When
+            final ReservationResDto result = queryActiveReservationService.execute();
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.id()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("만료 예약과 유효 예약이 혼재하면 유효한 예약을 반환한다")
+        void execute_ShouldReturnValidReservation_WhenMixedExpiredAndValidReservationsExist() {
+            // Given
+            final Reservation expiredReservation = mock(Reservation.class);
+            final Reservation validReservation = mock(Reservation.class);
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            when(reservationRepository.findByUserAndStatusIn(eq(user), anyList()))
+                    .thenReturn(List.of(expiredReservation, validReservation));
+            when(expiredReservation.isExpired()).thenReturn(true);
+            when(validReservation.isExpired()).thenReturn(false);
+            when(validReservation.getCreatedAt()).thenReturn(LocalDateTime.now());
+            stubReservationDtoFields(validReservation, 2L);
+
+            // When
+            final ReservationResDto result = queryActiveReservationService.execute();
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.id()).isEqualTo(2L);
+        }
+
+        @Test
+        @DisplayName("유효한 예약이 여러 개이면 생성 시각이 가장 최근인 예약을 반환한다")
+        void execute_ShouldReturnLatestReservation_WhenMultipleValidReservationsExist() {
+            // Given
+            final Reservation olderReservation = mock(Reservation.class);
+            final Reservation newerReservation = mock(Reservation.class);
+            final LocalDateTime older = LocalDateTime.now().minusMinutes(10);
+            final LocalDateTime newer = LocalDateTime.now();
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            when(reservationRepository.findByUserAndStatusIn(eq(user), anyList()))
+                    .thenReturn(List.of(olderReservation, newerReservation));
+            when(olderReservation.isExpired()).thenReturn(false);
+            when(newerReservation.isExpired()).thenReturn(false);
+            when(olderReservation.getCreatedAt()).thenReturn(older);
+            when(newerReservation.getCreatedAt()).thenReturn(newer);
+            stubReservationDtoFields(newerReservation, 2L);
+
+            // When
+            final ReservationResDto result = queryActiveReservationService.execute();
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(result.id()).isEqualTo(2L);
+        }
+
+        @Test
+        @DisplayName("만료된 예약만 존재하면 null을 반환한다")
+        void execute_ShouldReturnNull_WhenOnlyExpiredReservationsExist() {
+            // Given
+            final Reservation expiredReservation = mock(Reservation.class);
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            when(reservationRepository.findByUserAndStatusIn(eq(user), anyList()))
+                    .thenReturn(List.of(expiredReservation));
+            when(expiredReservation.isExpired()).thenReturn(true);
+
+            // When
+            final ReservationResDto result = queryActiveReservationService.execute();
+
+            // Then
+            assertThat(result).isNull();
+        }
+
+        @Test
+        @DisplayName("활성 예약이 없으면 null을 반환한다")
+        void execute_ShouldReturnNull_WhenNoActiveReservationsExist() {
+            // Given
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            when(reservationRepository.findByUserAndStatusIn(eq(user), anyList())).thenReturn(Collections.emptyList());
+
+            // When
+            final ReservationResDto result = queryActiveReservationService.execute();
+
+            // Then
+            assertThat(result).isNull();
+        }
+
+        @Test
+        @DisplayName("사용자를 찾을 수 없으면 예외를 발생시킨다")
+        void execute_ShouldThrowException_WhenUserNotFound() {
+            // Given
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> queryActiveReservationService.execute()).isInstanceOf(ExpectedException.class)
+                    .hasMessage("사용자를 찾을 수 없습니다");
+        }
+    }
+
+    private void stubReservationDtoFields(Reservation reservation, Long reservationId) {
+        when(reservation.getId()).thenReturn(reservationId);
+        when(reservation.getUser()).thenReturn(user);
+        when(user.getId()).thenReturn(USER_ID);
+        when(user.getName()).thenReturn("김철수");
+        when(user.getRoomNumber()).thenReturn("301");
+        when(reservation.getMachine()).thenReturn(machine);
+        when(machine.getId()).thenReturn(1L);
+        when(machine.getName()).thenReturn("세탁기 1");
+        when(reservation.getReservedAt()).thenReturn(LocalDateTime.now());
+        when(reservation.getStartTime()).thenReturn(LocalDateTime.now());
+        when(reservation.getStatus()).thenReturn(ReservationStatus.RESERVED);
+    }
+}


### PR DESCRIPTION
## 개요

사용자의 활성 예약을 조회할 때 만료된 예약을 제외하도록 필터링 로직을 추가했습니다.

## 본문

### 작업 이유
예약 상태가 활성 상태(RESERVED, CONFIRMED, RUNNING)라 하더라도, 시간이 경과하여 만료된 경우(isExpired) 이를 유효한 예약으로 간주하지 않아야 합니다. 기존 로직은 상태 값만을 기준으로 조회하여 만료된 예약이 반환될 수 있는 문제가 있었습니다.

### 구현 방식
`QueryActiveReservationServiceImpl`에서 데이터베이스로부터 조회된 예약 리스트를 Java Stream API를 사용하여 필터링하도록 수정했습니다. `Reservation.isExpired()` 메서드를 호출하여 만료되지 않은 예약들만 `validReservations` 리스트로 추출합니다.

### 현재 상태
필터링된 결과인 `validReservations`가 비어있을 경우 null을 반환하며, 유효한 예약이 존재할 경우 그 중 생성 시각이 가장 최근인 예약을 `ReservationResDto`로 변환하여 반환합니다.
