### PR TITLE
[reservation] 호실 기준으로 활성 예약 조회 API 구현

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/controller/ReservationController.java
@@ -1,6 +1,7 @@
 package team.washer.server.v2.domain.reservation.controller;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -24,6 +25,7 @@ import team.washer.server.v2.domain.reservation.dto.response.ReservationHistoryP
 import team.washer.server.v2.domain.reservation.dto.response.ReservationResDto;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.service.*;
+import team.washer.server.v2.domain.reservation.service.QueryRoomActiveReservationsService;
 
 @RestController
 @RequestMapping("/api/v2/reservations")
@@ -39,6 +41,7 @@ public class ReservationController {
     private final QueryReservationHistoryService queryReservationHistoryService;
     private final QueryReservationService queryReservationService;
     private final QueryReservationAvailabilityService queryReservationAvailabilityService;
+    private final QueryRoomActiveReservationsService queryRoomActiveReservationsService;
 
     @PostMapping
     @Operation(summary = "예약 생성", description = """
@@ -71,6 +74,12 @@ public class ReservationController {
     @Operation(summary = "내 활성 예약 조회", description = "현재 활성 상태인 나의 예약을 조회합니다.")
     public ReservationResDto getActiveReservation() {
         return queryActiveReservationService.execute();
+    }
+
+    @GetMapping("/active/room")
+    @Operation(summary = "내 호실 활성 예약 목록 조회", description = "현재 로그인된 사용자의 호실에 있는 모든 활성 예약 목록을 조회합니다.")
+    public List<ReservationResDto> getRoomActiveReservations() {
+        return queryRoomActiveReservationsService.execute();
     }
 
     @GetMapping("/history")

--- a/src/main/java/team/washer/server/v2/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/controller/ReservationController.java
@@ -1,7 +1,6 @@
 package team.washer.server.v2.domain.reservation.controller;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -23,6 +22,7 @@ import team.washer.server.v2.domain.reservation.dto.response.CancellationResDto;
 import team.washer.server.v2.domain.reservation.dto.response.ReservationAvailabilityResDto;
 import team.washer.server.v2.domain.reservation.dto.response.ReservationHistoryPageResDto;
 import team.washer.server.v2.domain.reservation.dto.response.ReservationResDto;
+import team.washer.server.v2.domain.reservation.dto.response.RoomActiveReservationsResDto;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.service.*;
 import team.washer.server.v2.domain.reservation.service.QueryRoomActiveReservationsService;
@@ -78,7 +78,7 @@ public class ReservationController {
 
     @GetMapping("/active/room")
     @Operation(summary = "내 호실 활성 예약 목록 조회", description = "현재 로그인된 사용자의 호실에 있는 모든 활성 예약 목록을 조회합니다.")
-    public List<ReservationResDto> getRoomActiveReservations() {
+    public RoomActiveReservationsResDto getRoomActiveReservations() {
         return queryRoomActiveReservationsService.execute();
     }
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/dto/response/RoomActiveReservationsResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/dto/response/RoomActiveReservationsResDto.java
@@ -1,0 +1,9 @@
+package team.washer.server.v2.domain.reservation.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "호실 활성 예약 목록 응답 DTO")
+public record RoomActiveReservationsResDto(@Schema(description = "호실 활성 예약 목록") List<ReservationResDto> reservations) {
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/ReservationRepositoryCustom.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/ReservationRepositoryCustom.java
@@ -64,6 +64,15 @@ public interface ReservationRepositoryCustom {
             Pageable pageable);
 
     /**
+     * 호실 번호 기준 활성 예약 목록 조회
+     *
+     * @param roomNumber
+     *            호실 번호
+     * @return 해당 호실의 활성(RESERVED/CONFIRMED/RUNNING) 예약 목록 (createdAt 내림차순)
+     */
+    List<Reservation> findActiveReservationsByRoomNumber(String roomNumber);
+
+    /**
      * 기기별 예약 히스토리 조회
      *
      * @param machineId

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
@@ -86,6 +86,16 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
     }
 
     @Override
+    public List<Reservation> findActiveReservationsByRoomNumber(String roomNumber) {
+        return jpaQueryFactory.selectFrom(reservation).join(reservation.user, user).fetchJoin()
+                .join(reservation.machine, machine).fetchJoin()
+                .where(reservation.user.roomNumber.eq(roomNumber),
+                        reservation.status
+                                .in(ReservationStatus.RESERVED, ReservationStatus.CONFIRMED, ReservationStatus.RUNNING))
+                .orderBy(reservation.createdAt.desc()).fetch();
+    }
+
+    @Override
     public List<Reservation> findExpiredReservations(ReservationStatus status,
             LocalDateTime threshold,
             LocalDateTime recentCutoff) {

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/QueryRoomActiveReservationsService.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/QueryRoomActiveReservationsService.java
@@ -1,10 +1,8 @@
 package team.washer.server.v2.domain.reservation.service;
 
-import java.util.List;
-
-import team.washer.server.v2.domain.reservation.dto.response.ReservationResDto;
+import team.washer.server.v2.domain.reservation.dto.response.RoomActiveReservationsResDto;
 
 public interface QueryRoomActiveReservationsService {
 
-    List<ReservationResDto> execute();
+    RoomActiveReservationsResDto execute();
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/QueryRoomActiveReservationsService.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/QueryRoomActiveReservationsService.java
@@ -1,0 +1,10 @@
+package team.washer.server.v2.domain.reservation.service;
+
+import java.util.List;
+
+import team.washer.server.v2.domain.reservation.dto.response.ReservationResDto;
+
+public interface QueryRoomActiveReservationsService {
+
+    List<ReservationResDto> execute();
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryRoomActiveReservationsServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryRoomActiveReservationsServiceImpl.java
@@ -1,7 +1,5 @@
 package team.washer.server.v2.domain.reservation.service.impl;
 
-import java.util.List;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.reservation.dto.response.ReservationResDto;
+import team.washer.server.v2.domain.reservation.dto.response.RoomActiveReservationsResDto;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.reservation.service.QueryRoomActiveReservationsService;
 import team.washer.server.v2.domain.user.entity.User;
@@ -25,12 +24,12 @@ public class QueryRoomActiveReservationsServiceImpl implements QueryRoomActiveRe
 
     @Override
     @Transactional(readOnly = true)
-    public List<ReservationResDto> execute() {
+    public RoomActiveReservationsResDto execute() {
         final var userId = currentUserProvider.getCurrentUserId();
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
-        return reservationRepository.findActiveReservationsByRoomNumber(user.getRoomNumber()).stream()
+        final var reservations = reservationRepository.findActiveReservationsByRoomNumber(user.getRoomNumber()).stream()
                 .filter(r -> !r.isExpired())
                 .map(r -> new ReservationResDto(r.getId(),
                         r.getUser().getId(),
@@ -49,5 +48,7 @@ public class QueryRoomActiveReservationsServiceImpl implements QueryRoomActiveRe
                         r.getCreatedAt(),
                         r.getUpdatedAt()))
                 .toList();
+
+        return new RoomActiveReservationsResDto(reservations);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryRoomActiveReservationsServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryRoomActiveReservationsServiceImpl.java
@@ -1,0 +1,53 @@
+package team.washer.server.v2.domain.reservation.service.impl;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.reservation.dto.response.ReservationResDto;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.reservation.service.QueryRoomActiveReservationsService;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+@Service
+@RequiredArgsConstructor
+public class QueryRoomActiveReservationsServiceImpl implements QueryRoomActiveReservationsService {
+
+    private final ReservationRepository reservationRepository;
+    private final UserRepository userRepository;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ReservationResDto> execute() {
+        final var userId = currentUserProvider.getCurrentUserId();
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        return reservationRepository.findActiveReservationsByRoomNumber(user.getRoomNumber()).stream()
+                .filter(r -> !r.isExpired())
+                .map(r -> new ReservationResDto(r.getId(),
+                        r.getUser().getId(),
+                        r.getUser().getName(),
+                        r.getUser().getRoomNumber(),
+                        r.getMachine().getId(),
+                        r.getMachine().getName(),
+                        r.getReservedAt(),
+                        r.getStartTime(),
+                        r.getExpectedCompletionTime(),
+                        r.getActualCompletionTime(),
+                        r.getStatus(),
+                        r.getConfirmedAt(),
+                        r.getCancelledAt(),
+                        r.getDayOfWeek(),
+                        r.getCreatedAt(),
+                        r.getUpdatedAt()))
+                .toList();
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/QueryRoomActiveReservationsServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/QueryRoomActiveReservationsServiceTest.java
@@ -1,0 +1,190 @@
+package team.washer.server.v2.domain.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.reservation.dto.response.RoomActiveReservationsResDto;
+import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.reservation.service.impl.QueryRoomActiveReservationsServiceImpl;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+@ExtendWith(MockitoExtension.class)
+class QueryRoomActiveReservationsServiceTest {
+
+    @InjectMocks
+    private QueryRoomActiveReservationsServiceImpl queryRoomActiveReservationsService;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CurrentUserProvider currentUserProvider;
+
+    @Mock
+    private User user;
+
+    @Mock
+    private Machine machine;
+
+    private static final Long USER_ID = 1L;
+    private static final String ROOM_NUMBER = "301";
+
+    @Nested
+    @DisplayName("호실 활성 예약 목록 조회")
+    class ExecuteTest {
+
+        @Test
+        @DisplayName("만료되지 않은 활성 예약이 있으면 해당 목록을 반환한다")
+        void execute_ShouldReturnReservations_WhenValidActiveReservationsExist() {
+            // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            when(user.getRoomNumber()).thenReturn(ROOM_NUMBER);
+            final Reservation reservation = mock(Reservation.class);
+            when(reservationRepository.findActiveReservationsByRoomNumber(ROOM_NUMBER))
+                    .thenReturn(List.of(reservation));
+            when(reservation.isExpired()).thenReturn(false);
+            stubReservationDtoFields(reservation, 1L);
+
+            // When
+            final RoomActiveReservationsResDto result = queryRoomActiveReservationsService.execute();
+
+            // Then
+            assertThat(result.reservations()).hasSize(1);
+            assertThat(result.reservations().get(0).id()).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("호실 내 세탁기·건조기 예약이 모두 있으면 2건을 반환한다")
+        void execute_ShouldReturnTwoReservations_WhenBothWasherAndDryerReservationsExist() {
+            // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            when(user.getRoomNumber()).thenReturn(ROOM_NUMBER);
+            final Reservation washerReservation = mock(Reservation.class);
+            final Reservation dryerReservation = mock(Reservation.class);
+            when(reservationRepository.findActiveReservationsByRoomNumber(ROOM_NUMBER))
+                    .thenReturn(List.of(washerReservation, dryerReservation));
+            when(washerReservation.isExpired()).thenReturn(false);
+            when(dryerReservation.isExpired()).thenReturn(false);
+            stubReservationDtoFields(washerReservation, 1L);
+            stubReservationDtoFields(dryerReservation, 2L);
+
+            // When
+            final RoomActiveReservationsResDto result = queryRoomActiveReservationsService.execute();
+
+            // Then
+            assertThat(result.reservations()).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("만료 예약과 유효 예약이 혼재하면 유효한 예약만 반환한다")
+        void execute_ShouldReturnOnlyValidReservations_WhenMixedExpiredAndValidReservationsExist() {
+            // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            when(user.getRoomNumber()).thenReturn(ROOM_NUMBER);
+            final Reservation expiredReservation = mock(Reservation.class);
+            final Reservation validReservation = mock(Reservation.class);
+            when(reservationRepository.findActiveReservationsByRoomNumber(ROOM_NUMBER))
+                    .thenReturn(List.of(expiredReservation, validReservation));
+            when(expiredReservation.isExpired()).thenReturn(true);
+            when(validReservation.isExpired()).thenReturn(false);
+            stubReservationDtoFields(validReservation, 2L);
+
+            // When
+            final RoomActiveReservationsResDto result = queryRoomActiveReservationsService.execute();
+
+            // Then
+            assertThat(result.reservations()).hasSize(1);
+            assertThat(result.reservations().get(0).id()).isEqualTo(2L);
+        }
+
+        @Test
+        @DisplayName("만료된 예약만 존재하면 빈 목록을 반환한다")
+        void execute_ShouldReturnEmptyList_WhenOnlyExpiredReservationsExist() {
+            // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            when(user.getRoomNumber()).thenReturn(ROOM_NUMBER);
+            final Reservation expiredReservation = mock(Reservation.class);
+            when(reservationRepository.findActiveReservationsByRoomNumber(ROOM_NUMBER))
+                    .thenReturn(List.of(expiredReservation));
+            when(expiredReservation.isExpired()).thenReturn(true);
+
+            // When
+            final RoomActiveReservationsResDto result = queryRoomActiveReservationsService.execute();
+
+            // Then
+            assertThat(result.reservations()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("호실에 활성 예약이 없으면 빈 목록을 반환한다")
+        void execute_ShouldReturnEmptyList_WhenNoActiveReservationsExist() {
+            // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            when(user.getRoomNumber()).thenReturn(ROOM_NUMBER);
+            when(reservationRepository.findActiveReservationsByRoomNumber(anyString()))
+                    .thenReturn(Collections.emptyList());
+
+            // When
+            final RoomActiveReservationsResDto result = queryRoomActiveReservationsService.execute();
+
+            // Then
+            assertThat(result.reservations()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("사용자를 찾을 수 없으면 예외를 발생시킨다")
+        void execute_ShouldThrowException_WhenUserNotFound() {
+            // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> queryRoomActiveReservationsService.execute()).isInstanceOf(ExpectedException.class)
+                    .hasMessage("사용자를 찾을 수 없습니다");
+        }
+    }
+
+    private void stubReservationDtoFields(Reservation reservation, Long reservationId) {
+        when(reservation.getId()).thenReturn(reservationId);
+        when(reservation.getUser()).thenReturn(user);
+        when(user.getId()).thenReturn(USER_ID);
+        when(user.getName()).thenReturn("김철수");
+        when(user.getRoomNumber()).thenReturn(ROOM_NUMBER);
+        when(reservation.getMachine()).thenReturn(machine);
+        when(machine.getId()).thenReturn(1L);
+        when(machine.getName()).thenReturn("세탁기 1");
+        when(reservation.getReservedAt()).thenReturn(LocalDateTime.now());
+        when(reservation.getStartTime()).thenReturn(LocalDateTime.now());
+        when(reservation.getStatus()).thenReturn(ReservationStatus.RESERVED);
+    }
+}


### PR DESCRIPTION
## 개요

로그인한 사용자의 호실 번호를 기준으로 현재 활성화된 모든 예약 목록을 조회하는 기능을 추가했습니다.

## 본문

### 작업 이유
같은 호실을 사용하는 사용자들 간의 세탁기 예약 현황을 공유하고 관리할 수 있도록 호실 단위의 활성 예약 조회 기능이 필요했습니다.

### 구현 방식
- ReservationRepositoryCustom에 호실 번호를 조건으로 활성 상태(RESERVED, CONFIRMED, RUNNING)의 예약을 조회하는 메서드를 추가하고 QueryDSL로 구현했습니다.
- QueryRoomActiveReservationsService를 통해 현재 사용자의 호실 정보를 가져와 해당 호실의 활성 예약 목록을 조회하고 DTO로 매핑하는 비즈니스 로직을 구현했습니다.
- ReservationController에 GET /api/v2/reservations/active/room 엔드포인트를 추가하여 클라이언트에서 접근 가능하도록 했습니다.

### 현재 상태
사용자는 새로운 API 엔드포인트를 통해 자신의 호실에서 진행 중이거나 예정된 모든 예약 목록을 최신순으로 확인할 수 있습니다.
