### PR TITLE
[global] CurrentUserProvider 도입으로 SecurityContext 접근 일원화

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/malfunction/service/impl/CreateMalfunctionReportServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/malfunction/service/impl/CreateMalfunctionReportServiceImpl.java
@@ -3,7 +3,6 @@ package team.washer.server.v2.domain.malfunction.service.impl;
 import java.time.LocalDateTime;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +18,7 @@ import team.washer.server.v2.domain.malfunction.repository.MalfunctionReportRepo
 import team.washer.server.v2.domain.malfunction.service.CreateMalfunctionReportService;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @Slf4j
 @Service
@@ -28,11 +28,12 @@ public class CreateMalfunctionReportServiceImpl implements CreateMalfunctionRepo
     private final MalfunctionReportRepository malfunctionReportRepository;
     private final UserRepository userRepository;
     private final MachineRepository machineRepository;
+    private final CurrentUserProvider currentUserProvider;
 
     @Override
     @Transactional
     public MalfunctionReportResDto execute(final CreateMalfunctionReportReqDto reqDto) {
-        final var userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        final var userId = currentUserProvider.getCurrentUserId();
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 

--- a/src/main/java/team/washer/server/v2/domain/notification/controller/FcmTokenController.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/controller/FcmTokenController.java
@@ -1,8 +1,5 @@
 package team.washer.server.v2.domain.notification.controller;
 
-import java.util.Objects;
-
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,6 +18,7 @@ import team.themoment.sdk.response.CommonApiResponse;
 import team.washer.server.v2.domain.notification.dto.request.FcmTokenReqDto;
 import team.washer.server.v2.domain.notification.service.DeleteFcmTokenService;
 import team.washer.server.v2.domain.notification.service.RegisterFcmTokenService;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @RestController
 @RequestMapping("/api/v2/notifications/fcm-token")
@@ -32,6 +30,7 @@ public class FcmTokenController {
 
     private final RegisterFcmTokenService registerFcmTokenService;
     private final DeleteFcmTokenService deleteFcmTokenService;
+    private final CurrentUserProvider currentUserProvider;
 
     @PostMapping
     @Operation(summary = "FCM 토큰 등록/갱신", description = "현재 로그인된 사용자의 FCM 토큰을 등록하거나 갱신합니다.")
@@ -51,11 +50,7 @@ public class FcmTokenController {
             @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(implementation = CommonApiResponse.class), examples = @ExampleObject(value = "{'status':401,'message':'인증이 필요합니다'}"))),
             @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content(schema = @Schema(implementation = CommonApiResponse.class), examples = @ExampleObject(value = "{'status':404,'message':'사용자를 찾을 수 없습니다'}")))})
     public CommonApiResponse deleteFcmToken() {
-        deleteFcmTokenService.execute(getCurrentUserId());
+        deleteFcmTokenService.execute(currentUserProvider.getCurrentUserId());
         return CommonApiResponse.success("FCM 토큰이 삭제되었습니다.");
-    }
-
-    private Long getCurrentUserId() {
-        return (Long) Objects.requireNonNull(SecurityContextHolder.getContext().getAuthentication()).getPrincipal();
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/notification/service/impl/RegisterFcmTokenServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/service/impl/RegisterFcmTokenServiceImpl.java
@@ -1,7 +1,6 @@
 package team.washer.server.v2.domain.notification.service.impl;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -11,6 +10,7 @@ import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.notification.service.RegisterFcmTokenService;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @Slf4j
 @Service
@@ -18,11 +18,12 @@ import team.washer.server.v2.domain.user.repository.UserRepository;
 public class RegisterFcmTokenServiceImpl implements RegisterFcmTokenService {
 
     private final UserRepository userRepository;
+    private final CurrentUserProvider currentUserProvider;
 
     @Override
     @Transactional
     public void execute(final String token) {
-        final var userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        final var userId = currentUserProvider.getCurrentUserId();
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ActivateSundayReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ActivateSundayReservationServiceImpl.java
@@ -1,7 +1,6 @@
 package team.washer.server.v2.domain.reservation.service.impl;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +11,7 @@ import team.washer.server.v2.domain.reservation.service.ActivateSundayReservatio
 import team.washer.server.v2.domain.reservation.util.SundayReservationRedisUtil;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @Slf4j
 @Service
@@ -20,11 +20,12 @@ public class ActivateSundayReservationServiceImpl implements ActivateSundayReser
 
     private final UserRepository userRepository;
     private final SundayReservationRedisUtil sundayReservationRedisUtil;
+    private final CurrentUserProvider currentUserProvider;
 
     @Override
     @Transactional
     public void execute(final String notes) {
-        final var adminId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        final var adminId = currentUserProvider.getCurrentUserId();
         final User admin = userRepository.findById(adminId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CancelReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CancelReservationServiceImpl.java
@@ -3,7 +3,6 @@ package team.washer.server.v2.domain.reservation.service.impl;
 import java.time.LocalDateTime;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +15,7 @@ import team.washer.server.v2.domain.reservation.repository.ReservationRepository
 import team.washer.server.v2.domain.reservation.service.CancelReservationService;
 import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
 import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @Slf4j
 @Service
@@ -24,11 +24,12 @@ public class CancelReservationServiceImpl implements CancelReservationService {
 
     private final ReservationRepository reservationRepository;
     private final PenaltyRedisUtil penaltyRedisUtil;
+    private final CurrentUserProvider currentUserProvider;
 
     @Override
     @Transactional
     public CancellationResDto execute(final Long reservationId) {
-        final var userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        final var userId = currentUserProvider.getCurrentUserId();
         final Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new ExpectedException("예약을 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ClearUserPenaltyServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ClearUserPenaltyServiceImpl.java
@@ -1,7 +1,6 @@
 package team.washer.server.v2.domain.reservation.service.impl;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +11,7 @@ import team.washer.server.v2.domain.reservation.service.ClearUserPenaltyService;
 import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @Slf4j
 @Service
@@ -20,11 +20,12 @@ public class ClearUserPenaltyServiceImpl implements ClearUserPenaltyService {
 
     private final UserRepository userRepository;
     private final PenaltyRedisUtil penaltyRedisUtil;
+    private final CurrentUserProvider currentUserProvider;
 
     @Override
     @Transactional
     public void execute(final Long userId) {
-        final var adminId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        final var adminId = currentUserProvider.getCurrentUserId();
         final User admin = userRepository.findById(adminId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ConfirmReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ConfirmReservationServiceImpl.java
@@ -1,7 +1,6 @@
 package team.washer.server.v2.domain.reservation.service.impl;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.reservation.service.ConfirmReservationService;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @Service
 @RequiredArgsConstructor
@@ -17,11 +17,12 @@ import team.washer.server.v2.domain.reservation.service.ConfirmReservationServic
 public class ConfirmReservationServiceImpl implements ConfirmReservationService {
 
     private final ReservationRepository reservationRepository;
+    private final CurrentUserProvider currentUserProvider;
 
     @Override
     @Transactional
     public void execute(Long reservationId) {
-        final var userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        final var userId = currentUserProvider.getCurrentUserId();
         var reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new ExpectedException("예약을 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
@@ -2,10 +2,8 @@ package team.washer.server.v2.domain.reservation.service.impl;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +24,7 @@ import team.washer.server.v2.domain.reservation.util.SundayReservationRedisUtil;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.global.common.constants.ReservationConstants;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @Slf4j
 @Service
@@ -38,13 +37,13 @@ public class CreateReservationServiceImpl implements CreateReservationService {
     private final PenaltyRedisUtil penaltyRedisUtil;
     private final SundayReservationRedisUtil sundayReservationRedisUtil;
     private final ReservationEnvironment reservationEnvironment;
+    private final CurrentUserProvider currentUserProvider;
 
     @Override
     @Transactional
     public ReservationResDto execute(final CreateReservationReqDto reqDto) {
-        final var userId = (Long) Objects.requireNonNull(SecurityContextHolder.getContext().getAuthentication())
-                .getPrincipal();
-        final User user = userRepository.findById(Objects.requireNonNull(userId))
+        final var userId = currentUserProvider.getCurrentUserId();
+        final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
         final Machine machine = machineRepository.findById(reqDto.machineId())

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/DeactivateSundayReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/DeactivateSundayReservationServiceImpl.java
@@ -1,9 +1,6 @@
 package team.washer.server.v2.domain.reservation.service.impl;
 
-import java.util.Objects;
-
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +11,7 @@ import team.washer.server.v2.domain.reservation.service.DeactivateSundayReservat
 import team.washer.server.v2.domain.reservation.util.SundayReservationRedisUtil;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @Slf4j
 @Service
@@ -22,12 +20,13 @@ public class DeactivateSundayReservationServiceImpl implements DeactivateSundayR
 
     private final UserRepository userRepository;
     private final SundayReservationRedisUtil sundayReservationRedisUtil;
+    private final CurrentUserProvider currentUserProvider;
 
     @Override
     @Transactional
     public void execute(final String notes) {
-        final var adminId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-        final User admin = userRepository.findById(Objects.requireNonNull(adminId))
+        final var adminId = currentUserProvider.getCurrentUserId();
+        final User admin = userRepository.findById(adminId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
         if (!admin.getRole().canManageSundayReservation()) {

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryActiveReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryActiveReservationServiceImpl.java
@@ -2,10 +2,8 @@ package team.washer.server.v2.domain.reservation.service.impl;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +16,7 @@ import team.washer.server.v2.domain.reservation.repository.ReservationRepository
 import team.washer.server.v2.domain.reservation.service.QueryActiveReservationService;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @Service
 @RequiredArgsConstructor
@@ -25,13 +24,13 @@ public class QueryActiveReservationServiceImpl implements QueryActiveReservation
 
     private final ReservationRepository reservationRepository;
     private final UserRepository userRepository;
+    private final CurrentUserProvider currentUserProvider;
 
     @Override
     @Transactional(readOnly = true)
     public ReservationResDto execute() {
-        final var userId = (Long) Objects.requireNonNull(SecurityContextHolder.getContext().getAuthentication())
-                .getPrincipal();
-        final User user = userRepository.findById(Objects.requireNonNull(userId))
+        final var userId = currentUserProvider.getCurrentUserId();
+        final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
         final List<Reservation> activeReservations = reservationRepository.findByUserAndStatusIn(user,

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryReservationAvailabilityServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryReservationAvailabilityServiceImpl.java
@@ -2,7 +2,6 @@ package team.washer.server.v2.domain.reservation.service.impl;
 
 import java.time.LocalDateTime;
 
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,17 +9,19 @@ import lombok.RequiredArgsConstructor;
 import team.washer.server.v2.domain.reservation.dto.response.ReservationAvailabilityResDto;
 import team.washer.server.v2.domain.reservation.service.QueryReservationAvailabilityService;
 import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @Service
 @RequiredArgsConstructor
 public class QueryReservationAvailabilityServiceImpl implements QueryReservationAvailabilityService {
 
     private final PenaltyRedisUtil penaltyRedisUtil;
+    private final CurrentUserProvider currentUserProvider;
 
     @Override
     @Transactional(readOnly = true)
     public ReservationAvailabilityResDto execute() {
-        final var userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        final var userId = currentUserProvider.getCurrentUserId();
         final LocalDateTime penaltyExpiresAt = penaltyRedisUtil.getPenaltyExpiryTime(userId);
         final boolean canReserve = penaltyExpiresAt == null || LocalDateTime.now().isAfter(penaltyExpiresAt);
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryReservationHistoryServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryReservationHistoryServiceImpl.java
@@ -5,7 +5,6 @@ import java.util.stream.Collectors;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,12 +16,14 @@ import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.reservation.service.QueryReservationHistoryService;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @Service
 @RequiredArgsConstructor
 public class QueryReservationHistoryServiceImpl implements QueryReservationHistoryService {
 
     private final ReservationRepository reservationRepository;
+    private final CurrentUserProvider currentUserProvider;
 
     @Override
     @Transactional(readOnly = true)
@@ -32,7 +33,7 @@ public class QueryReservationHistoryServiceImpl implements QueryReservationHisto
             final MachineType machineType,
             final Pageable pageable) {
 
-        final var userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        final var userId = currentUserProvider.getCurrentUserId();
         final Page<Reservation> reservations = reservationRepository
                 .findReservationHistory(userId, status, startDate, endDate, machineType, pageable);
 

--- a/src/main/java/team/washer/server/v2/domain/user/service/impl/QueryMyInfoServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/impl/QueryMyInfoServiceImpl.java
@@ -3,7 +3,6 @@ package team.washer.server.v2.domain.user.service.impl;
 import java.time.LocalDateTime;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,6 +12,7 @@ import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
 import team.washer.server.v2.domain.user.dto.response.MyInfoResDto;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.domain.user.service.QueryMyInfoService;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @Service
 @RequiredArgsConstructor
@@ -20,11 +20,12 @@ public class QueryMyInfoServiceImpl implements QueryMyInfoService {
 
     private final UserRepository userRepository;
     private final PenaltyRedisUtil penaltyRedisUtil;
+    private final CurrentUserProvider currentUserProvider;
 
     @Override
     @Transactional(readOnly = true)
     public MyInfoResDto execute() {
-        final var userId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        final var userId = currentUserProvider.getCurrentUserId();
         final var user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 

--- a/src/main/java/team/washer/server/v2/global/security/provider/CurrentUserProvider.java
+++ b/src/main/java/team/washer/server/v2/global/security/provider/CurrentUserProvider.java
@@ -1,0 +1,29 @@
+package team.washer.server.v2.global.security.provider;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import team.themoment.sdk.exception.ExpectedException;
+
+/**
+ * SecurityContext에서 현재 인증된 사용자의 ID를 추출하는 컴포넌트입니다.
+ */
+@Component
+public class CurrentUserProvider {
+
+    /**
+     * 현재 요청의 SecurityContext에서 인증된 사용자의 ID를 반환합니다.
+     *
+     * @return 현재 인증된 사용자의 ID
+     * @throws ExpectedException
+     *             인증 정보가 존재하지 않을 경우 (401 UNAUTHORIZED)
+     */
+    public Long getCurrentUserId() {
+        final var authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null) {
+            throw new ExpectedException("인증 정보가 존재하지 않습니다.", HttpStatus.UNAUTHORIZED);
+        }
+        return (Long) authentication.getPrincipal();
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/malfunction/service/CreateMalfunctionReportServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/malfunction/service/CreateMalfunctionReportServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.BDDMockito.*;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,9 +15,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.machine.entity.Machine;
@@ -35,6 +31,7 @@ import team.washer.server.v2.domain.malfunction.repository.MalfunctionReportRepo
 import team.washer.server.v2.domain.malfunction.service.impl.CreateMalfunctionReportServiceImpl;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("CreateMalfunctionReportServiceImpl 클래스의")
@@ -52,18 +49,8 @@ class CreateMalfunctionReportServiceTest {
     @Mock
     private MachineRepository machineRepository;
 
-    @AfterEach
-    void clearSecurityContext() {
-        SecurityContextHolder.clearContext();
-    }
-
-    private void setUpSecurityContext(final Long userId) {
-        final SecurityContext securityContext = mock(SecurityContext.class);
-        final Authentication authentication = mock(Authentication.class);
-        given(authentication.getPrincipal()).willReturn(userId);
-        given(securityContext.getAuthentication()).willReturn(authentication);
-        SecurityContextHolder.setContext(securityContext);
-    }
+    @Mock
+    private CurrentUserProvider currentUserProvider;
 
     @Nested
     @DisplayName("execute 메서드는")
@@ -92,7 +79,7 @@ class CreateMalfunctionReportServiceTest {
                 MalfunctionReport savedReport = MalfunctionReport.builder().machine(machine).reporter(user)
                         .description(description).reportedAt(LocalDateTime.now()).build();
 
-                setUpSecurityContext(userId);
+                given(currentUserProvider.getCurrentUserId()).willReturn(userId);
                 given(userRepository.findById(userId)).willReturn(Optional.of(user));
                 given(machineRepository.findById(machineId)).willReturn(Optional.of(machine));
                 given(malfunctionReportRepository.save(any(MalfunctionReport.class))).willReturn(savedReport);
@@ -123,7 +110,7 @@ class CreateMalfunctionReportServiceTest {
                 Long machineId = 1L;
                 CreateMalfunctionReportReqDto reqDto = new CreateMalfunctionReportReqDto(machineId, "고장 신고");
 
-                setUpSecurityContext(invalidUserId);
+                given(currentUserProvider.getCurrentUserId()).willReturn(invalidUserId);
                 given(userRepository.findById(invalidUserId)).willReturn(Optional.empty());
 
                 // When & Then
@@ -154,7 +141,7 @@ class CreateMalfunctionReportServiceTest {
                 User user = User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3)
                         .penaltyCount(0).build();
 
-                setUpSecurityContext(userId);
+                given(currentUserProvider.getCurrentUserId()).willReturn(userId);
                 given(userRepository.findById(userId)).willReturn(Optional.of(user));
                 given(machineRepository.findById(invalidMachineId)).willReturn(Optional.empty());
 

--- a/src/test/java/team/washer/server/v2/domain/notification/service/RegisterFcmTokenServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/service/RegisterFcmTokenServiceTest.java
@@ -5,8 +5,6 @@ import static org.mockito.BDDMockito.*;
 
 import java.util.Optional;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,14 +13,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.notification.service.impl.RegisterFcmTokenServiceImpl;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("RegisterFcmTokenServiceImpl 클래스의")
@@ -34,21 +30,10 @@ class RegisterFcmTokenServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    @Mock
+    private CurrentUserProvider currentUserProvider;
+
     private static final Long USER_ID = 1L;
-
-    @BeforeEach
-    void setUpSecurityContext() {
-        final SecurityContext securityContext = mock(SecurityContext.class);
-        final Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(USER_ID);
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        SecurityContextHolder.setContext(securityContext);
-    }
-
-    @AfterEach
-    void clearSecurityContext() {
-        SecurityContextHolder.clearContext();
-    }
 
     private User createUser() {
         return User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3).build();
@@ -66,6 +51,7 @@ class RegisterFcmTokenServiceTest {
             @DisplayName("토큰이 등록되어야 한다")
             void it_registers_token() {
                 // Given
+                when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
                 String token = "new-fcm-token";
                 User user = createUser();
 
@@ -88,6 +74,7 @@ class RegisterFcmTokenServiceTest {
             @DisplayName("토큰이 새 값으로 갱신되어야 한다")
             void it_updates_token() {
                 // Given
+                when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
                 String newToken = "updated-fcm-token";
                 User user = createUser();
                 user.updateFcmToken("old-fcm-token");
@@ -111,6 +98,7 @@ class RegisterFcmTokenServiceTest {
             @DisplayName("ExpectedException을 던져야 한다")
             void it_throws_expected_exception() {
                 // Given
+                when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
                 given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
 
                 // When & Then

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ConfirmReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ConfirmReservationServiceTest.java
@@ -5,8 +5,6 @@ import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,15 +12,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.reservation.service.impl.ConfirmReservationServiceImpl;
 import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @ExtendWith(MockitoExtension.class)
 class ConfirmReservationServiceTest {
@@ -34,26 +30,15 @@ class ConfirmReservationServiceTest {
     private ReservationRepository reservationRepository;
 
     @Mock
+    private CurrentUserProvider currentUserProvider;
+
+    @Mock
     private Reservation reservation;
 
     @Mock
     private User user;
 
     private static final Long USER_ID = 100L;
-
-    @BeforeEach
-    void setUpSecurityContext() {
-        final SecurityContext securityContext = mock(SecurityContext.class);
-        final Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(USER_ID);
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        SecurityContextHolder.setContext(securityContext);
-    }
-
-    @AfterEach
-    void clearSecurityContext() {
-        SecurityContextHolder.clearContext();
-    }
 
     @Nested
     @DisplayName("예약 확인")
@@ -63,6 +48,7 @@ class ConfirmReservationServiceTest {
         @DisplayName("본인의 예약을 성공적으로 확인한다")
         void execute_ShouldConfirmReservation_WhenValidUserAndReservation() {
             // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
             Long reservationId = 1L;
 
             when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));
@@ -81,6 +67,7 @@ class ConfirmReservationServiceTest {
         @DisplayName("예약이 존재하지 않으면 예외를 발생시킨다")
         void execute_ShouldThrowException_WhenReservationNotFound() {
             // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
             Long reservationId = 999L;
 
             when(reservationRepository.findById(reservationId)).thenReturn(Optional.empty());
@@ -94,6 +81,7 @@ class ConfirmReservationServiceTest {
         @DisplayName("다른 사용자의 예약을 확인하려고 하면 예외를 발생시킨다")
         void execute_ShouldThrowException_WhenUnauthorizedUser() {
             // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
             Long reservationId = 1L;
             Long differentUserId = 200L;
 

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
@@ -9,8 +9,6 @@ import static org.mockito.Mockito.*;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -18,9 +16,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.machine.entity.Machine;
@@ -36,6 +31,7 @@ import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
 import team.washer.server.v2.domain.reservation.util.SundayReservationRedisUtil;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @ExtendWith(MockitoExtension.class)
 class CreateReservationServiceTest {
@@ -55,6 +51,8 @@ class CreateReservationServiceTest {
     private SundayReservationRedisUtil sundayReservationRedisUtil;
     @Mock
     private ReservationEnvironment reservationEnvironment;
+    @Mock
+    private CurrentUserProvider currentUserProvider;
 
     @Mock
     private User user;
@@ -66,20 +64,6 @@ class CreateReservationServiceTest {
     private static final Long USER_ID = 1L;
     private static final String ROOM_NUMBER = "101";
 
-    @BeforeEach
-    void setUpSecurityContext() {
-        final SecurityContext securityContext = mock(SecurityContext.class);
-        final Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(USER_ID);
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        SecurityContextHolder.setContext(securityContext);
-    }
-
-    @AfterEach
-    void clearSecurityContext() {
-        SecurityContextHolder.clearContext();
-    }
-
     @Nested
     @DisplayName("예약 생성")
     class ExecuteTest {
@@ -88,6 +72,7 @@ class CreateReservationServiceTest {
         @DisplayName("유효한 요청이면 예약이 정상적으로 생성된다")
         void execute_ShouldCreateReservation_WhenValidRequest() {
             // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
             final var reqDto = new CreateReservationReqDto(1L, LocalDateTime.now().plusHours(1));
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
@@ -121,6 +106,7 @@ class CreateReservationServiceTest {
         @DisplayName("세탁기와 건조기는 동시에 각 1개씩 예약할 수 있다")
         void execute_ShouldCreateReservation_WhenRoomHasDifferentTypeActiveReservation() {
             // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
             final var reqDto = new CreateReservationReqDto(2L, LocalDateTime.now().plusHours(1));
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
@@ -155,6 +141,7 @@ class CreateReservationServiceTest {
         @DisplayName("이미 활성 예약이 있는 개인이 추가 예약을 시도하면 예외를 발생시킨다")
         void execute_ShouldThrowException_WhenUserAlreadyHasActiveReservation() {
             // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
             final var reqDto = new CreateReservationReqDto(1L, LocalDateTime.now().plusHours(1));
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
@@ -172,6 +159,7 @@ class CreateReservationServiceTest {
         @DisplayName("동일 호실에 같은 유형의 활성 예약이 있으면 예외를 발생시킨다")
         void execute_ShouldThrowException_WhenRoomAlreadyHasSameTypeActiveReservation() {
             // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
             final var reqDto = new CreateReservationReqDto(1L, LocalDateTime.now().plusHours(1));
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
@@ -193,6 +181,7 @@ class CreateReservationServiceTest {
         @DisplayName("해당 시간에 기기가 이미 예약되어 있으면 예외를 발생시킨다")
         void execute_ShouldThrowException_WhenMachineHasConflictingReservation() {
             // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
             final var reqDto = new CreateReservationReqDto(1L, LocalDateTime.now().plusHours(1));
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/QueryActiveReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/QueryActiveReservationServiceTest.java
@@ -12,8 +12,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -21,9 +19,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 
 import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.machine.entity.Machine;
@@ -34,6 +29,7 @@ import team.washer.server.v2.domain.reservation.repository.ReservationRepository
 import team.washer.server.v2.domain.reservation.service.impl.QueryActiveReservationServiceImpl;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @ExtendWith(MockitoExtension.class)
 class QueryActiveReservationServiceTest {
@@ -48,26 +44,15 @@ class QueryActiveReservationServiceTest {
     private UserRepository userRepository;
 
     @Mock
+    private CurrentUserProvider currentUserProvider;
+
+    @Mock
     private User user;
 
     @Mock
     private Machine machine;
 
     private static final Long USER_ID = 1L;
-
-    @BeforeEach
-    void setUpSecurityContext() {
-        final SecurityContext securityContext = mock(SecurityContext.class);
-        final Authentication authentication = mock(Authentication.class);
-        when(authentication.getPrincipal()).thenReturn(USER_ID);
-        when(securityContext.getAuthentication()).thenReturn(authentication);
-        SecurityContextHolder.setContext(securityContext);
-    }
-
-    @AfterEach
-    void clearSecurityContext() {
-        SecurityContextHolder.clearContext();
-    }
 
     @Nested
     @DisplayName("활성 예약 조회")
@@ -77,6 +62,7 @@ class QueryActiveReservationServiceTest {
         @DisplayName("만료되지 않은 활성 예약이 있으면 해당 예약을 반환한다")
         void execute_ShouldReturnReservation_WhenValidActiveReservationExists() {
             // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
             final Reservation reservation = mock(Reservation.class);
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
             when(reservationRepository.findByUserAndStatusIn(eq(user), anyList())).thenReturn(List.of(reservation));
@@ -96,6 +82,7 @@ class QueryActiveReservationServiceTest {
         @DisplayName("만료 예약과 유효 예약이 혼재하면 유효한 예약을 반환한다")
         void execute_ShouldReturnValidReservation_WhenMixedExpiredAndValidReservationsExist() {
             // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
             final Reservation expiredReservation = mock(Reservation.class);
             final Reservation validReservation = mock(Reservation.class);
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
@@ -118,6 +105,7 @@ class QueryActiveReservationServiceTest {
         @DisplayName("유효한 예약이 여러 개이면 생성 시각이 가장 최근인 예약을 반환한다")
         void execute_ShouldReturnLatestReservation_WhenMultipleValidReservationsExist() {
             // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
             final Reservation olderReservation = mock(Reservation.class);
             final Reservation newerReservation = mock(Reservation.class);
             final LocalDateTime older = LocalDateTime.now().minusMinutes(10);
@@ -143,6 +131,7 @@ class QueryActiveReservationServiceTest {
         @DisplayName("만료된 예약만 존재하면 null을 반환한다")
         void execute_ShouldReturnNull_WhenOnlyExpiredReservationsExist() {
             // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
             final Reservation expiredReservation = mock(Reservation.class);
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
             when(reservationRepository.findByUserAndStatusIn(eq(user), anyList()))
@@ -160,6 +149,7 @@ class QueryActiveReservationServiceTest {
         @DisplayName("활성 예약이 없으면 null을 반환한다")
         void execute_ShouldReturnNull_WhenNoActiveReservationsExist() {
             // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
             when(reservationRepository.findByUserAndStatusIn(eq(user), anyList())).thenReturn(Collections.emptyList());
 
@@ -174,6 +164,7 @@ class QueryActiveReservationServiceTest {
         @DisplayName("사용자를 찾을 수 없으면 예외를 발생시킨다")
         void execute_ShouldThrowException_WhenUserNotFound() {
             // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
             when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
 
             // When & Then


### PR DESCRIPTION
## 개요

SecurityContextHolder 직접 호출이 서비스/컨트롤러 12곳에서 중복되고
null 체크 없음, Objects.requireNonNull, private 헬퍼 메서드 등 패턴이 불일치하는 문제를 해결합니다.

## 본문

- CurrentUserProvider Spring Bean 추가 (global/security/provider)
  - null 체크 포함, 미인증 시 401 ExpectedException 발생
- 서비스 12개, 컨트롤러 1개에서 currentUserProvider.getCurrentUserId()로 교체
- 테스트 5개에서 SecurityContext static mock 제거 후 @Mock CurrentUserProvider로 교체하여 테스트 격리성 향상