### PR TITLE
[ci/cd] GSM SV 기반 개발서버로 마이그레이션

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "WebFetch(domain:raw.githubusercontent.com)"
-    ]
-  }
-}

--- a/.github/workflows/Washer Stage CD.yaml
+++ b/.github/workflows/Washer Stage CD.yaml
@@ -27,7 +27,9 @@ jobs:
         run: ./gradlew bootJar -x test --no-daemon
 
       - name: Create .env.stage
-        run: echo "${{ secrets.ENV_STAGE }}" > .env.stage
+        env:
+          ENV_STAGE: ${{ secrets.ENV_STAGE }}
+        run: printf '%s' "$ENV_STAGE" > .env.stage
 
       - name: Deploy to Server
         uses: 8G4B/GSM-SV-Deploy@v1.2.1

--- a/.github/workflows/Washer Stage CD.yaml
+++ b/.github/workflows/Washer Stage CD.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-      - cicd/*
   workflow_dispatch:
 jobs:
   Stage-CD:

--- a/.github/workflows/Washer Stage CD.yaml
+++ b/.github/workflows/Washer Stage CD.yaml
@@ -25,6 +25,9 @@ jobs:
       - name: Build bootJar
         run: ./gradlew bootJar -x test --no-daemon
 
+      - name: Rename JAR
+        run: mv $(ls build/libs/*.jar | grep -v plain) build/libs/app.jar
+
       - name: Create .env.stage
         env:
           ENV_STAGE: ${{ secrets.ENV_STAGE }}

--- a/.github/workflows/Washer Stage CD.yaml
+++ b/.github/workflows/Washer Stage CD.yaml
@@ -3,20 +3,32 @@ on:
   push:
     branches:
       - develop
-      - cicd/*
   workflow_dispatch:
 jobs:
   Stage-CD:
     runs-on: ubuntu-latest
     environment: Stage-CD
     steps:
-      - name: Repository Checkout
+      - name: 레포지토리 체크아웃
         uses: actions/checkout@v6
 
-      - name: Set Environment Variables
+      - name: JDK 25 설정
+        uses: actions/setup-java@v4
+        with:
+          java-version: 25
+          distribution: zulu
+          cache: gradle
+
+      - name: Gradle 설정
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: bootJar 빌드
+        run: ./gradlew bootJar -x test --no-daemon
+
+      - name: .env.stage 생성
         run: echo "${{ secrets.ENV_STAGE }}" > .env.stage
 
-      - name: Deploy to Stage Server
+      - name: 서버 배포
         uses: 8G4B/GSM-SV-Deploy@v1.2.1
         with:
           host: ${{ secrets.SSH_HOST }}
@@ -26,21 +38,21 @@ jobs:
           source_path: .
           target_path: /app/washer
 
-      - name: Notify Stage CD Success
+      - name: CD 성공 알림
         uses: sarisia/actions-status-discord@v1
         if: success()
         with:
           webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
           color: 0x4CAF50
 
-      - name: Notify Stage CD Failure
+      - name: CD 실패 알림
         uses: sarisia/actions-status-discord@v1
         if: failure()
         with:
           webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
           color: 0xFF4C4C
 
-      - name: Notify Stage CD Cancelled
+      - name: CD 취소 알림
         uses: sarisia/actions-status-discord@v1
         if: cancelled()
         with:

--- a/.github/workflows/Washer Stage CD.yaml
+++ b/.github/workflows/Washer Stage CD.yaml
@@ -9,68 +9,39 @@ jobs:
     runs-on: ubuntu-latest
     environment: Stage-CD
     steps:
-      - name: Checkout Repository
+      - name: Repository Checkout
         uses: actions/checkout@v6
 
-      - name: Deploy
-        uses: cloudtype-github-actions/deploy@v1
-        with:
-          token: ${{ secrets.CLOUDTYPE_TOKEN }}
-          project: snowykte0426/daram
-          stage: main
-          yaml: |
-            name: washer-backend-v2
-            app: dockerfile
-            options:
-              ports: "8080"
-              dockerfile: stage.dockerfile
-              env:
-                - name: SPRING_DATASOURCE_URL
-                  value: ${{ secrets.RDB_URL }}
-                - name: SPRING_DATASOURCE_USERNAME
-                  value: ${{ secrets.RDB_USERNAME }}
-                - name: SPRING_DATASOURCE_PASSWORD
-                  value: ${{ secrets.RDB_PASSWORD }}
-                - name: SPRING_DATA_REDIS_HOST
-                  value: ${{ secrets.REDIS_HOST }}
-                - name: SPRING_DATA_REDIS_PORT
-                  value: ${{ secrets.REDIS_PORT }}
-                - name: SPRING_DATA_REDIS_PASSWORD
-                  value: ${{ secrets.REDIS_PASSWORD }}
-                - name: THIRD_PARTY_DISCORD_WEBHOOK_URL
-                  value: ${{ secrets.DISCORD_EMERGENCY_ALERT_CHANNEL_WEBHOOK }}
-                - name: THIRD_PARTY_SMARTTHINGS_REDIRECT_URI
-                  value: ${{ secrets.SMARTTHINGS_REDIRECT_URI }}
-                - name: THIRD_PARTY_SMARTTHINGS_CLIENT_ID
-                  value: ${{ secrets.SMARTTHINGS_CLIENT_ID }}
-                - name: THIRD_PARTY_SMARTTHINGS_CLIENT_SECRET
-                  value: ${{ secrets.SMARTTHINGS_CLIENT_SECRET }}
-                - name: THIRD_PARTY_SMARTTHINGS_OPERATION_SCHEDULE_ENABLED
-                  value: ${{ secrets.SMARTTHINGS_OPERATION_SCHEDULE_ENABLED }}
-                - name: THIRD_PARTY_DATAGSM_CLIENT_ID
-                  value: ${{ secrets.DATAGSM_CLIENT_ID }}
-                - name: THIRD_PARTY_DATAGSM_CLIENT_SECRET
-                  value: ${{ secrets.DATAGSM_CLIENT_SECRET }}
-                - name: THIRD_PARTY_DATAGSM_REDIRECT_URI
-                  value: ${{ secrets.DATAGSM_REDIRECT_URI }}
-                - name: JWT_SECRET
-                  value: ${{ secrets.JWT_SECRET_KEY }}
-            context:
-              git:
-                url: https://github.com/${{ github.repository }}.git
-                ref: ${{ github.ref }}
-              preset: dockerfile
+      - name: Set Environment Variables
+        run: echo "${{ secrets.ENV_STAGE }}" > .env.stage
 
-      - name: CD Success Notification
+      - name: Deploy to Stage Server
+        uses: 8G4B/GSM-SV-Deploy@v1.2.1
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          user: ${{ secrets.SSH_USER }}
+          password: ${{ secrets.SSH_PASSWORD }}
+          port: ${{ secrets.SSH_PORT }}
+          source_path: .
+          target_path: /app/washer
+
+      - name: Notify Stage CD Success
         uses: sarisia/actions-status-discord@v1
         if: success()
         with:
           webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
           color: 0x4CAF50
 
-      - name: CD Failure Notification
+      - name: Notify Stage CD Failure
         uses: sarisia/actions-status-discord@v1
         if: failure()
+        with:
+          webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
+          color: 0xFF4C4C
+
+      - name: Notify Stage CD Cancelled
+        uses: sarisia/actions-status-discord@v1
+        if: cancelled()
         with:
           webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
           color: 0xFF4C4C

--- a/.github/workflows/Washer Stage CD.yaml
+++ b/.github/workflows/Washer Stage CD.yaml
@@ -3,32 +3,33 @@ on:
   push:
     branches:
       - develop
+      - cicd/*
   workflow_dispatch:
 jobs:
   Stage-CD:
     runs-on: ubuntu-latest
     environment: Stage-CD
     steps:
-      - name: 레포지토리 체크아웃
+      - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: JDK 25 설정
-        uses: actions/setup-java@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
           java-version: 25
           distribution: zulu
           cache: gradle
 
-      - name: Gradle 설정
-        uses: gradle/actions/setup-gradle@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
 
-      - name: bootJar 빌드
+      - name: Build bootJar
         run: ./gradlew bootJar -x test --no-daemon
 
-      - name: .env.stage 생성
+      - name: Create .env.stage
         run: echo "${{ secrets.ENV_STAGE }}" > .env.stage
 
-      - name: 서버 배포
+      - name: Deploy to Server
         uses: 8G4B/GSM-SV-Deploy@v1.2.1
         with:
           host: ${{ secrets.SSH_HOST }}
@@ -38,21 +39,21 @@ jobs:
           source_path: .
           target_path: /app/washer
 
-      - name: CD 성공 알림
+      - name: Notify CD Success
         uses: sarisia/actions-status-discord@v1
         if: success()
         with:
           webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
           color: 0x4CAF50
 
-      - name: CD 실패 알림
+      - name: Notify CD Failure
         uses: sarisia/actions-status-discord@v1
         if: failure()
         with:
           webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
           color: 0xFF4C4C
 
-      - name: CD 취소 알림
+      - name: Notify CD Cancelled
         uses: sarisia/actions-status-discord@v1
         if: cancelled()
         with:

--- a/.github/workflows/Washer Stage CD.yaml
+++ b/.github/workflows/Washer Stage CD.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+      - cicd/*
   workflow_dispatch:
 jobs:
   Stage-CD:

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ src/main/generated/
 
 ### LLM ###
 PR_BODY.md
+
+### Env ###
+.env*

--- a/deployspec.yml
+++ b/deployspec.yml
@@ -4,13 +4,10 @@ hooks:
   ApplicationStop:
     - location: scripts/stop.sh
       timeout: 300
-      runas: root
 
   ApplicationStart:
     - location: scripts/start.sh
       timeout: 600
-      runas: root
-
 permissions:
   - object: /app/washer/scripts
     pattern: "*.sh"

--- a/deployspec.yml
+++ b/deployspec.yml
@@ -7,9 +7,14 @@ hooks:
 
   ApplicationStart:
     - location: scripts/start.sh
+      timeout: 60
+
+  ValidateService:
+    - location: scripts/validate.sh
       timeout: 600
+
 permissions:
-  - object: /app/washer/scripts
+  - object: scripts
     pattern: "*.sh"
     owner: root
     group: root

--- a/deployspec.yml
+++ b/deployspec.yml
@@ -1,0 +1,9 @@
+ApplicationStop:
+  - location: scripts/stop.sh
+    timeout: 300
+    runas: root
+
+ApplicationStart:
+  - location: scripts/start.sh
+    timeout: 600
+    runas: root

--- a/deployspec.yml
+++ b/deployspec.yml
@@ -7,11 +7,7 @@ hooks:
 
   ApplicationStart:
     - location: scripts/start.sh
-      timeout: 60
-
-  ValidateService:
-    - location: scripts/validate.sh
-      timeout: 600
+      timeout: 120
 
 permissions:
   - object: scripts

--- a/deployspec.yml
+++ b/deployspec.yml
@@ -1,9 +1,21 @@
-ApplicationStop:
-  - location: scripts/stop.sh
-    timeout: 300
-    runas: root
+version: 1.0
 
-ApplicationStart:
-  - location: scripts/start.sh
-    timeout: 600
-    runas: root
+hooks:
+  ApplicationStop:
+    - location: scripts/stop.sh
+      timeout: 300
+      runas: root
+
+  ApplicationStart:
+    - location: scripts/start.sh
+      timeout: 600
+      runas: root
+
+permissions:
+  - object: /app/washer/scripts
+    pattern: "*.sh"
+    owner: root
+    group: root
+    mode: 755
+    type:
+      - file

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,18 +1,12 @@
 #!/bin/bash
 set -e
 cd /app/washer
-
-nohup bash -c '
-  docker build -f stage.dockerfile -t washer-backend-v2:latest . > /tmp/washer-deploy.log 2>&1 && \
-  docker run -d \
-    --name washer-backend-v2 \
-    --env-file /app/washer/.env.stage \
-    -p 8080:8080 \
-    --restart unless-stopped \
-    washer-backend-v2:latest >> /tmp/washer-deploy.log 2>&1 && \
-  docker image prune -f >> /tmp/washer-deploy.log 2>&1 && \
-  echo "DEPLOY_SUCCESS" >> /tmp/washer-deploy.log || \
-  echo "DEPLOY_FAILED" >> /tmp/washer-deploy.log
-' > /dev/null 2>&1 &
-
-echo "배포 시작 (PID: $!), 로그: /tmp/washer-deploy.log"
+docker build -f stage.dockerfile -t washer-backend-v2:latest .
+docker run -d \
+  --name washer-backend-v2 \
+  --env-file /app/washer/.env.stage \
+  -p 8080:8080 \
+  --restart unless-stopped \
+  washer-backend-v2:latest
+docker image prune -f
+docker ps | grep washer-backend-v2

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -5,7 +5,7 @@ docker build -f stage.dockerfile -t washer-backend-v2:latest .
 docker run -d \
   --name washer-backend-v2 \
   --env-file /app/washer/.env.stage \
-  -p 8080:8080 \
+  --network host \
   --restart unless-stopped \
   washer-backend-v2:latest
 docker image prune -f

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+cd /app/washer
+docker build -f stage.dockerfile -t washer-backend-v2:latest .
+docker run -d \
+  --name washer-backend-v2 \
+  --env-file /app/washer/.env.stage \
+  -p 8080:8080 \
+  --restart unless-stopped \
+  washer-backend-v2:latest
+docker image prune -f
+sleep 10
+docker ps | grep washer-backend-v2

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 set -e
 cd /app/washer
-docker build -f stage.dockerfile -t washer-backend-v2:latest .
-docker run -d \
-  --name washer-backend-v2 \
-  --env-file /app/washer/.env.stage \
-  -p 8080:8080 \
-  --restart unless-stopped \
-  washer-backend-v2:latest
-docker image prune -f
-sleep 10
-docker ps | grep washer-backend-v2
+
+nohup bash -c '
+  docker build -f stage.dockerfile -t washer-backend-v2:latest . > /tmp/washer-deploy.log 2>&1 && \
+  docker run -d \
+    --name washer-backend-v2 \
+    --env-file /app/washer/.env.stage \
+    -p 8080:8080 \
+    --restart unless-stopped \
+    washer-backend-v2:latest >> /tmp/washer-deploy.log 2>&1 && \
+  docker image prune -f >> /tmp/washer-deploy.log 2>&1 && \
+  echo "DEPLOY_SUCCESS" >> /tmp/washer-deploy.log || \
+  echo "DEPLOY_FAILED" >> /tmp/washer-deploy.log
+' > /dev/null 2>&1 &
+
+echo "배포 시작 (PID: $!), 로그: /tmp/washer-deploy.log"

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker stop washer-backend-v2 || true
+docker rm washer-backend-v2 || true

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+echo "배포 완료 대기 중..."
+for i in $(seq 1 60); do
+  if grep -q "DEPLOY_SUCCESS" /tmp/washer-deploy.log 2>/dev/null; then
+    echo "배포 성공"
+    docker ps | grep washer-backend-v2
+    exit 0
+  fi
+  if grep -q "DEPLOY_FAILED" /tmp/washer-deploy.log 2>/dev/null; then
+    echo "배포 실패 - 로그:"
+    cat /tmp/washer-deploy.log
+    exit 1
+  fi
+  sleep 10
+done
+
+echo "타임아웃 - 로그:"
+cat /tmp/washer-deploy.log
+exit 1

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryActiveReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryActiveReservationServiceImpl.java
@@ -36,8 +36,8 @@ public class QueryActiveReservationServiceImpl implements QueryActiveReservation
         final List<Reservation> activeReservations = reservationRepository.findByUserAndStatusIn(user,
                 List.of(ReservationStatus.RESERVED, ReservationStatus.CONFIRMED, ReservationStatus.RUNNING));
 
-        final Reservation latest = activeReservations.stream().max(Comparator.comparing(Reservation::getCreatedAt))
-                .orElse(null);
+        final Reservation latest = activeReservations.stream().filter(r -> !r.isExpired())
+                .max(Comparator.comparing(Reservation::getCreatedAt)).orElse(null);
 
         if (latest == null) {
             return null;

--- a/src/main/resources/application-stage.yml
+++ b/src/main/resources/application-stage.yml
@@ -71,6 +71,7 @@ logging:
 server:
   port: 8080
   shutdown: graceful
+  forward-headers-strategy: framework
 jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: 3600

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/CancelOverdueConfirmedReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/CancelOverdueConfirmedReservationServiceTest.java
@@ -21,6 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import jakarta.persistence.EntityManager;
 import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
@@ -48,6 +49,9 @@ class CancelOverdueConfirmedReservationServiceTest {
 
     @Mock
     private QueryDeviceStatusService queryDeviceStatusService;
+
+    @Mock
+    private MachineRepository machineRepository;
 
     @Mock
     private EntityManager entityManager;

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ConfirmReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ConfirmReservationServiceTest.java
@@ -14,6 +14,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.reservation.service.impl.ConfirmReservationServiceImpl;
@@ -30,10 +32,16 @@ class ConfirmReservationServiceTest {
     private ReservationRepository reservationRepository;
 
     @Mock
+    private MachineRepository machineRepository;
+
+    @Mock
     private CurrentUserProvider currentUserProvider;
 
     @Mock
     private Reservation reservation;
+
+    @Mock
+    private Machine machine;
 
     @Mock
     private User user;
@@ -54,6 +62,7 @@ class ConfirmReservationServiceTest {
             when(reservationRepository.findById(reservationId)).thenReturn(Optional.of(reservation));
             when(reservation.getUser()).thenReturn(user);
             when(user.getId()).thenReturn(USER_ID);
+            when(reservation.getMachine()).thenReturn(machine);
 
             // When
             confirmReservationService.execute(reservationId);

--- a/stage.dockerfile
+++ b/stage.dockerfile
@@ -1,7 +1,7 @@
 FROM amazoncorretto:25-alpine
 WORKDIR /app
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
-COPY build/libs/*.jar app.jar
+COPY build/libs/app.jar app.jar
 RUN chown appuser:appgroup app.jar
 USER appuser
 EXPOSE 8080

--- a/stage.dockerfile
+++ b/stage.dockerfile
@@ -1,15 +1,7 @@
-FROM gradle:jdk25-alpine AS build
-WORKDIR /app
-COPY gradlew build.gradle.kts settings.gradle.kts eclipse-formatter.xml ./
-COPY gradle gradle
-RUN chmod +x ./gradlew
-RUN ./gradlew dependencies --no-daemon
-COPY src src
-RUN ./gradlew bootJar --no-daemon
 FROM amazoncorretto:25-alpine
 WORKDIR /app
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
-COPY --from=build /app/build/libs/*.jar app.jar
+COPY build/libs/*.jar app.jar
 RUN chown appuser:appgroup app.jar
 USER appuser
 EXPOSE 8080


### PR DESCRIPTION
## 개요

Cloudtype 기반의 스테이지 배포를 제거하고 온프레미스 학교 서버에 SSH로 직접 배포하는 방식으로 전환하였습니다.

## 본문

### 작업 이유

Cloudtype 의존성을 제거하고 학교 온프레미스 서버에 직접 배포할 수 있는 구조가 필요하였습니다. 기존에는 Cloudtype GitHub Action을 통해 배포하였으나, 이를 `8G4B/GSM-SV-Deploy@v1.2.1` 액션 기반의 SSH 배포로 교체하였습니다.

### 구현 방식

**배포 구조 변경**
- GitHub Actions runner에서 `./gradlew bootJar -x test`로 JAR를 빌드한 후 소스 전체를 서버로 전송합니다.
- 서버의 `stage.dockerfile`은 전송된 JAR를 `COPY`하는 단순 구조로, 서버에서 별도 빌드를 수행하지 않습니다.
- `deployspec.yml`에 `ApplicationStop`(컨테이너 stop/rm)과 `ApplicationStart`(docker build/run) 훅을 정의합니다.
- 컨테이너는 외부 DB 및 Redis 접근을 위해 `--network host` 모드로 실행합니다.
- `.env.stage` 파일은 GitHub Secret `ENV_STAGE`에서 `printf '%s'`로 생성하여 쉘의 따옴표 해석 문제를 방지합니다.

### 현재 상태

`develop` 브랜치 push 시 GitHub Actions에서 JAR를 빌드하고 학교 서버(`/app/washer`)에 배포됩니다. 컨테이너는 `--network host`로 실행되어 외부 MySQL 및 Redis에 접근합니다. Discord 웹훅을 통해 CD 성공/실패/취소 알림이 전송됩니다.
