### PR TITLE
[notification] 알림 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,6 +115,9 @@ dependencies {
     implementation("io.jsonwebtoken:jjwt-api:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
+
+    // Firebase Admin SDK
+    implementation("com.google.firebase:firebase-admin:9.4.3")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/team/washer/server/v2/domain/notification/controller/FcmTokenController.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/controller/FcmTokenController.java
@@ -1,0 +1,43 @@
+package team.washer.server.v2.domain.notification.controller;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import team.themoment.sdk.response.CommonApiResponse;
+import team.washer.server.v2.domain.notification.dto.request.FcmTokenReqDto;
+import team.washer.server.v2.domain.notification.service.DeleteFcmTokenService;
+import team.washer.server.v2.domain.notification.service.RegisterFcmTokenService;
+
+@RestController
+@RequestMapping("/api/v2/notifications/fcm-token")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "FCM Token", description = "FCM 토큰 관리 API")
+public class FcmTokenController {
+
+    private final RegisterFcmTokenService registerFcmTokenService;
+    private final DeleteFcmTokenService deleteFcmTokenService;
+
+    @PostMapping
+    @Operation(summary = "FCM 토큰 등록/갱신", description = "사용자의 FCM 토큰을 등록하거나 갱신합니다.")
+    public CommonApiResponse registerFcmToken(
+            @Parameter(description = "사용자 ID (임시: 인증 시스템 구현 후 제거 예정)", required = true) @RequestParam @NotNull Long userId,
+            @RequestBody @Valid FcmTokenReqDto requestDto) {
+        registerFcmTokenService.execute(userId, requestDto.token());
+        return CommonApiResponse.success("FCM 토큰이 등록되었습니다.");
+    }
+
+    @DeleteMapping
+    @Operation(summary = "FCM 토큰 삭제", description = "사용자의 FCM 토큰을 삭제합니다.")
+    public CommonApiResponse deleteFcmToken(
+            @Parameter(description = "사용자 ID (임시: 인증 시스템 구현 후 제거 예정)", required = true) @RequestParam @NotNull Long userId) {
+        deleteFcmTokenService.execute(userId);
+        return CommonApiResponse.success("FCM 토큰이 삭제되었습니다.");
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/notification/dto/request/FcmTokenReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/dto/request/FcmTokenReqDto.java
@@ -1,0 +1,8 @@
+package team.washer.server.v2.domain.notification.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record FcmTokenReqDto(
+        @NotBlank(message = "FCM 토큰은 필수입니다") @Schema(description = "FCM 토큰", example = "dGVzdC10b2tlbi1leGFtcGxl") String token) {
+}

--- a/src/main/java/team/washer/server/v2/domain/notification/service/DeleteFcmTokenService.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/service/DeleteFcmTokenService.java
@@ -1,0 +1,6 @@
+package team.washer.server.v2.domain.notification.service;
+
+public interface DeleteFcmTokenService {
+
+    void execute(Long userId);
+}

--- a/src/main/java/team/washer/server/v2/domain/notification/service/RegisterFcmTokenService.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/service/RegisterFcmTokenService.java
@@ -1,0 +1,6 @@
+package team.washer.server.v2.domain.notification.service;
+
+public interface RegisterFcmTokenService {
+
+    void execute(Long userId, String token);
+}

--- a/src/main/java/team/washer/server/v2/domain/notification/service/SendFcmNotificationService.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/service/SendFcmNotificationService.java
@@ -1,0 +1,8 @@
+package team.washer.server.v2.domain.notification.service;
+
+import team.washer.server.v2.domain.user.entity.User;
+
+public interface SendFcmNotificationService {
+
+    void execute(User user, String title, String body);
+}

--- a/src/main/java/team/washer/server/v2/domain/notification/service/impl/DeleteFcmTokenServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/service/impl/DeleteFcmTokenServiceImpl.java
@@ -1,0 +1,30 @@
+package team.washer.server.v2.domain.notification.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.notification.service.DeleteFcmTokenService;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeleteFcmTokenServiceImpl implements DeleteFcmTokenService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public void execute(final Long userId) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        user.clearFcmToken();
+        log.info("FCM token deleted: userId={}", userId);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/notification/service/impl/RegisterFcmTokenServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/service/impl/RegisterFcmTokenServiceImpl.java
@@ -1,0 +1,30 @@
+package team.washer.server.v2.domain.notification.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.notification.service.RegisterFcmTokenService;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RegisterFcmTokenServiceImpl implements RegisterFcmTokenService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public void execute(final Long userId, final String token) {
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        user.updateFcmToken(token);
+        log.info("FCM token registered/updated: userId={}", userId);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/notification/service/impl/SendCompletionNotificationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/service/impl/SendCompletionNotificationServiceImpl.java
@@ -1,14 +1,15 @@
 package team.washer.server.v2.domain.notification.service.impl;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.notification.entity.Notification;
+import team.washer.server.v2.domain.notification.enums.NotificationType;
 import team.washer.server.v2.domain.notification.repository.NotificationRepository;
 import team.washer.server.v2.domain.notification.service.SendCompletionNotificationService;
+import team.washer.server.v2.domain.notification.service.SendFcmNotificationService;
 import team.washer.server.v2.domain.user.entity.User;
 
 @Service
@@ -17,9 +18,9 @@ import team.washer.server.v2.domain.user.entity.User;
 public class SendCompletionNotificationServiceImpl implements SendCompletionNotificationService {
 
     private final NotificationRepository notificationRepository;
+    private final SendFcmNotificationService sendFcmNotificationService;
 
     @Override
-    @Transactional
     public void execute(User user, Machine machine) {
         try {
             var notification = Notification.createCompletionNotification(user, machine);
@@ -30,6 +31,14 @@ public class SendCompletionNotificationServiceImpl implements SendCompletionNoti
                     user.getId(),
                     machine.getName(),
                     e);
+        }
+
+        try {
+            final var fcmTitle = "세탁 완료 알림";
+            final var fcmBody = NotificationType.COMPLETION.formatMessage(machine.getName());
+            sendFcmNotificationService.execute(user, fcmTitle, fcmBody);
+        } catch (Exception e) {
+            log.error("Error sending FCM notification: userId={}, machineName={}", user.getId(), machine.getName(), e);
         }
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/notification/service/impl/SendCompletionNotificationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/service/impl/SendCompletionNotificationServiceImpl.java
@@ -22,23 +22,12 @@ public class SendCompletionNotificationServiceImpl implements SendCompletionNoti
 
     @Override
     public void execute(User user, Machine machine) {
-        try {
-            var notification = Notification.createCompletionNotification(user, machine);
-            notificationRepository.save(notification);
-            log.info("Completion notification sent to user {} for machine {}", user.getId(), machine.getName());
-        } catch (Exception e) {
-            log.error("Failed to send completion notification to user {} for machine {}",
-                    user.getId(),
-                    machine.getName(),
-                    e);
-        }
+        var notification = Notification.createCompletionNotification(user, machine);
+        notificationRepository.save(notification);
+        log.info("Completion notification sent to user {} for machine {}", user.getId(), machine.getName());
 
-        try {
-            final var fcmTitle = "세탁 완료 알림";
-            final var fcmBody = NotificationType.COMPLETION.formatMessage(machine.getName());
-            sendFcmNotificationService.execute(user, fcmTitle, fcmBody);
-        } catch (Exception e) {
-            log.error("Error sending FCM notification: userId={}, machineName={}", user.getId(), machine.getName(), e);
-        }
+        final var fcmTitle = "세탁 완료 알림";
+        final var fcmBody = NotificationType.COMPLETION.formatMessage(machine.getName());
+        sendFcmNotificationService.execute(user, fcmTitle, fcmBody);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/notification/service/impl/SendFcmNotificationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/service/impl/SendFcmNotificationServiceImpl.java
@@ -1,0 +1,47 @@
+package team.washer.server.v2.domain.notification.service.impl;
+
+import org.springframework.stereotype.Service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+import com.google.firebase.messaging.Notification;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.notification.service.DeleteFcmTokenService;
+import team.washer.server.v2.domain.notification.service.SendFcmNotificationService;
+import team.washer.server.v2.domain.user.entity.User;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SendFcmNotificationServiceImpl implements SendFcmNotificationService {
+
+    private final FirebaseMessaging firebaseMessaging;
+    private final DeleteFcmTokenService deleteFcmTokenService;
+
+    @Override
+    public void execute(final User user, final String title, final String body) {
+        final String token = user.getFcmToken();
+        if (token == null || token.isBlank()) {
+            log.debug("FCM token not found, skipping notification: userId={}", user.getId());
+            return;
+        }
+
+        try {
+            final var notification = Notification.builder().setTitle(title).setBody(body).build();
+            final var message = Message.builder().setToken(token).setNotification(notification).build();
+            final String messageId = firebaseMessaging.send(message);
+            log.info("FCM notification sent successfully: userId={}, messageId={}", user.getId(), messageId);
+        } catch (FirebaseMessagingException e) {
+            final MessagingErrorCode errorCode = e.getMessagingErrorCode();
+            log.error("Failed to send FCM notification: userId={}, errorCode={}", user.getId(), errorCode, e);
+            if (errorCode == MessagingErrorCode.UNREGISTERED || errorCode == MessagingErrorCode.INVALID_ARGUMENT) {
+                log.warn("Removing invalid FCM token: userId={}, errorCode={}", user.getId(), errorCode);
+                deleteFcmTokenService.execute(user.getId());
+            }
+        }
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
@@ -54,7 +54,6 @@ public class CreateReservationServiceImpl implements CreateReservationService {
         final LocalDateTime penaltyExpiresAt = penaltyRedisUtil.getPenaltyExpiryTime(userId);
         user.validateNotPenalized(penaltyExpiresAt);
 
-
         // 시간 제한 검증 (일요일 활성화 여부 포함, 개발환경에서는 비활성화 가능)
         if (!reservationEnvironment.disableTimeRestriction()) {
             final boolean isSundayActive = sundayReservationRedisUtil.isSundayActive();

--- a/src/main/java/team/washer/server/v2/domain/user/entity/User.java
+++ b/src/main/java/team/washer/server/v2/domain/user/entity/User.java
@@ -72,6 +72,9 @@ public class User extends BaseEntity {
     @Column(name = "last_cancellation_at")
     private LocalDateTime lastCancellationAt;
 
+    @Column(name = "fcm_token", length = 255)
+    private String fcmToken;
+
     // Relationships
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
@@ -109,6 +112,23 @@ public class User extends BaseEntity {
 
     public void clearLastCancellationTime() {
         this.lastCancellationAt = null;
+    }
+
+    /**
+     * FCM 토큰을 등록하거나 갱신합니다.
+     *
+     * @param token
+     *            FCM 토큰
+     */
+    public void updateFcmToken(final String token) {
+        this.fcmToken = token;
+    }
+
+    /**
+     * FCM 토큰을 삭제합니다.
+     */
+    public void clearFcmToken() {
+        this.fcmToken = null;
     }
 
     public boolean hasRecentCancellation(int penaltyMinutes) {

--- a/src/main/java/team/washer/server/v2/global/config/FcmConfig.java
+++ b/src/main/java/team/washer/server/v2/global/config/FcmConfig.java
@@ -1,0 +1,49 @@
+package team.washer.server.v2.global.config;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Configuration
+@RequiredArgsConstructor
+public class FcmConfig {
+
+    private final FcmProperties fcmProperties;
+
+    /**
+     * FirebaseMessaging 빈 등록
+     *
+     * @return FirebaseMessaging 인스턴스
+     * @throws IOException
+     *             서비스 계정 JSON 파싱 실패 시
+     */
+    @Bean
+    public FirebaseMessaging firebaseMessaging() throws IOException {
+        if (fcmProperties.serviceAccountJson() == null || fcmProperties.serviceAccountJson().isBlank()) {
+            throw new IllegalStateException(
+                    "FCM service account JSON is not configured. Set FIREBASE_SERVICE_ACCOUNT_JSON environment variable.");
+        }
+
+        if (FirebaseApp.getApps().isEmpty()) {
+            final var credentialStream = new ByteArrayInputStream(
+                    fcmProperties.serviceAccountJson().getBytes(StandardCharsets.UTF_8));
+            final var credentials = GoogleCredentials.fromStream(credentialStream);
+            final var options = FirebaseOptions.builder().setCredentials(credentials).build();
+            FirebaseApp.initializeApp(options);
+        }
+
+        return FirebaseMessaging.getInstance();
+    }
+}

--- a/src/main/java/team/washer/server/v2/global/config/FcmProperties.java
+++ b/src/main/java/team/washer/server/v2/global/config/FcmProperties.java
@@ -1,0 +1,7 @@
+package team.washer.server.v2.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("fcm")
+public record FcmProperties(String serviceAccountJson) {
+}

--- a/src/main/resources/application-stage.yml
+++ b/src/main/resources/application-stage.yml
@@ -75,6 +75,8 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: 3600
   refresh-token-expiration: 2592000
+fcm:
+  service-account-json: ${FIREBASE_SERVICE_ACCOUNT_JSON}
 third-party:
   discord:
     webhook-url: ${THIRD_PARTY_DISCORD_WEBHOOK_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,6 +55,8 @@ third-party:
     redirect-uri: ${THIRD_PARTY_DATAGSM_REDIRECT_URI:http://localhost:8080/api/v2/admin/datagsm/oauth/callback}
 reservation:
   disable-time-restriction: true
+fcm:
+  service-account-json: ${FIREBASE_SERVICE_ACCOUNT_JSON:}
 sdk:
   logging:
     enabled: true

--- a/src/test/java/team/washer/server/v2/domain/notification/service/DeleteFcmTokenServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/service/DeleteFcmTokenServiceTest.java
@@ -1,0 +1,107 @@
+package team.washer.server.v2.domain.notification.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.notification.service.impl.DeleteFcmTokenServiceImpl;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeleteFcmTokenServiceImpl 클래스의")
+class DeleteFcmTokenServiceTest {
+
+    @InjectMocks
+    private DeleteFcmTokenServiceImpl deleteFcmTokenService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User createUserWithToken(String token) {
+        User user = User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3).build();
+        user.updateFcmToken(token);
+        return user;
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("FCM 토큰이 있는 사용자의 토큰을 삭제할 때")
+        class Context_with_existing_token {
+
+            @Test
+            @DisplayName("FCM 토큰이 null로 초기화되어야 한다")
+            void it_clears_token() {
+                // Given
+                Long userId = 1L;
+                User user = createUserWithToken("existing-fcm-token");
+
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+                // When
+                deleteFcmTokenService.execute(userId);
+
+                // Then
+                assertThat(user.getFcmToken()).isNull();
+                then(userRepository).should(times(1)).findById(userId);
+            }
+        }
+
+        @Nested
+        @DisplayName("FCM 토큰이 없는 사용자의 토큰 삭제를 요청할 때")
+        class Context_with_no_existing_token {
+
+            @Test
+            @DisplayName("FCM 토큰이 null로 유지되어야 한다")
+            void it_remains_null() {
+                // Given
+                Long userId = 1L;
+                User user = User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3)
+                        .build();
+
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+                // When
+                deleteFcmTokenService.execute(userId);
+
+                // Then
+                assertThat(user.getFcmToken()).isNull();
+                then(userRepository).should(times(1)).findById(userId);
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 사용자 ID로 요청할 때")
+        class Context_with_nonexistent_user_id {
+
+            @Test
+            @DisplayName("ExpectedException을 던져야 한다")
+            void it_throws_expected_exception() {
+                // Given
+                Long userId = 999L;
+
+                given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+                // When & Then
+                assertThatThrownBy(() -> deleteFcmTokenService.execute(userId)).isInstanceOf(ExpectedException.class)
+                        .hasMessage("사용자를 찾을 수 없습니다").hasFieldOrPropertyWithValue("statusCode", HttpStatus.NOT_FOUND);
+
+                then(userRepository).should(times(1)).findById(userId);
+            }
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/notification/service/RegisterFcmTokenServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/service/RegisterFcmTokenServiceTest.java
@@ -1,0 +1,108 @@
+package team.washer.server.v2.domain.notification.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.notification.service.impl.RegisterFcmTokenServiceImpl;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RegisterFcmTokenServiceImpl 클래스의")
+class RegisterFcmTokenServiceTest {
+
+    @InjectMocks
+    private RegisterFcmTokenServiceImpl registerFcmTokenService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User createUser() {
+        return User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3).build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("FCM 토큰이 없는 사용자에게 토큰을 등록할 때")
+        class Context_with_no_existing_token {
+
+            @Test
+            @DisplayName("토큰이 등록되어야 한다")
+            void it_registers_token() {
+                // Given
+                Long userId = 1L;
+                String token = "new-fcm-token";
+                User user = createUser();
+
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+                // When
+                registerFcmTokenService.execute(userId, token);
+
+                // Then
+                assertThat(user.getFcmToken()).isEqualTo(token);
+                then(userRepository).should(times(1)).findById(userId);
+            }
+        }
+
+        @Nested
+        @DisplayName("기존 FCM 토큰이 있는 사용자의 토큰을 갱신할 때")
+        class Context_with_existing_token {
+
+            @Test
+            @DisplayName("토큰이 새 값으로 갱신되어야 한다")
+            void it_updates_token() {
+                // Given
+                Long userId = 1L;
+                String newToken = "updated-fcm-token";
+                User user = createUser();
+                user.updateFcmToken("old-fcm-token");
+
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+                // When
+                registerFcmTokenService.execute(userId, newToken);
+
+                // Then
+                assertThat(user.getFcmToken()).isEqualTo(newToken);
+                then(userRepository).should(times(1)).findById(userId);
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 사용자 ID로 요청할 때")
+        class Context_with_nonexistent_user_id {
+
+            @Test
+            @DisplayName("ExpectedException을 던져야 한다")
+            void it_throws_expected_exception() {
+                // Given
+                Long userId = 999L;
+
+                given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+                // When & Then
+                assertThatThrownBy(() -> registerFcmTokenService.execute(userId, "some-token"))
+                        .isInstanceOf(ExpectedException.class).hasMessage("사용자를 찾을 수 없습니다")
+                        .hasFieldOrPropertyWithValue("statusCode", HttpStatus.NOT_FOUND);
+
+                then(userRepository).should(times(1)).findById(userId);
+            }
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/notification/service/SendCompletionNotificationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/service/SendCompletionNotificationServiceTest.java
@@ -1,6 +1,7 @@
 package team.washer.server.v2.domain.notification.service;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -28,6 +29,9 @@ class SendCompletionNotificationServiceTest {
     private NotificationRepository notificationRepository;
 
     @Mock
+    private SendFcmNotificationService sendFcmNotificationService;
+
+    @Mock
     private User user;
 
     @Mock
@@ -48,6 +52,7 @@ class SendCompletionNotificationServiceTest {
 
             // Then
             verify(notificationRepository).save(any(Notification.class));
+            verify(sendFcmNotificationService).execute(any(User.class), anyString(), anyString());
         }
 
         @Test

--- a/src/test/java/team/washer/server/v2/domain/notification/service/SendCompletionNotificationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/service/SendCompletionNotificationServiceTest.java
@@ -54,17 +54,5 @@ class SendCompletionNotificationServiceTest {
             verify(notificationRepository).save(any(Notification.class));
             verify(sendFcmNotificationService).execute(any(User.class), anyString(), anyString());
         }
-
-        @Test
-        @DisplayName("알림 전송 실패 시 예외를 로그로 처리한다")
-        void execute_ShouldLogException_WhenNotificationFails() {
-            // Given
-            when(machine.getName()).thenReturn("W-3F-A1");
-            when(notificationRepository.save(any(Notification.class)))
-                    .thenThrow(new RuntimeException("Database error"));
-
-            // When & Then - 예외가 전파되지 않고 로그로 처리됨
-            sendCompletionNotificationService.execute(user, machine);
-        }
     }
 }

--- a/src/test/java/team/washer/server/v2/domain/notification/service/SendFcmNotificationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/service/SendFcmNotificationServiceTest.java
@@ -1,0 +1,172 @@
+package team.washer.server.v2.domain.notification.service;
+
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.MessagingErrorCode;
+
+import team.washer.server.v2.domain.notification.service.impl.SendFcmNotificationServiceImpl;
+import team.washer.server.v2.domain.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SendFcmNotificationServiceImpl 클래스의")
+class SendFcmNotificationServiceTest {
+
+    @InjectMocks
+    private SendFcmNotificationServiceImpl sendFcmNotificationService;
+
+    @Mock
+    private FirebaseMessaging firebaseMessaging;
+
+    @Mock
+    private DeleteFcmTokenService deleteFcmTokenService;
+
+    @Mock
+    private User user;
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("유효한 FCM 토큰이 있는 사용자에게 알림을 전송할 때")
+        class Context_with_valid_token {
+
+            @Test
+            @DisplayName("FCM 메시지를 전송해야 한다")
+            void it_sends_fcm_message() throws Exception {
+                // Given
+                given(user.getFcmToken()).willReturn("valid-fcm-token");
+                given(user.getId()).willReturn(1L);
+                given(firebaseMessaging.send(any(Message.class))).willReturn("message-id-123");
+
+                // When
+                sendFcmNotificationService.execute(user, "세탁 완료 알림", "W-3F-L1 세탁이 완료되었습니다.");
+
+                // Then
+                then(firebaseMessaging).should(times(1)).send(any(Message.class));
+                then(deleteFcmTokenService).should(never()).execute(anyLong());
+            }
+        }
+
+        @Nested
+        @DisplayName("FCM 토큰이 null인 사용자에게 알림을 전송할 때")
+        class Context_with_null_token {
+
+            @Test
+            @DisplayName("FCM 메시지를 전송하지 않아야 한다")
+            void it_skips_notification() throws Exception {
+                // Given
+                given(user.getFcmToken()).willReturn(null);
+
+                // When
+                sendFcmNotificationService.execute(user, "세탁 완료 알림", "W-3F-L1 세탁이 완료되었습니다.");
+
+                // Then
+                then(firebaseMessaging).should(never()).send(any(Message.class));
+                then(deleteFcmTokenService).should(never()).execute(anyLong());
+            }
+        }
+
+        @Nested
+        @DisplayName("FCM 토큰이 빈 문자열인 사용자에게 알림을 전송할 때")
+        class Context_with_blank_token {
+
+            @Test
+            @DisplayName("FCM 메시지를 전송하지 않아야 한다")
+            void it_skips_notification() throws Exception {
+                // Given
+                given(user.getFcmToken()).willReturn("   ");
+
+                // When
+                sendFcmNotificationService.execute(user, "세탁 완료 알림", "W-3F-L1 세탁이 완료되었습니다.");
+
+                // Then
+                then(firebaseMessaging).should(never()).send(any(Message.class));
+                then(deleteFcmTokenService).should(never()).execute(anyLong());
+            }
+        }
+
+        @Nested
+        @DisplayName("UNREGISTERED 에러로 FCM 전송이 실패할 때")
+        class Context_with_unregistered_error {
+
+            @Test
+            @DisplayName("만료된 FCM 토큰을 삭제해야 한다")
+            void it_deletes_unregistered_token() throws Exception {
+                // Given
+                Long userId = 1L;
+                given(user.getFcmToken()).willReturn("expired-fcm-token");
+                given(user.getId()).willReturn(userId);
+
+                FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
+                given(exception.getMessagingErrorCode()).willReturn(MessagingErrorCode.UNREGISTERED);
+                given(firebaseMessaging.send(any(Message.class))).willThrow(exception);
+
+                // When
+                sendFcmNotificationService.execute(user, "세탁 완료 알림", "W-3F-L1 세탁이 완료되었습니다.");
+
+                // Then
+                then(deleteFcmTokenService).should(times(1)).execute(userId);
+            }
+        }
+
+        @Nested
+        @DisplayName("INVALID_ARGUMENT 에러로 FCM 전송이 실패할 때")
+        class Context_with_invalid_argument_error {
+
+            @Test
+            @DisplayName("잘못된 형식의 FCM 토큰을 삭제해야 한다")
+            void it_deletes_malformed_token() throws Exception {
+                // Given
+                Long userId = 1L;
+                given(user.getFcmToken()).willReturn("malformed-fcm-token");
+                given(user.getId()).willReturn(userId);
+
+                FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
+                given(exception.getMessagingErrorCode()).willReturn(MessagingErrorCode.INVALID_ARGUMENT);
+                given(firebaseMessaging.send(any(Message.class))).willThrow(exception);
+
+                // When
+                sendFcmNotificationService.execute(user, "세탁 완료 알림", "W-3F-L1 세탁이 완료되었습니다.");
+
+                // Then
+                then(deleteFcmTokenService).should(times(1)).execute(userId);
+            }
+        }
+
+        @Nested
+        @DisplayName("일시적 에러(INTERNAL)로 FCM 전송이 실패할 때")
+        class Context_with_internal_error {
+
+            @Test
+            @DisplayName("FCM 토큰을 삭제하지 않아야 한다")
+            void it_does_not_delete_token() throws Exception {
+                // Given
+                Long userId = 1L;
+                given(user.getFcmToken()).willReturn("valid-fcm-token");
+                given(user.getId()).willReturn(userId);
+
+                FirebaseMessagingException exception = mock(FirebaseMessagingException.class);
+                given(exception.getMessagingErrorCode()).willReturn(MessagingErrorCode.INTERNAL);
+                given(firebaseMessaging.send(any(Message.class))).willThrow(exception);
+
+                // When
+                sendFcmNotificationService.execute(user, "세탁 완료 알림", "W-3F-L1 세탁이 완료되었습니다.");
+
+                // Then
+                then(deleteFcmTokenService).should(never()).execute(anyLong());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

세탁 완료 시 사용자에게 FCM 푸시 알림을 전송하는 기능을 구현했습니다. Firebase Admin SDK를 도입하고, 클라이언트 기기의 FCM 토큰을 등록·삭제하는 API와 알림 전송 서비스를 추가했습니다.

## 본문

### 작업내용

- `build.gradle.kts`에 Firebase Admin SDK 의존성 추가
- `User` 엔티티에 `fcmToken` 필드 및 토큰 등록·삭제 비즈니스 메서드 추가
- Firebase 초기화 설정 클래스 및 환경변수(`FIREBASE_SERVICE_ACCOUNT_KEY`) 구성 추가
- FCM 토큰 등록(`RegisterFcmTokenService`) 및 삭제(`DeleteFcmTokenService`) 서비스 구현
- FCM 메시지 전송 서비스(`SendFcmNotificationService`) 구현 — Firebase `FirebaseMessaging`을 통해 단건 전송
- `POST /api/v2/notifications/fcm-token`, `DELETE /api/v2/notifications/fcm-token` 엔드포인트 추가
- 기존 `NotifyWashingCompleteService`에 FCM 알림 전송 로직 연동
- FCM 토큰 관리 서비스 및 알림 전송 서비스에 대한 단위 테스트 추가