### PR TITLE
[auth] 회원탈퇴 API 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,10 @@ Korean dormitory laundry management system with Java 25 + Spring Boot 4.0.1. Fea
 - API docs (`@Operation`, `@Tag`)
 - Commit messages
 
+**Exception: Log messages must be in English** (`log.info/warn/error`)
+- Use `key=value` format for structured fields — no colons
+- e.g. `log.info("user withdrawn studentId={}", id)` (O) / `log.info("탈퇴: studentId={}", id)` (X)
+
 ## Git & Testing
 - Branches: `master`, `develop`, `feat/`, `fix/`, `docs/`
 - Commits (Korean): `add/update/fix/delete/docs/test/merge/init: {설명}`

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -49,6 +49,10 @@ config/, util/       # Configuration and utilities
 - API documentation (`@Operation`, `@Tag`)
 - Commit messages
 
+**Exception: Log messages must be in English** (`log.info/warn/error`)
+- Use `key=value` format for structured fields — no colons
+- e.g. `log.info("user withdrawn studentId={}", id)` (O) / `log.info("탈퇴: studentId={}", id)` (X)
+
 ## Git Commits (Korean)
 - `add/update/fix/delete/docs/test/merge/init: {설명}`
 - Branches: `master`, `develop`, `feat/`, `fix/`, `docs/`

--- a/src/main/java/team/washer/server/v2/domain/auth/entity/redis/WithdrawnStudentEntity.java
+++ b/src/main/java/team/washer/server/v2/domain/auth/entity/redis/WithdrawnStudentEntity.java
@@ -1,0 +1,24 @@
+package team.washer.server.v2.domain.auth.entity.redis;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@RedisHash("auth:withdrawn:student")
+public class WithdrawnStudentEntity {
+
+    @Id
+    private String studentId;
+
+    @TimeToLive
+    private Long ttl;
+}

--- a/src/main/java/team/washer/server/v2/domain/auth/repository/redis/WithdrawnStudentRedisRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/auth/repository/redis/WithdrawnStudentRedisRepository.java
@@ -1,0 +1,8 @@
+package team.washer.server.v2.domain.auth.repository.redis;
+
+import org.springframework.data.repository.CrudRepository;
+
+import team.washer.server.v2.domain.auth.entity.redis.WithdrawnStudentEntity;
+
+public interface WithdrawnStudentRedisRepository extends CrudRepository<WithdrawnStudentEntity, String> {
+}

--- a/src/main/java/team/washer/server/v2/domain/auth/service/impl/SignInServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/auth/service/impl/SignInServiceImpl.java
@@ -12,6 +12,7 @@ import team.washer.server.v2.domain.auth.dto.request.TokenReqDto;
 import team.washer.server.v2.domain.auth.dto.response.TokenResDto;
 import team.washer.server.v2.domain.auth.service.SignInService;
 import team.washer.server.v2.domain.auth.support.TokenGenerationSupport;
+import team.washer.server.v2.domain.auth.util.WithdrawnStudentRedisUtil;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.domain.user.support.UserRegistrationSupport;
@@ -25,6 +26,7 @@ public class SignInServiceImpl implements SignInService {
     private final UserRepository userRepository;
     private final UserRegistrationSupport userRegistrationSupport;
     private final TokenGenerationSupport tokenGenerationSupport;
+    private final WithdrawnStudentRedisUtil withdrawnStudentRedisUtil;
 
     @Override
     public TokenResDto execute(TokenReqDto reqDto) {
@@ -33,6 +35,9 @@ public class SignInServiceImpl implements SignInService {
         Student oauthUser = oauthClient.getUserInfo(accessToken).getStudent();
         if (oauthUser == null) {
             throw new ExpectedException("학생정보가 없는 DataGSM 계정입니다.", HttpStatus.BAD_REQUEST);
+        }
+        if (withdrawnStudentRedisUtil.isWithdrawnRecently(oauthUser.getStudentNumber().toString())) {
+            throw new ExpectedException("탈퇴 후 30일이 지나지 않아 재가입할 수 없습니다.", HttpStatus.FORBIDDEN);
         }
         User user;
         try {

--- a/src/main/java/team/washer/server/v2/domain/auth/util/WithdrawnStudentRedisUtil.java
+++ b/src/main/java/team/washer/server/v2/domain/auth/util/WithdrawnStudentRedisUtil.java
@@ -1,0 +1,43 @@
+package team.washer.server.v2.domain.auth.util;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.auth.entity.redis.WithdrawnStudentEntity;
+import team.washer.server.v2.domain.auth.repository.redis.WithdrawnStudentRedisRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WithdrawnStudentRedisUtil {
+
+    private static final long THIRTY_DAYS_IN_SECONDS = 30L * 24 * 60 * 60;
+
+    private final WithdrawnStudentRedisRepository withdrawnStudentRedisRepository;
+
+    /**
+     * 탈퇴한 학번을 30일간 Redis에 기록합니다.
+     */
+    public void markWithdrawn(final String studentId) {
+        try {
+            withdrawnStudentRedisRepository
+                    .save(WithdrawnStudentEntity.builder().studentId(studentId).ttl(THIRTY_DAYS_IN_SECONDS).build());
+            log.info("withdrawn student recorded studentId={}", studentId);
+        } catch (Exception e) {
+            log.error("failed to record withdrawn student studentId={}", studentId, e);
+        }
+    }
+
+    /**
+     * 해당 학번이 탈퇴 후 30일 이내인지 여부를 반환합니다.
+     */
+    public boolean isWithdrawnRecently(final String studentId) {
+        try {
+            return withdrawnStudentRedisRepository.existsById(studentId);
+        } catch (Exception e) {
+            log.warn("failed to check withdrawn student studentId={}", studentId, e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/user/controller/UserController.java
+++ b/src/main/java/team/washer/server/v2/domain/user/controller/UserController.java
@@ -1,14 +1,19 @@
 package team.washer.server.v2.domain.user.controller;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import team.themoment.sdk.response.CommonApiResponse;
 import team.washer.server.v2.domain.user.dto.response.MyInfoResDto;
 import team.washer.server.v2.domain.user.service.QueryMyInfoService;
+import team.washer.server.v2.domain.user.service.WithdrawUserService;
 
 @RestController
 @RequestMapping("/api/v2/users")
@@ -17,10 +22,19 @@ import team.washer.server.v2.domain.user.service.QueryMyInfoService;
 public class UserController {
 
     private final QueryMyInfoService queryMyInfoService;
+    private final WithdrawUserService withdrawUserService;
 
     @GetMapping("/my")
     @Operation(summary = "내 정보 조회", description = "현재 로그인된 사용자의 정보와 예약 가능 여부를 조회합니다.")
     public MyInfoResDto getMyInfo() {
         return queryMyInfoService.execute();
+    }
+
+    @DeleteMapping("/me")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "회원탈퇴", description = "현재 로그인된 사용자의 계정을 삭제합니다. 활성 예약은 자동으로 취소되며, 탈퇴 후 30일간 재가입이 제한됩니다.")
+    public CommonApiResponse withdrawUser() {
+        withdrawUserService.execute();
+        return CommonApiResponse.success("회원탈퇴가 완료되었습니다.");
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/user/controller/UserController.java
+++ b/src/main/java/team/washer/server/v2/domain/user/controller/UserController.java
@@ -1,10 +1,8 @@
 package team.washer.server.v2.domain.user.controller;
 
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -31,7 +29,6 @@ public class UserController {
     }
 
     @DeleteMapping("/me")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
     @Operation(summary = "회원탈퇴", description = "현재 로그인된 사용자의 계정을 삭제합니다. 활성 예약은 자동으로 취소되며, 탈퇴 후 30일간 재가입이 제한됩니다.")
     public CommonApiResponse withdrawUser() {
         withdrawUserService.execute();

--- a/src/main/java/team/washer/server/v2/domain/user/service/WithdrawUserService.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/WithdrawUserService.java
@@ -1,0 +1,5 @@
+package team.washer.server.v2.domain.user.service;
+
+public interface WithdrawUserService {
+    void execute();
+}

--- a/src/main/java/team/washer/server/v2/domain/user/service/impl/WithdrawUserServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/impl/WithdrawUserServiceImpl.java
@@ -1,0 +1,53 @@
+package team.washer.server.v2.domain.user.service.impl;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.auth.repository.redis.RefreshTokenRedisRepository;
+import team.washer.server.v2.domain.auth.util.WithdrawnStudentRedisUtil;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.domain.user.service.WithdrawUserService;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+@Service
+@RequiredArgsConstructor
+public class WithdrawUserServiceImpl implements WithdrawUserService {
+
+    private final UserRepository userRepository;
+    private final ReservationRepository reservationRepository;
+    private final MachineRepository machineRepository;
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
+    private final WithdrawnStudentRedisUtil withdrawnStudentRedisUtil;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    @Transactional
+    public void execute() {
+        final var userId = currentUserProvider.getCurrentUserId();
+        final var user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        final var activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
+        final var activeReservations = reservationRepository.findByUserAndStatusIn(user, activeStatuses);
+        for (final var reservation : activeReservations) {
+            final var machine = reservation.getMachine();
+            reservation.cancel();
+            machine.markAsAvailable();
+            machineRepository.save(machine);
+        }
+
+        refreshTokenRedisRepository.deleteById(userId);
+
+        withdrawnStudentRedisUtil.markWithdrawn(user.getStudentId());
+
+        userRepository.delete(user);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/user/service/impl/WithdrawUserServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/impl/WithdrawUserServiceImpl.java
@@ -1,5 +1,6 @@
 package team.washer.server.v2.domain.user.service.impl;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.auth.repository.redis.RefreshTokenRedisRepository;
 import team.washer.server.v2.domain.auth.util.WithdrawnStudentRedisUtil;
+import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
@@ -37,12 +39,14 @@ public class WithdrawUserServiceImpl implements WithdrawUserService {
 
         final var activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
         final var activeReservations = reservationRepository.findByUserAndStatusIn(user, activeStatuses);
+        final var machinesToUpdate = new ArrayList<Machine>();
         for (final var reservation : activeReservations) {
             final var machine = reservation.getMachine();
             reservation.cancel();
             machine.markAsAvailable();
-            machineRepository.save(machine);
+            machinesToUpdate.add(machine);
         }
+        machineRepository.saveAll(machinesToUpdate);
 
         refreshTokenRedisRepository.deleteById(userId);
 

--- a/src/test/java/team/washer/server/v2/domain/user/service/WithdrawUserServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/service/WithdrawUserServiceTest.java
@@ -131,7 +131,7 @@ class WithdrawUserServiceTest {
                 // Then
                 assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
                 assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
-                then(machineRepository).should(times(1)).save(machine);
+                then(machineRepository).should(times(1)).saveAll(anyList());
                 then(refreshTokenRedisRepository).should(times(1)).deleteById(userId);
                 then(withdrawnStudentRedisUtil).should(times(1)).markWithdrawn(user.getStudentId());
                 then(userRepository).should(times(1)).delete(user);
@@ -163,7 +163,7 @@ class WithdrawUserServiceTest {
                 // Then
                 assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
                 assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
-                then(machineRepository).should(times(1)).save(machine);
+                then(machineRepository).should(times(1)).saveAll(anyList());
                 then(refreshTokenRedisRepository).should(times(1)).deleteById(userId);
                 then(withdrawnStudentRedisUtil).should(times(1)).markWithdrawn(user.getStudentId());
                 then(userRepository).should(times(1)).delete(user);
@@ -201,7 +201,9 @@ class WithdrawUserServiceTest {
                 assertThat(machine1.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
                 assertThat(running.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
                 assertThat(machine2.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
-                then(machineRepository).should(times(2)).save(any(Machine.class));
+                then(machineRepository).should(times(1)).saveAll(anyList());
+                then(refreshTokenRedisRepository).should(times(1)).deleteById(userId);
+                then(withdrawnStudentRedisUtil).should(times(1)).markWithdrawn(user.getStudentId());
                 then(userRepository).should(times(1)).delete(user);
             }
         }

--- a/src/test/java/team/washer/server/v2/domain/user/service/WithdrawUserServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/service/WithdrawUserServiceTest.java
@@ -1,0 +1,233 @@
+package team.washer.server.v2.domain.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.auth.repository.redis.RefreshTokenRedisRepository;
+import team.washer.server.v2.domain.auth.util.WithdrawnStudentRedisUtil;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.enums.Position;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.domain.user.service.impl.WithdrawUserServiceImpl;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WithdrawUserServiceImpl 클래스의")
+class WithdrawUserServiceTest {
+
+    @InjectMocks
+    private WithdrawUserServiceImpl withdrawUserService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private MachineRepository machineRepository;
+
+    @Mock
+    private RefreshTokenRedisRepository refreshTokenRedisRepository;
+
+    @Mock
+    private WithdrawnStudentRedisUtil withdrawnStudentRedisUtil;
+
+    @Mock
+    private CurrentUserProvider currentUserProvider;
+
+    private User createUser() {
+        return User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3).penaltyCount(0)
+                .build();
+    }
+
+    private Machine createMachine() {
+        return Machine.builder().name("W-2F-L1").type(MachineType.WASHER).deviceId("device-1").floor(2)
+                .position(Position.LEFT).number(1).status(MachineStatus.NORMAL)
+                .availability(MachineAvailability.RESERVED).build();
+    }
+
+    private Reservation createReservation(final ReservationStatus status, final User user, final Machine machine) {
+        return Reservation.builder().user(user).machine(machine).reservedAt(LocalDateTime.now())
+                .startTime(LocalDateTime.now().plusMinutes(10)).status(status).build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("활성 예약이 없는 사용자가 탈퇴할 때")
+        class Context_without_active_reservations {
+
+            @Test
+            @DisplayName("리프레시 토큰을 삭제하고 탈퇴 학번을 기록한 후 사용자를 삭제해야 한다")
+            void it_deletes_user_with_token_and_withdrawal_recorded() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+                List<ReservationStatus> activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
+
+                given(currentUserProvider.getCurrentUserId()).willReturn(userId);
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(reservationRepository.findByUserAndStatusIn(user, activeStatuses)).willReturn(List.of());
+
+                // When
+                withdrawUserService.execute();
+
+                // Then
+                then(reservationRepository).should(times(1)).findByUserAndStatusIn(user, activeStatuses);
+                then(machineRepository).should(never()).save(any(Machine.class));
+                then(refreshTokenRedisRepository).should(times(1)).deleteById(userId);
+                then(withdrawnStudentRedisUtil).should(times(1)).markWithdrawn(user.getStudentId());
+                then(userRepository).should(times(1)).delete(user);
+            }
+        }
+
+        @Nested
+        @DisplayName("RESERVED 상태의 예약이 있는 사용자가 탈퇴할 때")
+        class Context_with_reserved_reservation {
+
+            @Test
+            @DisplayName("예약을 패널티 없이 취소하고 기기를 AVAILABLE 상태로 변경한 후 사용자를 삭제해야 한다")
+            void it_cancels_reservation_and_deletes_user() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+                Machine machine = createMachine();
+                Reservation reservation = createReservation(ReservationStatus.RESERVED, user, machine);
+                List<ReservationStatus> activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
+
+                given(currentUserProvider.getCurrentUserId()).willReturn(userId);
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(reservationRepository.findByUserAndStatusIn(user, activeStatuses))
+                        .willReturn(List.of(reservation));
+
+                // When
+                withdrawUserService.execute();
+
+                // Then
+                assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+                assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
+                then(machineRepository).should(times(1)).save(machine);
+                then(refreshTokenRedisRepository).should(times(1)).deleteById(userId);
+                then(withdrawnStudentRedisUtil).should(times(1)).markWithdrawn(user.getStudentId());
+                then(userRepository).should(times(1)).delete(user);
+            }
+        }
+
+        @Nested
+        @DisplayName("RUNNING 상태의 예약이 있는 사용자가 탈퇴할 때")
+        class Context_with_running_reservation {
+
+            @Test
+            @DisplayName("예약을 패널티 없이 취소하고 기기를 AVAILABLE 상태로 변경한 후 사용자를 삭제해야 한다")
+            void it_cancels_reservation_and_deletes_user() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+                Machine machine = createMachine();
+                Reservation reservation = createReservation(ReservationStatus.RUNNING, user, machine);
+                List<ReservationStatus> activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
+
+                given(currentUserProvider.getCurrentUserId()).willReturn(userId);
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(reservationRepository.findByUserAndStatusIn(user, activeStatuses))
+                        .willReturn(List.of(reservation));
+
+                // When
+                withdrawUserService.execute();
+
+                // Then
+                assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+                assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
+                then(machineRepository).should(times(1)).save(machine);
+                then(refreshTokenRedisRepository).should(times(1)).deleteById(userId);
+                then(withdrawnStudentRedisUtil).should(times(1)).markWithdrawn(user.getStudentId());
+                then(userRepository).should(times(1)).delete(user);
+            }
+        }
+
+        @Nested
+        @DisplayName("RESERVED와 RUNNING 예약이 동시에 있는 사용자가 탈퇴할 때")
+        class Context_with_multiple_active_reservations {
+
+            @Test
+            @DisplayName("모든 활성 예약을 취소하고 사용자를 삭제해야 한다")
+            void it_cancels_all_reservations_and_deletes_user() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+                Machine machine1 = createMachine();
+                Machine machine2 = Machine.builder().name("W-2F-R1").type(MachineType.WASHER).deviceId("device-2")
+                        .floor(2).position(Position.RIGHT).number(2).status(MachineStatus.NORMAL)
+                        .availability(MachineAvailability.IN_USE).build();
+                Reservation reserved = createReservation(ReservationStatus.RESERVED, user, machine1);
+                Reservation running = createReservation(ReservationStatus.RUNNING, user, machine2);
+                List<ReservationStatus> activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
+
+                given(currentUserProvider.getCurrentUserId()).willReturn(userId);
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(reservationRepository.findByUserAndStatusIn(user, activeStatuses))
+                        .willReturn(List.of(reserved, running));
+
+                // When
+                withdrawUserService.execute();
+
+                // Then
+                assertThat(reserved.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+                assertThat(machine1.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
+                assertThat(running.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+                assertThat(machine2.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
+                then(machineRepository).should(times(2)).save(any(Machine.class));
+                then(userRepository).should(times(1)).delete(user);
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 사용자 ID로 요청할 때")
+        class Context_with_nonexistent_user_id {
+
+            @Test
+            @DisplayName("ExpectedException을 던져야 한다")
+            void it_throws_expected_exception() {
+                // Given
+                Long userId = 999L;
+
+                given(currentUserProvider.getCurrentUserId()).willReturn(userId);
+                given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+                // When & Then
+                assertThatThrownBy(() -> withdrawUserService.execute()).isInstanceOf(ExpectedException.class)
+                        .hasMessage("사용자를 찾을 수 없습니다").hasFieldOrPropertyWithValue("statusCode", HttpStatus.NOT_FOUND);
+
+                then(reservationRepository).should(never()).findByUserAndStatusIn(any(User.class), anyList());
+                then(refreshTokenRedisRepository).should(never()).deleteById(anyLong());
+                then(withdrawnStudentRedisUtil).should(never()).markWithdrawn(anyString());
+                then(userRepository).should(never()).delete(any(User.class));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

사용자 계정 삭제를 위한 회원탈퇴 기능을 구현하고, 탈퇴 후 30일간의 재가입 제한 정책을 적용하였습니다.

## 본문

### 작업 이유
사용자가 직접 계정을 탈퇴할 수 있는 기능을 제공하고, 탈퇴 직후 재가입을 반복하는 비정상적인 이용 패턴을 방지하기 위해 30일간의 재가입 제한 로직이 필요하였습니다.

### 구현 방식
- Redis를 사용하여 탈퇴한 학생의 학번을 30일 동안 보관하는 WithdrawnStudentEntity 및 관련 리포지토리를 구현하였습니다.
- WithdrawnStudentRedisUtil을 통해 로그인 시 해당 학번의 탈퇴 이력을 확인하고, 30일이 지나지 않은 경우 예외를 발생시키도록 SignInServiceImpl을 수정하였습니다.
- WithdrawUserServiceImpl에서 사용자 계정 삭제와 동시에 Redis에 탈퇴 정보를 기록하는 로직을 구현하였습니다.
- UserController에 회원탈퇴를 수행하는 DELETE /api/v2/users/me 엔드포인트를 추가하였습니다.

### 현재 상태
회원탈퇴 요청 시 사용자의 계정 정보가 삭제되며, 해당 사용자는 30일 동안 재가입이 불가능한 상태가 됩니다. 관련 서비스 로직에 대한 단위 테스트가 작성되어 정상 작동을 확인하였습니다.
