### PR TITLE
[admin] 어드민 관련 기능을 요구사항을 충실히 따르도록 재설계

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/admin/dto/response/AdminDashboardResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/admin/dto/response/AdminDashboardResDto.java
@@ -9,5 +9,11 @@ public record AdminDashboardResDto(@Schema(description = "활성 예약 수", ex
 
         @Schema(description = "처리 중인 고장 신고 수", example = "2") Long processingMalfunctionReports,
 
-        @Schema(description = "처리 완료된 고장 신고 수", example = "10") Long completedMalfunctionReports) {
+        @Schema(description = "처리 완료된 고장 신고 수", example = "10") Long completedMalfunctionReports,
+
+        @Schema(description = "전체 기기 수", example = "8") Long totalMachines,
+
+        @Schema(description = "고장 상태 기기 수", example = "2") Long malfunctionMachines,
+
+        @Schema(description = "세탁 정지된 학생 수", example = "1") Long suspendedStudents) {
 }

--- a/src/main/java/team/washer/server/v2/domain/admin/service/impl/QueryAdminDashboardServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/admin/service/impl/QueryAdminDashboardServiceImpl.java
@@ -1,5 +1,7 @@
 package team.washer.server.v2.domain.admin.service.impl;
 
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -7,9 +9,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.admin.dto.response.AdminDashboardResDto;
 import team.washer.server.v2.domain.admin.service.QueryAdminDashboardService;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.malfunction.enums.MalfunctionReportStatus;
 import team.washer.server.v2.domain.malfunction.repository.MalfunctionReportRepository;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.common.constants.PenaltyConstants;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +24,8 @@ public class QueryAdminDashboardServiceImpl implements QueryAdminDashboardServic
 
     private final ReservationRepository reservationRepository;
     private final MalfunctionReportRepository malfunctionReportRepository;
+    private final MachineRepository machineRepository;
+    private final UserRepository userRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -28,8 +36,18 @@ public class QueryAdminDashboardServiceImpl implements QueryAdminDashboardServic
         var pendingReports = malfunctionReportRepository.countByStatus(MalfunctionReportStatus.PENDING);
         var processingReports = malfunctionReportRepository.countByStatus(MalfunctionReportStatus.IN_PROGRESS);
         var completedReports = malfunctionReportRepository.countByStatus(MalfunctionReportStatus.RESOLVED);
+        var totalMachines = machineRepository.count();
+        var malfunctionMachines = machineRepository.countByStatus(MachineStatus.MALFUNCTION);
+        var penaltyThreshold = LocalDateTime.now().minusMinutes(PenaltyConstants.PENALTY_DURATION_MINUTES);
+        var suspendedStudents = userRepository.countSuspendedStudents(penaltyThreshold);
 
-        var result = new AdminDashboardResDto(activeReservations, pendingReports, processingReports, completedReports);
+        var result = new AdminDashboardResDto(activeReservations,
+                pendingReports,
+                processingReports,
+                completedReports,
+                totalMachines,
+                malfunctionMachines,
+                suspendedStudents);
 
         log.info("Successfully queried admin dashboard statistics");
 

--- a/src/main/java/team/washer/server/v2/domain/machine/repository/MachineRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/repository/MachineRepository.java
@@ -29,6 +29,8 @@ public interface MachineRepository extends JpaRepository<Machine, Long>, Machine
 
     List<Machine> findByStatus(MachineStatus status);
 
+    long countByStatus(MachineStatus status);
+
     List<Machine> findByAvailability(MachineAvailability availability);
 
     List<Machine> findByTypeAndFloor(MachineType type, Integer floor);

--- a/src/main/java/team/washer/server/v2/domain/malfunction/controller/AdminMalfunctionReportController.java
+++ b/src/main/java/team/washer/server/v2/domain/malfunction/controller/AdminMalfunctionReportController.java
@@ -1,5 +1,8 @@
 package team.washer.server.v2.domain.malfunction.controller;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -27,10 +30,11 @@ public class AdminMalfunctionReportController {
     private final UpdateMalfunctionReportStatusService updateMalfunctionReportStatusService;
 
     @GetMapping
-    @Operation(summary = "고장 신고 목록 조회", description = "고장 신고 목록을 조회합니다. 상태별 필터링을 지원합니다.")
+    @Operation(summary = "고장 신고 목록 조회", description = "고장 신고 목록을 최근 순으로 조회합니다. 상태별 필터링과 페이지네이션을 지원합니다.")
     public MalfunctionReportListResDto getMalfunctionReports(
-            @Parameter(description = "신고 상태 필터") @RequestParam(required = false) MalfunctionReportStatus status) {
-        return queryMalfunctionReportListService.execute(status);
+            @Parameter(description = "신고 상태 필터") @RequestParam(required = false) MalfunctionReportStatus status,
+            @PageableDefault(size = 20, sort = "reportedAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return queryMalfunctionReportListService.execute(status, pageable);
     }
 
     @PutMapping("/{id}/status")

--- a/src/main/java/team/washer/server/v2/domain/malfunction/dto/response/MalfunctionReportListResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/malfunction/dto/response/MalfunctionReportListResDto.java
@@ -6,5 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "고장 신고 목록 응답 DTO")
 public record MalfunctionReportListResDto(@Schema(description = "고장 신고 목록") List<MalfunctionReportResDto> reports,
-        @Schema(description = "총 신고 수", example = "5") Integer totalCount) {
+        @Schema(description = "총 신고 수", example = "5") long totalCount,
+        @Schema(description = "총 페이지 수", example = "3") int totalPages,
+        @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0") int currentPage) {
 }

--- a/src/main/java/team/washer/server/v2/domain/malfunction/repository/custom/MalfunctionReportRepositoryCustom.java
+++ b/src/main/java/team/washer/server/v2/domain/malfunction/repository/custom/MalfunctionReportRepositoryCustom.java
@@ -1,10 +1,11 @@
 package team.washer.server.v2.domain.malfunction.repository.custom;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import team.washer.server.v2.domain.malfunction.entity.MalfunctionReport;
 import team.washer.server.v2.domain.malfunction.enums.MalfunctionReportStatus;
 
 public interface MalfunctionReportRepositoryCustom {
-    List<MalfunctionReport> findWithDetails(MalfunctionReportStatus status);
+    Page<MalfunctionReport> findWithDetails(MalfunctionReportStatus status, Pageable pageable);
 }

--- a/src/main/java/team/washer/server/v2/domain/malfunction/repository/custom/impl/MalfunctionReportRepositoryCustomImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/malfunction/repository/custom/impl/MalfunctionReportRepositoryCustomImpl.java
@@ -6,6 +6,9 @@ import static team.washer.server.v2.domain.user.entity.QUser.user;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -22,9 +25,16 @@ public class MalfunctionReportRepositoryCustomImpl implements MalfunctionReportR
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<MalfunctionReport> findWithDetails(final MalfunctionReportStatus status) {
-        return jpaQueryFactory.selectFrom(malfunctionReport).leftJoin(malfunctionReport.machine, machine).fetchJoin()
-                .leftJoin(malfunctionReport.reporter, user).fetchJoin()
-                .where(status != null ? malfunctionReport.status.eq(status) : null).fetch();
+    public Page<MalfunctionReport> findWithDetails(final MalfunctionReportStatus status, final Pageable pageable) {
+        final List<MalfunctionReport> content = jpaQueryFactory.selectFrom(malfunctionReport)
+                .leftJoin(malfunctionReport.machine, machine).fetchJoin().leftJoin(malfunctionReport.reporter, user)
+                .fetchJoin().where(status != null ? malfunctionReport.status.eq(status) : null)
+                .orderBy(malfunctionReport.reportedAt.desc()).offset(pageable.getOffset()).limit(pageable.getPageSize())
+                .fetch();
+
+        final Long total = jpaQueryFactory.select(malfunctionReport.count()).from(malfunctionReport)
+                .where(status != null ? malfunctionReport.status.eq(status) : null).fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/malfunction/service/QueryMalfunctionReportListService.java
+++ b/src/main/java/team/washer/server/v2/domain/malfunction/service/QueryMalfunctionReportListService.java
@@ -1,8 +1,10 @@
 package team.washer.server.v2.domain.malfunction.service;
 
+import org.springframework.data.domain.Pageable;
+
 import team.washer.server.v2.domain.malfunction.dto.response.MalfunctionReportListResDto;
 import team.washer.server.v2.domain.malfunction.enums.MalfunctionReportStatus;
 
 public interface QueryMalfunctionReportListService {
-    MalfunctionReportListResDto execute(MalfunctionReportStatus status);
+    MalfunctionReportListResDto execute(MalfunctionReportStatus status, Pageable pageable);
 }

--- a/src/main/java/team/washer/server/v2/domain/malfunction/service/impl/QueryMalfunctionReportListServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/malfunction/service/impl/QueryMalfunctionReportListServiceImpl.java
@@ -1,7 +1,7 @@
 package team.washer.server.v2.domain.malfunction.service.impl;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,12 +21,15 @@ public class QueryMalfunctionReportListServiceImpl implements QueryMalfunctionRe
 
     @Override
     @Transactional(readOnly = true)
-    public MalfunctionReportListResDto execute(final MalfunctionReportStatus status) {
-        final List<MalfunctionReport> reports = malfunctionReportRepository.findWithDetails(status);
+    public MalfunctionReportListResDto execute(final MalfunctionReportStatus status, final Pageable pageable) {
+        final Page<MalfunctionReport> reportsPage = malfunctionReportRepository.findWithDetails(status, pageable);
 
-        final List<MalfunctionReportResDto> reportDtos = reports.stream().map(this::toResDto).toList();
+        final var reportDtos = reportsPage.getContent().stream().map(this::toResDto).toList();
 
-        return new MalfunctionReportListResDto(reportDtos, reportDtos.size());
+        return new MalfunctionReportListResDto(reportDtos,
+                reportsPage.getTotalElements(),
+                reportsPage.getTotalPages(),
+                reportsPage.getNumber());
     }
 
     private MalfunctionReportResDto toResDto(final MalfunctionReport report) {

--- a/src/main/java/team/washer/server/v2/domain/reservation/controller/AdminReservationController.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/controller/AdminReservationController.java
@@ -13,6 +13,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import team.themoment.sdk.response.CommonApiResponse;
+import team.washer.server.v2.domain.machine.enums.MachineType;
 import team.washer.server.v2.domain.reservation.dto.request.SundayActivationReqDto;
 import team.washer.server.v2.domain.reservation.dto.response.AdminCancellationResDto;
 import team.washer.server.v2.domain.reservation.dto.response.AdminReservationListResDto;
@@ -76,16 +77,18 @@ public class AdminReservationController {
     }
 
     @GetMapping
-    @Operation(summary = "전체 예약 조회", description = "필터링 옵션으로 예약 목록을 조회합니다 (페이지네이션 지원)")
+    @Operation(summary = "전체 예약 조회", description = "필터링 옵션으로 예약 목록을 조회합니다. 기기 유형(세탁기/건조기)으로 필터링하거나 함께 조회할 수 있습니다 (페이지네이션 지원)")
     public AdminReservationListResDto getReservations(
             @Parameter(description = "사용자 이름 (부분 검색)") @RequestParam(required = false) String userName,
             @Parameter(description = "기기명 (부분 검색)") @RequestParam(required = false) String machineName,
             @Parameter(description = "예약 상태") @RequestParam(required = false) ReservationStatus status,
             @Parameter(description = "시작일") @RequestParam(required = false) LocalDateTime startDate,
             @Parameter(description = "종료일") @RequestParam(required = false) LocalDateTime endDate,
+            @Parameter(description = "기기 유형 (WASHER: 세탁기, DRYER: 건조기)") @RequestParam(required = false) MachineType machineType,
             Pageable pageable) {
 
-        return queryAllReservationsService.execute(userName, machineName, status, startDate, endDate, pageable);
+        return queryAllReservationsService
+                .execute(userName, machineName, status, startDate, endDate, machineType, pageable);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/ReservationRepositoryCustom.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/ReservationRepositoryCustom.java
@@ -52,6 +52,8 @@ public interface ReservationRepositoryCustom {
      *            시작일 (null 가능)
      * @param endDate
      *            종료일 (null 가능)
+     * @param machineType
+     *            기기 유형 (세탁기/건조기, null 가능)
      * @param pageable
      *            페이지네이션 정보
      * @return 필터링된 예약 페이지 (생성일 기준 내림차순)
@@ -61,6 +63,7 @@ public interface ReservationRepositoryCustom {
             ReservationStatus status,
             LocalDateTime startDate,
             LocalDateTime endDate,
+            MachineType machineType,
             Pageable pageable);
 
     /**

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
@@ -114,6 +114,7 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
             ReservationStatus status,
             LocalDateTime startDate,
             LocalDateTime endDate,
+            MachineType machineType,
             Pageable pageable) {
 
         final var content = jpaQueryFactory.selectFrom(reservation).leftJoin(reservation.user, user).fetchJoin()
@@ -122,7 +123,8 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
                         machineNameContains(machineName),
                         statusEquals(status),
                         startTimeAfter(startDate),
-                        startTimeBefore(endDate))
+                        startTimeBefore(endDate),
+                        machineTypeEquals(machineType))
                 .orderBy(reservation.createdAt.desc()).offset(pageable.getOffset()).limit(pageable.getPageSize())
                 .fetch();
 
@@ -131,7 +133,8 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
                         machineNameContains(machineName),
                         statusEquals(status),
                         startTimeAfter(startDate),
-                        startTimeBefore(endDate))
+                        startTimeBefore(endDate),
+                        machineTypeEquals(machineType))
                 .fetchOne();
 
         final var count = total != null ? total : 0L;
@@ -185,5 +188,9 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 
     private BooleanExpression startTimeBefore(LocalDateTime endDate) {
         return endDate != null ? reservation.startTime.loe(endDate) : null;
+    }
+
+    private BooleanExpression machineTypeEquals(MachineType machineType) {
+        return machineType != null ? reservation.machine.type.eq(machineType) : null;
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/QueryAllReservationsService.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/QueryAllReservationsService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import org.springframework.data.domain.Pageable;
 
+import team.washer.server.v2.domain.machine.enums.MachineType;
 import team.washer.server.v2.domain.reservation.dto.response.AdminReservationListResDto;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 
@@ -13,5 +14,6 @@ public interface QueryAllReservationsService {
             ReservationStatus status,
             LocalDateTime startDate,
             LocalDateTime endDate,
+            MachineType machineType,
             Pageable pageable);
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryAllReservationsServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryAllReservationsServiceImpl.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.machine.enums.MachineType;
 import team.washer.server.v2.domain.reservation.dto.response.AdminReservationListResDto;
 import team.washer.server.v2.domain.reservation.dto.response.AdminReservationResDto;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
@@ -27,10 +28,11 @@ public class QueryAllReservationsServiceImpl implements QueryAllReservationsServ
             ReservationStatus status,
             LocalDateTime startDate,
             LocalDateTime endDate,
+            MachineType machineType,
             Pageable pageable) {
 
         final var reservationsPage = reservationRepository
-                .findAllWithFilters(userName, machineName, status, startDate, endDate, pageable);
+                .findAllWithFilters(userName, machineName, status, startDate, endDate, machineType, pageable);
         final var reservationDtos = reservationsPage.getContent().stream().map(this::toAdminReservationResDto).toList();
 
         return new AdminReservationListResDto(reservationDtos,

--- a/src/main/java/team/washer/server/v2/domain/user/controller/AdminUserController.java
+++ b/src/main/java/team/washer/server/v2/domain/user/controller/AdminUserController.java
@@ -1,5 +1,8 @@
 package team.washer.server.v2.domain.user.controller;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,12 +35,14 @@ public class AdminUserController {
     private final DeleteUserService deleteUserService;
 
     @GetMapping
-    @Operation(summary = "전체 사용자 조회", description = "필터링 옵션으로 사용자 목록을 조회합니다")
+    @Operation(summary = "전체 사용자 조회", description = "필터링 옵션으로 사용자 목록을 조회합니다. 이름, 학번(부분 검색) 및 페이지네이션을 지원합니다.")
     public UserListResDto getUsers(@Parameter(description = "이름 (부분 검색)") @RequestParam(required = false) String name,
+            @Parameter(description = "학번 (부분 검색)") @RequestParam(required = false) String studentId,
             @Parameter(description = "호실") @RequestParam(required = false) String roomNumber,
             @Parameter(description = "학년") @RequestParam(required = false) Integer grade,
-            @Parameter(description = "층") @RequestParam(required = false) Integer floor) {
-        return searchUserService.getUsersByFilter(name, roomNumber, grade, floor);
+            @Parameter(description = "층") @RequestParam(required = false) Integer floor,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        return searchUserService.execute(name, studentId, roomNumber, grade, floor, pageable);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/team/washer/server/v2/domain/user/dto/response/UserListResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/user/dto/response/UserListResDto.java
@@ -6,5 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "사용자 목록 응답 DTO")
 public record UserListResDto(@Schema(description = "사용자 목록") List<UserResDto> users,
-        @Schema(description = "총 사용자 수", example = "5") Integer totalCount) {
+        @Schema(description = "총 사용자 수", example = "5") long totalCount,
+        @Schema(description = "총 페이지 수", example = "3") int totalPages,
+        @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0") int currentPage) {
 }

--- a/src/main/java/team/washer/server/v2/domain/user/repository/UserRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package team.washer.server.v2.domain.user.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,4 +32,7 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
 
     @Query("SELECT u FROM User u WHERE u.penaltyCount > :threshold ORDER BY u.penaltyCount DESC")
     List<User> findUsersWithPenaltyAbove(@Param("threshold") Integer threshold);
+
+    @Query("SELECT COUNT(u) FROM User u WHERE u.lastCancellationAt IS NOT NULL AND u.lastCancellationAt >= :threshold")
+    long countSuspendedStudents(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/team/washer/server/v2/domain/user/repository/custom/UserRepositoryCustom.java
+++ b/src/main/java/team/washer/server/v2/domain/user/repository/custom/UserRepositoryCustom.java
@@ -1,10 +1,16 @@
 package team.washer.server.v2.domain.user.repository.custom;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import team.washer.server.v2.domain.user.entity.User;
 
 public interface UserRepositoryCustom {
 
-    List<User> findUsersByFilter(String name, String roomNumber, Integer grade, Integer floor);
+    Page<User> findUsersByFilter(String name,
+            String studentId,
+            String roomNumber,
+            Integer grade,
+            Integer floor,
+            Pageable pageable);
 }

--- a/src/main/java/team/washer/server/v2/domain/user/repository/custom/impl/UserRepositoryCustomImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/repository/custom/impl/UserRepositoryCustomImpl.java
@@ -4,9 +4,13 @@ import static team.washer.server.v2.domain.user.entity.QUser.*;
 
 import java.util.List;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -20,12 +24,48 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public List<User> findUsersByFilter(String name, String roomNumber, Integer grade, Integer floor) {
-        return jpaQueryFactory.selectFrom(user)
-                .where(StringUtils.hasText(name) ? user.name.contains(name) : null,
-                        StringUtils.hasText(roomNumber) ? user.roomNumber.eq(roomNumber) : null,
-                        grade != null ? user.grade.eq(grade) : null,
-                        floor != null ? user.floor.eq(floor) : null)
-                .fetch();
+    public Page<User> findUsersByFilter(String name,
+            String studentId,
+            String roomNumber,
+            Integer grade,
+            Integer floor,
+            Pageable pageable) {
+        final List<User> content = jpaQueryFactory.selectFrom(user)
+                .where(nameContains(name),
+                        studentIdContains(studentId),
+                        roomNumberEquals(roomNumber),
+                        gradeEquals(grade),
+                        floorEquals(floor))
+                .orderBy(user.createdAt.desc()).offset(pageable.getOffset()).limit(pageable.getPageSize()).fetch();
+
+        final Long total = jpaQueryFactory.select(user.count()).from(user)
+                .where(nameContains(name),
+                        studentIdContains(studentId),
+                        roomNumberEquals(roomNumber),
+                        gradeEquals(grade),
+                        floorEquals(floor))
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    private BooleanExpression nameContains(String name) {
+        return StringUtils.hasText(name) ? user.name.contains(name) : null;
+    }
+
+    private BooleanExpression studentIdContains(String studentId) {
+        return StringUtils.hasText(studentId) ? user.studentId.contains(studentId) : null;
+    }
+
+    private BooleanExpression roomNumberEquals(String roomNumber) {
+        return StringUtils.hasText(roomNumber) ? user.roomNumber.eq(roomNumber) : null;
+    }
+
+    private BooleanExpression gradeEquals(Integer grade) {
+        return grade != null ? user.grade.eq(grade) : null;
+    }
+
+    private BooleanExpression floorEquals(Integer floor) {
+        return floor != null ? user.floor.eq(floor) : null;
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/user/service/SearchUserService.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/SearchUserService.java
@@ -1,7 +1,14 @@
 package team.washer.server.v2.domain.user.service;
 
+import org.springframework.data.domain.Pageable;
+
 import team.washer.server.v2.domain.user.dto.response.UserListResDto;
 
 public interface SearchUserService {
-    UserListResDto getUsersByFilter(String name, String roomNumber, Integer grade, Integer floor);
+    UserListResDto execute(String name,
+            String studentId,
+            String roomNumber,
+            Integer grade,
+            Integer floor,
+            Pageable pageable);
 }

--- a/src/main/java/team/washer/server/v2/domain/user/service/impl/SearchUserServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/impl/SearchUserServiceImpl.java
@@ -1,8 +1,7 @@
 package team.washer.server.v2.domain.user.service.impl;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,23 +20,30 @@ public class SearchUserServiceImpl implements SearchUserService {
 
     @Override
     @Transactional(readOnly = true)
-    public UserListResDto getUsersByFilter(String name, String roomNumber, Integer grade, Integer floor) {
-        List<User> users = userRepository.findUsersByFilter(name, roomNumber, grade, floor);
-        return buildUserListResponse(users);
+    public UserListResDto execute(String name,
+            String studentId,
+            String roomNumber,
+            Integer grade,
+            Integer floor,
+            Pageable pageable) {
+        final Page<User> usersPage = userRepository
+                .findUsersByFilter(name, studentId, roomNumber, grade, floor, pageable);
+        final var userDtos = usersPage.getContent().stream().map(this::toUserResDto).toList();
+        return new UserListResDto(userDtos,
+                usersPage.getTotalElements(),
+                usersPage.getTotalPages(),
+                usersPage.getNumber());
     }
 
-    private UserListResDto buildUserListResponse(List<User> users) {
-        List<UserResDto> userDtos = users.stream()
-                .map(user -> new UserResDto(user.getId(),
-                        user.getName(),
-                        user.getStudentId(),
-                        user.getRoomNumber(),
-                        user.getGrade(),
-                        user.getFloor(),
-                        user.getPenaltyCount(),
-                        user.getCreatedAt(),
-                        user.getUpdatedAt()))
-                .collect(Collectors.toList());
-        return new UserListResDto(userDtos, userDtos.size());
+    private UserResDto toUserResDto(User user) {
+        return new UserResDto(user.getId(),
+                user.getName(),
+                user.getStudentId(),
+                user.getRoomNumber(),
+                user.getGrade(),
+                user.getFloor(),
+                user.getPenaltyCount(),
+                user.getCreatedAt(),
+                user.getUpdatedAt());
     }
 }

--- a/src/test/java/team/washer/server/v2/domain/admin/service/QueryAdminDashboardServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/admin/service/QueryAdminDashboardServiceTest.java
@@ -1,6 +1,7 @@
 package team.washer.server.v2.domain.admin.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.DisplayName;
@@ -12,9 +13,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import team.washer.server.v2.domain.admin.service.impl.QueryAdminDashboardServiceImpl;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.malfunction.enums.MalfunctionReportStatus;
 import team.washer.server.v2.domain.malfunction.repository.MalfunctionReportRepository;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.user.repository.UserRepository;
 
 @ExtendWith(MockitoExtension.class)
 class QueryAdminDashboardServiceTest {
@@ -28,18 +32,27 @@ class QueryAdminDashboardServiceTest {
     @Mock
     private MalfunctionReportRepository malfunctionReportRepository;
 
+    @Mock
+    private MachineRepository machineRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
     @Nested
     @DisplayName("관리자 대시보드 통계 조회")
     class ExecuteTest {
 
         @Test
-        @DisplayName("활성 예약, 고장 신고 통계를 성공적으로 조회한다")
+        @DisplayName("활성 예약, 고장 신고, 기기, 세탁정지 학생 통계를 성공적으로 조회한다")
         void execute_ShouldReturnDashboardStatistics_WhenDataExists() {
             // Given
             when(reservationRepository.countActiveReservations()).thenReturn(5L);
             when(malfunctionReportRepository.countByStatus(MalfunctionReportStatus.PENDING)).thenReturn(3L);
             when(malfunctionReportRepository.countByStatus(MalfunctionReportStatus.IN_PROGRESS)).thenReturn(2L);
             when(malfunctionReportRepository.countByStatus(MalfunctionReportStatus.RESOLVED)).thenReturn(10L);
+            when(machineRepository.count()).thenReturn(8L);
+            when(machineRepository.countByStatus(MachineStatus.MALFUNCTION)).thenReturn(2L);
+            when(userRepository.countSuspendedStudents(any())).thenReturn(1L);
 
             // When
             var result = queryAdminDashboardService.execute();
@@ -50,6 +63,9 @@ class QueryAdminDashboardServiceTest {
             assertThat(result.pendingMalfunctionReports()).isEqualTo(3L);
             assertThat(result.processingMalfunctionReports()).isEqualTo(2L);
             assertThat(result.completedMalfunctionReports()).isEqualTo(10L);
+            assertThat(result.totalMachines()).isEqualTo(8L);
+            assertThat(result.malfunctionMachines()).isEqualTo(2L);
+            assertThat(result.suspendedStudents()).isEqualTo(1L);
         }
 
         @Test
@@ -60,6 +76,9 @@ class QueryAdminDashboardServiceTest {
             when(malfunctionReportRepository.countByStatus(MalfunctionReportStatus.PENDING)).thenReturn(0L);
             when(malfunctionReportRepository.countByStatus(MalfunctionReportStatus.IN_PROGRESS)).thenReturn(0L);
             when(malfunctionReportRepository.countByStatus(MalfunctionReportStatus.RESOLVED)).thenReturn(0L);
+            when(machineRepository.count()).thenReturn(0L);
+            when(machineRepository.countByStatus(MachineStatus.MALFUNCTION)).thenReturn(0L);
+            when(userRepository.countSuspendedStudents(any())).thenReturn(0L);
 
             // When
             var result = queryAdminDashboardService.execute();
@@ -70,6 +89,9 @@ class QueryAdminDashboardServiceTest {
             assertThat(result.pendingMalfunctionReports()).isZero();
             assertThat(result.processingMalfunctionReports()).isZero();
             assertThat(result.completedMalfunctionReports()).isZero();
+            assertThat(result.totalMachines()).isZero();
+            assertThat(result.malfunctionMachines()).isZero();
+            assertThat(result.suspendedStudents()).isZero();
         }
     }
 }

--- a/src/test/java/team/washer/server/v2/domain/malfunction/service/QueryMalfunctionReportListServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/malfunction/service/QueryMalfunctionReportListServiceTest.java
@@ -13,6 +13,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.machine.enums.MachineAvailability;
@@ -35,6 +39,8 @@ class QueryMalfunctionReportListServiceTest {
 
     @Mock
     private MalfunctionReportRepository malfunctionReportRepository;
+
+    private final Pageable defaultPageable = PageRequest.of(0, 20);
 
     private User createTestUser() {
         return User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3).penaltyCount(0)
@@ -72,17 +78,18 @@ class QueryMalfunctionReportListServiceTest {
                 MalfunctionReport report2 = createTestReport(machine2, user, MalfunctionReportStatus.IN_PROGRESS);
 
                 List<MalfunctionReport> allReports = List.of(report1, report2);
-                given(malfunctionReportRepository.findWithDetails(null)).willReturn(allReports);
+                Page<MalfunctionReport> reportPage = new PageImpl<>(allReports, defaultPageable, allReports.size());
+                given(malfunctionReportRepository.findWithDetails(null, defaultPageable)).willReturn(reportPage);
 
                 // When
-                MalfunctionReportListResDto result = queryMalfunctionReportListService.execute(null);
+                MalfunctionReportListResDto result = queryMalfunctionReportListService.execute(null, defaultPageable);
 
                 // Then
                 assertThat(result).isNotNull();
                 assertThat(result.totalCount()).isEqualTo(2);
                 assertThat(result.reports()).hasSize(2);
 
-                then(malfunctionReportRepository).should(times(1)).findWithDetails(null);
+                then(malfunctionReportRepository).should(times(1)).findWithDetails(null, defaultPageable);
             }
         }
 
@@ -99,19 +106,23 @@ class QueryMalfunctionReportListServiceTest {
                 MalfunctionReport pendingReport = createTestReport(machine, user, MalfunctionReportStatus.PENDING);
 
                 List<MalfunctionReport> pendingReports = List.of(pendingReport);
-                given(malfunctionReportRepository.findWithDetails(MalfunctionReportStatus.PENDING))
-                        .willReturn(pendingReports);
+                Page<MalfunctionReport> reportPage = new PageImpl<>(pendingReports,
+                        defaultPageable,
+                        pendingReports.size());
+                given(malfunctionReportRepository.findWithDetails(MalfunctionReportStatus.PENDING, defaultPageable))
+                        .willReturn(reportPage);
 
                 // When
                 MalfunctionReportListResDto result = queryMalfunctionReportListService
-                        .execute(MalfunctionReportStatus.PENDING);
+                        .execute(MalfunctionReportStatus.PENDING, defaultPageable);
 
                 // Then
                 assertThat(result).isNotNull();
                 assertThat(result.totalCount()).isEqualTo(1);
                 assertThat(result.reports()).hasSize(1);
 
-                then(malfunctionReportRepository).should(times(1)).findWithDetails(MalfunctionReportStatus.PENDING);
+                then(malfunctionReportRepository).should(times(1)).findWithDetails(MalfunctionReportStatus.PENDING,
+                        defaultPageable);
             }
         }
 
@@ -123,17 +134,18 @@ class QueryMalfunctionReportListServiceTest {
             @DisplayName("빈 목록을 반환해야 한다")
             void it_returns_empty_list() {
                 // Given
-                given(malfunctionReportRepository.findWithDetails(null)).willReturn(List.of());
+                Page<MalfunctionReport> emptyPage = new PageImpl<>(List.of(), defaultPageable, 0);
+                given(malfunctionReportRepository.findWithDetails(null, defaultPageable)).willReturn(emptyPage);
 
                 // When
-                MalfunctionReportListResDto result = queryMalfunctionReportListService.execute(null);
+                MalfunctionReportListResDto result = queryMalfunctionReportListService.execute(null, defaultPageable);
 
                 // Then
                 assertThat(result).isNotNull();
                 assertThat(result.totalCount()).isEqualTo(0);
                 assertThat(result.reports()).isEmpty();
 
-                then(malfunctionReportRepository).should(times(1)).findWithDetails(null);
+                then(malfunctionReportRepository).should(times(1)).findWithDetails(null, defaultPageable);
             }
         }
     }

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/QueryAllReservationsServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/QueryAllReservationsServiceTest.java
@@ -81,18 +81,18 @@ class QueryAllReservationsServiceTest {
                         reservations.size());
 
                 given(reservationRepository.findAllWithFilters(eq(
-                        searchName), eq(null), eq(null), eq(null), eq(null), any(Pageable.class)))
+                        searchName), eq(null), eq(null), eq(null), eq(null), eq(null), any(Pageable.class)))
                         .willReturn(reservationPage);
 
                 // When
                 AdminReservationListResDto result = queryAllReservationsService
-                        .execute(searchName, null, null, null, null, PageRequest.of(0, 10));
+                        .execute(searchName, null, null, null, null, null, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(2);
                 assertThat(result.reservations()).allMatch(r -> r.userName().contains("김"));
                 then(reservationRepository).should(times(1)).findAllWithFilters(eq(
-                        searchName), eq(null), eq(null), eq(null), eq(null), any(Pageable.class));
+                        searchName), eq(null), eq(null), eq(null), eq(null), eq(null), any(Pageable.class));
             }
         }
 
@@ -114,18 +114,18 @@ class QueryAllReservationsServiceTest {
                         reservations.size());
 
                 given(reservationRepository.findAllWithFilters(eq(
-                        null), eq(searchMachineName), eq(null), eq(null), eq(null), any(Pageable.class)))
+                        null), eq(searchMachineName), eq(null), eq(null), eq(null), eq(null), any(Pageable.class)))
                         .willReturn(reservationPage);
 
                 // When
                 AdminReservationListResDto result = queryAllReservationsService
-                        .execute(null, searchMachineName, null, null, null, PageRequest.of(0, 10));
+                        .execute(null, searchMachineName, null, null, null, null, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(1);
                 assertThat(result.reservations().get(0).machineName()).contains("W-2F");
                 then(reservationRepository).should(times(1)).findAllWithFilters(eq(
-                        null), eq(searchMachineName), eq(null), eq(null), eq(null), any(Pageable.class));
+                        null), eq(searchMachineName), eq(null), eq(null), eq(null), eq(null), any(Pageable.class));
             }
         }
 
@@ -146,19 +146,19 @@ class QueryAllReservationsServiceTest {
                         PageRequest.of(0, 10),
                         reservations.size());
 
-                given(reservationRepository
-                        .findAllWithFilters(eq(null), eq(null), eq(status), eq(null), eq(null), any(Pageable.class)))
+                given(reservationRepository.findAllWithFilters(eq(
+                        null), eq(null), eq(status), eq(null), eq(null), eq(null), any(Pageable.class)))
                         .willReturn(reservationPage);
 
                 // When
                 AdminReservationListResDto result = queryAllReservationsService
-                        .execute(null, null, status, null, null, PageRequest.of(0, 10));
+                        .execute(null, null, status, null, null, null, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(1);
                 assertThat(result.reservations().get(0).status()).isEqualTo(ReservationStatus.RESERVED);
-                then(reservationRepository).should(times(1))
-                        .findAllWithFilters(eq(null), eq(null), eq(status), eq(null), eq(null), any(Pageable.class));
+                then(reservationRepository).should(times(1)).findAllWithFilters(eq(
+                        null), eq(null), eq(status), eq(null), eq(null), eq(null), any(Pageable.class));
             }
         }
 
@@ -181,17 +181,49 @@ class QueryAllReservationsServiceTest {
                         reservations.size());
 
                 given(reservationRepository.findAllWithFilters(eq(
-                        null), eq(null), eq(null), eq(startDate), eq(endDate), any(Pageable.class)))
+                        null), eq(null), eq(null), eq(startDate), eq(endDate), eq(null), any(Pageable.class)))
                         .willReturn(reservationPage);
 
                 // When
                 AdminReservationListResDto result = queryAllReservationsService
-                        .execute(null, null, null, startDate, endDate, PageRequest.of(0, 10));
+                        .execute(null, null, null, startDate, endDate, null, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(1);
                 then(reservationRepository).should(times(1)).findAllWithFilters(eq(
-                        null), eq(null), eq(null), eq(startDate), eq(endDate), any(Pageable.class));
+                        null), eq(null), eq(null), eq(startDate), eq(endDate), eq(null), any(Pageable.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("기기 유형으로 필터링할 때")
+        class Context_with_machine_type_filter {
+
+            @Test
+            @DisplayName("해당 기기 유형의 예약 목록을 반환해야 한다")
+            void it_returns_reservations_by_machine_type() {
+                // Given
+                MachineType machineType = MachineType.WASHER;
+                User user = createUser("김철수", "301");
+                Machine machine = createMachine("W-2F-L1");
+                Reservation reservation = createReservation(user, machine, ReservationStatus.RUNNING);
+                List<Reservation> reservations = List.of(reservation);
+                Page<Reservation> reservationPage = new PageImpl<>(reservations,
+                        PageRequest.of(0, 10),
+                        reservations.size());
+
+                given(reservationRepository.findAllWithFilters(eq(
+                        null), eq(null), eq(null), eq(null), eq(null), eq(machineType), any(Pageable.class)))
+                        .willReturn(reservationPage);
+
+                // When
+                AdminReservationListResDto result = queryAllReservationsService
+                        .execute(null, null, null, null, null, machineType, PageRequest.of(0, 10));
+
+                // Then
+                assertThat(result.totalCount()).isEqualTo(1);
+                then(reservationRepository).should(times(1)).findAllWithFilters(eq(
+                        null), eq(null), eq(null), eq(null), eq(null), eq(machineType), any(Pageable.class));
             }
         }
 
@@ -213,18 +245,18 @@ class QueryAllReservationsServiceTest {
                         PageRequest.of(0, 10),
                         reservations.size());
 
-                given(reservationRepository
-                        .findAllWithFilters(eq(null), eq(null), eq(null), eq(null), eq(null), any(Pageable.class)))
+                given(reservationRepository.findAllWithFilters(eq(
+                        null), eq(null), eq(null), eq(null), eq(null), eq(null), any(Pageable.class)))
                         .willReturn(reservationPage);
 
                 // When
                 AdminReservationListResDto result = queryAllReservationsService
-                        .execute(null, null, null, null, null, PageRequest.of(0, 10));
+                        .execute(null, null, null, null, null, null, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(2);
-                then(reservationRepository).should(times(1))
-                        .findAllWithFilters(eq(null), eq(null), eq(null), eq(null), eq(null), any(Pageable.class));
+                then(reservationRepository).should(times(1)).findAllWithFilters(eq(
+                        null), eq(null), eq(null), eq(null), eq(null), eq(null), any(Pageable.class));
             }
         }
 
@@ -241,6 +273,7 @@ class QueryAllReservationsServiceTest {
                 ReservationStatus status = ReservationStatus.RESERVED;
                 LocalDateTime startDate = LocalDateTime.now();
                 LocalDateTime endDate = LocalDateTime.now().plusDays(7);
+                MachineType machineType = MachineType.WASHER;
                 User user = createUser("김철수", "301");
                 Machine machine = createMachine("W-2F-L1");
                 Reservation reservation = createReservation(user, machine, ReservationStatus.RESERVED);
@@ -249,21 +282,30 @@ class QueryAllReservationsServiceTest {
                         PageRequest.of(0, 10),
                         reservations.size());
 
-                given(reservationRepository.findAllWithFilters(eq(
-                        userName), eq(machineName), eq(status), eq(startDate), eq(endDate), any(Pageable.class)))
-                        .willReturn(reservationPage);
+                given(reservationRepository.findAllWithFilters(eq(userName),
+                        eq(machineName),
+                        eq(status),
+                        eq(startDate),
+                        eq(endDate),
+                        eq(machineType),
+                        any(Pageable.class))).willReturn(reservationPage);
 
                 // When
                 AdminReservationListResDto result = queryAllReservationsService
-                        .execute(userName, machineName, status, startDate, endDate, PageRequest.of(0, 10));
+                        .execute(userName, machineName, status, startDate, endDate, machineType, PageRequest.of(0, 10));
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(1);
                 assertThat(result.reservations().get(0).userName()).contains("김");
                 assertThat(result.reservations().get(0).machineName()).contains("W-2F");
                 assertThat(result.reservations().get(0).status()).isEqualTo(ReservationStatus.RESERVED);
-                then(reservationRepository).should(times(1)).findAllWithFilters(eq(
-                        userName), eq(machineName), eq(status), eq(startDate), eq(endDate), any(Pageable.class));
+                then(reservationRepository).should(times(1)).findAllWithFilters(eq(userName),
+                        eq(machineName),
+                        eq(status),
+                        eq(startDate),
+                        eq(endDate),
+                        eq(machineType),
+                        any(Pageable.class));
             }
         }
     }

--- a/src/test/java/team/washer/server/v2/domain/user/service/SearchUserServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/service/SearchUserServiceTest.java
@@ -13,6 +13,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 import team.washer.server.v2.domain.user.dto.response.UserListResDto;
 import team.washer.server.v2.domain.user.entity.User;
@@ -29,14 +33,16 @@ class SearchUserServiceTest {
     @Mock
     private UserRepository userRepository;
 
+    private final Pageable defaultPageable = PageRequest.of(0, 20);
+
     private User createUser(String name, String studentId, String roomNumber, Integer grade, Integer floor) {
         return User.builder().name(name).studentId(studentId).roomNumber(roomNumber).grade(grade).floor(floor)
                 .penaltyCount(0).build();
     }
 
     @Nested
-    @DisplayName("getUsersByFilter 메서드는")
-    class Describe_getUsersByFilter {
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
 
         @Nested
         @DisplayName("이름으로 필터링할 때")
@@ -50,16 +56,47 @@ class SearchUserServiceTest {
                 User user1 = createUser("김철수", "20210001", "301", 3, 3);
                 User user2 = createUser("김영희", "20210002", "302", 2, 3);
                 List<User> users = Arrays.asList(user1, user2);
+                Page<User> userPage = new PageImpl<>(users, defaultPageable, users.size());
 
-                given(userRepository.findUsersByFilter(searchName, null, null, null)).willReturn(users);
+                given(userRepository.findUsersByFilter(searchName, null, null, null, null, defaultPageable))
+                        .willReturn(userPage);
 
                 // When
-                UserListResDto result = searchUserService.getUsersByFilter(searchName, null, null, null);
+                UserListResDto result = searchUserService.execute(searchName, null, null, null, null, defaultPageable);
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(2);
                 assertThat(result.users()).allMatch(u -> u.name().contains("김"));
-                then(userRepository).should(times(1)).findUsersByFilter(searchName, null, null, null);
+                then(userRepository).should(times(1))
+                        .findUsersByFilter(searchName, null, null, null, null, defaultPageable);
+            }
+        }
+
+        @Nested
+        @DisplayName("학번으로 필터링할 때")
+        class Context_with_student_id_filter {
+
+            @Test
+            @DisplayName("학번을 포함하는 사용자 목록을 반환해야 한다")
+            void it_returns_users_by_student_id() {
+                // Given
+                String studentId = "2021";
+                User user1 = createUser("김철수", "20210001", "301", 3, 3);
+                User user2 = createUser("이영희", "20210002", "302", 2, 3);
+                List<User> users = Arrays.asList(user1, user2);
+                Page<User> userPage = new PageImpl<>(users, defaultPageable, users.size());
+
+                given(userRepository.findUsersByFilter(null, studentId, null, null, null, defaultPageable))
+                        .willReturn(userPage);
+
+                // When
+                UserListResDto result = searchUserService.execute(null, studentId, null, null, null, defaultPageable);
+
+                // Then
+                assertThat(result.totalCount()).isEqualTo(2);
+                assertThat(result.users()).allMatch(u -> u.studentId().contains("2021"));
+                then(userRepository).should(times(1))
+                        .findUsersByFilter(null, studentId, null, null, null, defaultPageable);
             }
         }
 
@@ -74,16 +111,19 @@ class SearchUserServiceTest {
                 String roomNumber = "301";
                 User user = createUser("김철수", "20210001", "301", 3, 3);
                 List<User> users = List.of(user);
+                Page<User> userPage = new PageImpl<>(users, defaultPageable, users.size());
 
-                given(userRepository.findUsersByFilter(null, roomNumber, null, null)).willReturn(users);
+                given(userRepository.findUsersByFilter(null, null, roomNumber, null, null, defaultPageable))
+                        .willReturn(userPage);
 
                 // When
-                UserListResDto result = searchUserService.getUsersByFilter(null, roomNumber, null, null);
+                UserListResDto result = searchUserService.execute(null, null, roomNumber, null, null, defaultPageable);
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(1);
                 assertThat(result.users().get(0).roomNumber()).isEqualTo("301");
-                then(userRepository).should(times(1)).findUsersByFilter(null, roomNumber, null, null);
+                then(userRepository).should(times(1))
+                        .findUsersByFilter(null, null, roomNumber, null, null, defaultPageable);
             }
         }
 
@@ -100,64 +140,19 @@ class SearchUserServiceTest {
                 User user1 = createUser("김철수", "20210001", "301", 3, 3);
                 User user2 = createUser("이영희", "20210002", "302", 3, 3);
                 List<User> users = Arrays.asList(user1, user2);
+                Page<User> userPage = new PageImpl<>(users, defaultPageable, users.size());
 
-                given(userRepository.findUsersByFilter(null, null, grade, floor)).willReturn(users);
+                given(userRepository.findUsersByFilter(null, null, null, grade, floor, defaultPageable))
+                        .willReturn(userPage);
 
                 // When
-                UserListResDto result = searchUserService.getUsersByFilter(null, null, grade, floor);
+                UserListResDto result = searchUserService.execute(null, null, null, grade, floor, defaultPageable);
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(2);
                 assertThat(result.users()).allMatch(u -> u.grade().equals(3) && u.floor().equals(3));
-                then(userRepository).should(times(1)).findUsersByFilter(null, null, grade, floor);
-            }
-        }
-
-        @Nested
-        @DisplayName("학년으로만 필터링할 때")
-        class Context_with_grade_only_filter {
-
-            @Test
-            @DisplayName("해당 학년의 사용자 목록을 반환해야 한다")
-            void it_returns_users_by_grade() {
-                // Given
-                Integer grade = 2;
-                User user = createUser("박민수", "20220001", "201", 2, 2);
-                List<User> users = List.of(user);
-
-                given(userRepository.findUsersByFilter(null, null, grade, null)).willReturn(users);
-
-                // When
-                UserListResDto result = searchUserService.getUsersByFilter(null, null, grade, null);
-
-                // Then
-                assertThat(result.totalCount()).isEqualTo(1);
-                assertThat(result.users().get(0).grade()).isEqualTo(2);
-                then(userRepository).should(times(1)).findUsersByFilter(null, null, grade, null);
-            }
-        }
-
-        @Nested
-        @DisplayName("층으로만 필터링할 때")
-        class Context_with_floor_only_filter {
-
-            @Test
-            @DisplayName("해당 층의 사용자 목록을 반환해야 한다")
-            void it_returns_users_by_floor() {
-                // Given
-                Integer floor = 4;
-                User user = createUser("최지우", "20200001", "401", 4, 4);
-                List<User> users = List.of(user);
-
-                given(userRepository.findUsersByFilter(null, null, null, floor)).willReturn(users);
-
-                // When
-                UserListResDto result = searchUserService.getUsersByFilter(null, null, null, floor);
-
-                // Then
-                assertThat(result.totalCount()).isEqualTo(1);
-                assertThat(result.users().get(0).floor()).isEqualTo(4);
-                then(userRepository).should(times(1)).findUsersByFilter(null, null, null, floor);
+                then(userRepository).should(times(1))
+                        .findUsersByFilter(null, null, null, grade, floor, defaultPageable);
             }
         }
 
@@ -172,32 +167,17 @@ class SearchUserServiceTest {
                 User user1 = createUser("김철수", "20210001", "301", 3, 3);
                 User user2 = createUser("이영희", "20210002", "302", 2, 2);
                 List<User> users = Arrays.asList(user1, user2);
+                Page<User> userPage = new PageImpl<>(users, defaultPageable, users.size());
 
-                given(userRepository.findUsersByFilter(null, null, null, null)).willReturn(users);
+                given(userRepository.findUsersByFilter(null, null, null, null, null, defaultPageable))
+                        .willReturn(userPage);
 
                 // When
-                UserListResDto result = searchUserService.getUsersByFilter(null, null, null, null);
+                UserListResDto result = searchUserService.execute(null, null, null, null, null, defaultPageable);
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(2);
-                then(userRepository).should(times(1)).findUsersByFilter(null, null, null, null);
-            }
-
-            @Test
-            @DisplayName("빈 문자열 필터도 무시하고 모든 사용자를 반환해야 한다")
-            void it_ignores_empty_string_filters() {
-                // Given
-                User user = createUser("김철수", "20210001", "301", 3, 3);
-                List<User> users = List.of(user);
-
-                given(userRepository.findUsersByFilter("", "", null, null)).willReturn(users);
-
-                // When
-                UserListResDto result = searchUserService.getUsersByFilter("", "", null, null);
-
-                // Then
-                assertThat(result.totalCount()).isEqualTo(1);
-                then(userRepository).should(times(1)).findUsersByFilter("", "", null, null);
+                then(userRepository).should(times(1)).findUsersByFilter(null, null, null, null, null, defaultPageable);
             }
         }
 
@@ -214,18 +194,21 @@ class SearchUserServiceTest {
                 Integer floor = 3;
                 User user = createUser("김철수", "20210001", "301", 3, 3);
                 List<User> users = List.of(user);
+                Page<User> userPage = new PageImpl<>(users, defaultPageable, users.size());
 
-                given(userRepository.findUsersByFilter(name, null, grade, floor)).willReturn(users);
+                given(userRepository.findUsersByFilter(name, null, null, grade, floor, defaultPageable))
+                        .willReturn(userPage);
 
                 // When
-                UserListResDto result = searchUserService.getUsersByFilter(name, null, grade, floor);
+                UserListResDto result = searchUserService.execute(name, null, null, grade, floor, defaultPageable);
 
                 // Then
                 assertThat(result.totalCount()).isEqualTo(1);
                 assertThat(result.users().get(0).name()).contains("김");
                 assertThat(result.users().get(0).grade()).isEqualTo(3);
                 assertThat(result.users().get(0).floor()).isEqualTo(3);
-                then(userRepository).should(times(1)).findUsersByFilter(name, null, grade, floor);
+                then(userRepository).should(times(1))
+                        .findUsersByFilter(name, null, null, grade, floor, defaultPageable);
             }
         }
     }


### PR DESCRIPTION
## 개요

관리자 기능 강화를 위해 대시보드 통계 항목을 추가하고, 주요 목록 조회(고장 신고, 예약, 사용자) API에 필터 및 페이징 처리를 적용하였습니다.

## 본문

### 작업 이유
관리자 페이지에서 보다 상세한 기기 및 사용자 상태를 파악할 수 있도록 통계 지표를 추가하고, 데이터 양 증가에 대비하여 목록 조회 시 부하를 방지하고 효율적인 조회가 가능하도록 페이징 및 필터 기능을 강화하기 위해 작업을 진행하였습니다.

### 구현 방식
관리자 대시보드 서비스에 기기 상태와 사용자 제재 상태를 집계하는 로직을 추가하고, 각 도메인(고장 신고, 예약, 사용자)의 QueryDSL 레포지토리와 서비스 계층에 Pageable 객체를 전달하여 페이징 쿼리를 수행하도록 변경하였습니다. 또한 예약 목록에는 기기 유형 필터를, 사용자 목록에는 학번 필터를 추가하여 검색 범위를 정교화하였습니다.

### 현재 상태
대시보드에서 전체 기기 수, 고장 기기 수, 세탁 정지 학생 수를 확인할 수 있습니다. 고장 신고, 예약, 사용자 목록 조회 API가 페이징 정보를 반환하며, 각각의 추가 필터를 통한 검색이 정상적으로 작동함을 테스트 코드를 통해 검증하였습니다.
