### PR TITLE
[notification] 알림 리스트 기능 추가

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/notification/controller/NotificationController.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/controller/NotificationController.java
@@ -1,0 +1,47 @@
+package team.washer.server.v2.domain.notification.controller;
+
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import team.themoment.sdk.response.CommonApiResponse;
+import team.washer.server.v2.domain.notification.dto.response.NotificationListResDto;
+import team.washer.server.v2.domain.notification.service.DeleteAllNotificationsService;
+import team.washer.server.v2.domain.notification.service.QueryNotificationListService;
+
+@RestController
+@RequestMapping("/api/v2/notifications")
+@RequiredArgsConstructor
+@Tag(name = "Notification", description = "알림 API")
+@SecurityRequirement(name = "bearerAuth")
+public class NotificationController {
+
+    private final QueryNotificationListService queryNotificationListService;
+    private final DeleteAllNotificationsService deleteAllNotificationsService;
+
+    @GetMapping
+    @Operation(summary = "알림 목록 조회", description = "현재 로그인된 사용자의 알림 목록을 최신순으로 조회합니다. 최대 30개까지 반환됩니다.")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "알림 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(implementation = CommonApiResponse.class), examples = @ExampleObject(value = "{'status':401,'message':'인증이 필요합니다'}"))),
+            @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content(schema = @Schema(implementation = CommonApiResponse.class), examples = @ExampleObject(value = "{'status':404,'message':'사용자를 찾을 수 없습니다'}")))})
+    public NotificationListResDto getNotifications() {
+        return queryNotificationListService.execute();
+    }
+
+    @DeleteMapping
+    @Operation(summary = "전체 알림 삭제", description = "현재 로그인된 사용자의 모든 알림을 삭제합니다.")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "전체 알림 삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(implementation = CommonApiResponse.class), examples = @ExampleObject(value = "{'status':401,'message':'인증이 필요합니다'}"))),
+            @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content(schema = @Schema(implementation = CommonApiResponse.class), examples = @ExampleObject(value = "{'status':404,'message':'사용자를 찾을 수 없습니다'}")))})
+    public CommonApiResponse deleteAllNotifications() {
+        deleteAllNotificationsService.execute();
+        return CommonApiResponse.success("알림이 모두 삭제되었습니다.");
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/notification/controller/NotificationController.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/controller/NotificationController.java
@@ -29,8 +29,8 @@ public class NotificationController {
     @GetMapping
     @Operation(summary = "알림 목록 조회", description = "현재 로그인된 사용자의 알림 목록을 최신순으로 조회합니다. 최대 30개까지 반환됩니다.")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "알림 목록 조회 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(implementation = CommonApiResponse.class), examples = @ExampleObject(value = "{'status':401,'message':'인증이 필요합니다'}"))),
-            @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content(schema = @Schema(implementation = CommonApiResponse.class), examples = @ExampleObject(value = "{'status':404,'message':'사용자를 찾을 수 없습니다'}")))})
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(implementation = CommonApiResponse.class), examples = @ExampleObject(value = "{\"status\":401,\"message\":\"인증이 필요합니다\"}"))),
+            @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content(schema = @Schema(implementation = CommonApiResponse.class), examples = @ExampleObject(value = "{\"status\":404,\"message\":\"사용자를 찾을 수 없습니다\"}")))})
     public NotificationListResDto getNotifications() {
         return queryNotificationListService.execute();
     }
@@ -38,8 +38,8 @@ public class NotificationController {
     @DeleteMapping
     @Operation(summary = "전체 알림 삭제", description = "현재 로그인된 사용자의 모든 알림을 삭제합니다.")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "전체 알림 삭제 성공"),
-            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(implementation = CommonApiResponse.class), examples = @ExampleObject(value = "{'status':401,'message':'인증이 필요합니다'}"))),
-            @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content(schema = @Schema(implementation = CommonApiResponse.class), examples = @ExampleObject(value = "{'status':404,'message':'사용자를 찾을 수 없습니다'}")))})
+            @ApiResponse(responseCode = "401", description = "인증 필요", content = @Content(schema = @Schema(implementation = CommonApiResponse.class), examples = @ExampleObject(value = "{\"status\":401,\"message\":\"인증이 필요합니다\"}"))),
+            @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content(schema = @Schema(implementation = CommonApiResponse.class), examples = @ExampleObject(value = "{\"status\":404,\"message\":\"사용자를 찾을 수 없습니다\"}")))})
     public CommonApiResponse deleteAllNotifications() {
         deleteAllNotificationsService.execute();
         return CommonApiResponse.success("알림이 모두 삭제되었습니다.");

--- a/src/main/java/team/washer/server/v2/domain/notification/dto/response/NotificationListResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/dto/response/NotificationListResDto.java
@@ -1,0 +1,9 @@
+package team.washer.server.v2.domain.notification.dto.response;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "알림 목록 응답 DTO")
+public record NotificationListResDto(@Schema(description = "알림 목록") List<NotificationResDto> notifications) {
+}

--- a/src/main/java/team/washer/server/v2/domain/notification/dto/response/NotificationResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/dto/response/NotificationResDto.java
@@ -1,0 +1,13 @@
+package team.washer.server.v2.domain.notification.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import team.washer.server.v2.domain.notification.enums.NotificationType;
+
+@Schema(description = "알림 응답 DTO")
+public record NotificationResDto(@Schema(description = "알림 ID", example = "1") Long id,
+        @Schema(description = "알림 유형", example = "COMPLETION") NotificationType type,
+        @Schema(description = "알림 메시지", example = "WASHER-3F-L1의 세탁이 완료되었습니다.") String message,
+        @Schema(description = "알림 생성 시간", example = "2026-03-30T14:30:00") LocalDateTime createdAt) {
+}

--- a/src/main/java/team/washer/server/v2/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/repository/NotificationRepository.java
@@ -10,10 +10,11 @@ import org.springframework.stereotype.Repository;
 
 import team.washer.server.v2.domain.notification.entity.Notification;
 import team.washer.server.v2.domain.notification.enums.NotificationType;
+import team.washer.server.v2.domain.notification.repository.custom.NotificationRepositoryCustom;
 import team.washer.server.v2.domain.user.entity.User;
 
 @Repository
-public interface NotificationRepository extends JpaRepository<Notification, Long> {
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
 
     List<Notification> findByUser(User user);
 
@@ -43,10 +44,4 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Modifying
     @Query("DELETE FROM Notification n WHERE n.user = :user")
     int deleteAllByUser(@Param("user") User user);
-
-    @Modifying
-    @Query(value = "DELETE FROM notifications WHERE user_id = :userId AND id NOT IN "
-            + "(SELECT id FROM (SELECT id FROM notifications WHERE user_id = :userId "
-            + "ORDER BY created_at DESC LIMIT :limit) AS keep_ids)", nativeQuery = true)
-    int deleteOldestByUserExceedingLimit(@Param("userId") Long userId, @Param("limit") int limit);
 }

--- a/src/main/java/team/washer/server/v2/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/repository/NotificationRepository.java
@@ -37,4 +37,16 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     @Modifying
     @Query("DELETE FROM Notification n WHERE n.user = :user AND n.isRead = true")
     int deleteReadNotificationsByUser(@Param("user") User user);
+
+    long countByUser(User user);
+
+    @Modifying
+    @Query("DELETE FROM Notification n WHERE n.user = :user")
+    int deleteAllByUser(@Param("user") User user);
+
+    @Modifying
+    @Query(value = "DELETE FROM notifications WHERE user_id = :userId AND id NOT IN "
+            + "(SELECT id FROM (SELECT id FROM notifications WHERE user_id = :userId "
+            + "ORDER BY created_at DESC LIMIT :limit) AS keep_ids)", nativeQuery = true)
+    int deleteOldestByUserExceedingLimit(@Param("userId") Long userId, @Param("limit") int limit);
 }

--- a/src/main/java/team/washer/server/v2/domain/notification/repository/custom/NotificationRepositoryCustom.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/repository/custom/NotificationRepositoryCustom.java
@@ -1,0 +1,17 @@
+package team.washer.server.v2.domain.notification.repository.custom;
+
+import team.washer.server.v2.domain.user.entity.User;
+
+public interface NotificationRepositoryCustom {
+
+    /**
+     * 사용자의 알림 중 최신 limit개를 제외한 오래된 알림을 삭제한다.
+     *
+     * @param user
+     *            대상 사용자
+     * @param limit
+     *            유지할 최대 알림 개수
+     * @return 삭제된 알림 수
+     */
+    int deleteOldestByUserExceedingLimit(User user, int limit);
+}

--- a/src/main/java/team/washer/server/v2/domain/notification/repository/custom/impl/NotificationRepositoryCustomImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/repository/custom/impl/NotificationRepositoryCustomImpl.java
@@ -1,0 +1,33 @@
+package team.washer.server.v2.domain.notification.repository.custom.impl;
+
+import static team.washer.server.v2.domain.notification.entity.QNotification.*;
+
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.notification.repository.custom.NotificationRepositoryCustom;
+import team.washer.server.v2.domain.user.entity.User;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryCustomImpl implements NotificationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public int deleteOldestByUserExceedingLimit(final User user, final int limit) {
+        final List<Long> keepIds = queryFactory.select(notification.id).from(notification)
+                .where(notification.user.eq(user)).orderBy(notification.createdAt.desc()).limit(limit).fetch();
+
+        if (keepIds.isEmpty()) {
+            return 0;
+        }
+
+        return (int) queryFactory.delete(notification)
+                .where(notification.user.eq(user).and(notification.id.notIn(keepIds))).execute();
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/notification/service/DeleteAllNotificationsService.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/service/DeleteAllNotificationsService.java
@@ -1,0 +1,6 @@
+package team.washer.server.v2.domain.notification.service;
+
+public interface DeleteAllNotificationsService {
+
+    void execute();
+}

--- a/src/main/java/team/washer/server/v2/domain/notification/service/QueryNotificationListService.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/service/QueryNotificationListService.java
@@ -1,0 +1,8 @@
+package team.washer.server.v2.domain.notification.service;
+
+import team.washer.server.v2.domain.notification.dto.response.NotificationListResDto;
+
+public interface QueryNotificationListService {
+
+    NotificationListResDto execute();
+}

--- a/src/main/java/team/washer/server/v2/domain/notification/service/impl/DeleteAllNotificationsServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/service/impl/DeleteAllNotificationsServiceImpl.java
@@ -1,0 +1,35 @@
+package team.washer.server.v2.domain.notification.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.notification.repository.NotificationRepository;
+import team.washer.server.v2.domain.notification.service.DeleteAllNotificationsService;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeleteAllNotificationsServiceImpl implements DeleteAllNotificationsService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    @Transactional
+    public void execute() {
+        final var userId = currentUserProvider.getCurrentUserId();
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        final int deletedCount = notificationRepository.deleteAllByUser(user);
+        log.info("All notifications deleted userId={} deletedCount={}", userId, deletedCount);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/notification/service/impl/QueryNotificationListServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/service/impl/QueryNotificationListServiceImpl.java
@@ -1,0 +1,48 @@
+package team.washer.server.v2.domain.notification.service.impl;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.notification.dto.response.NotificationListResDto;
+import team.washer.server.v2.domain.notification.dto.response.NotificationResDto;
+import team.washer.server.v2.domain.notification.entity.Notification;
+import team.washer.server.v2.domain.notification.repository.NotificationRepository;
+import team.washer.server.v2.domain.notification.service.QueryNotificationListService;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+@Service
+@RequiredArgsConstructor
+public class QueryNotificationListServiceImpl implements QueryNotificationListService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    @Transactional(readOnly = true)
+    public NotificationListResDto execute() {
+        final var userId = currentUserProvider.getCurrentUserId();
+        final User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        final List<Notification> notifications = notificationRepository.findByUserOrderByCreatedAtDesc(user);
+
+        final List<NotificationResDto> notificationResDtos = notifications.stream().map(this::toResDto).toList();
+
+        return new NotificationListResDto(notificationResDtos);
+    }
+
+    private NotificationResDto toResDto(final Notification notification) {
+        return new NotificationResDto(notification.getId(),
+                notification.getType(),
+                notification.getMessage(),
+                notification.getCreatedAt());
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupport.java
@@ -89,7 +89,7 @@ public class ReservationNotificationSupport {
     private void enforceNotificationLimit(final User user) {
         final long count = notificationRepository.countByUser(user);
         if (count > MAX_NOTIFICATIONS_PER_USER) {
-            final int deleted = notificationRepository.deleteOldestByUserExceedingLimit(user.getId(),
+            final int deleted = notificationRepository.deleteOldestByUserExceedingLimit(user,
                     MAX_NOTIFICATIONS_PER_USER);
             log.info("Excess notifications removed userId={} deletedCount={}", user.getId(), deleted);
         }

--- a/src/main/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupport.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.notification.entity.Notification;
-import team.washer.server.v2.domain.notification.enums.NotificationType;
 import team.washer.server.v2.domain.notification.repository.NotificationRepository;
 import team.washer.server.v2.domain.user.entity.User;
 
@@ -21,6 +20,8 @@ import team.washer.server.v2.domain.user.entity.User;
 @RequiredArgsConstructor
 public class ReservationNotificationSupport {
 
+    private static final int MAX_NOTIFICATIONS_PER_USER = 30;
+
     private final NotificationRepository notificationRepository;
     private final FcmNotificationSupport fcmNotificationSupport;
 
@@ -30,12 +31,7 @@ public class ReservationNotificationSupport {
     @Transactional
     public void sendCompletion(User user, Machine machine) {
         var notification = Notification.createCompletionNotification(user, machine);
-        notificationRepository.save(notification);
-        log.info("Completion notification sent to user {} for machine {}", user.getId(), machine.getName());
-
-        final var fcmTitle = machine.getType().getDescription() + " 완료 알림";
-        final var fcmBody = NotificationType.COMPLETION.formatMessage(machine.getName(), machine.getType());
-        fcmNotificationSupport.send(user, fcmTitle, fcmBody);
+        persistAndSend(user, notification, machine.getType().getDescription() + " 완료 알림");
     }
 
     /**
@@ -44,12 +40,7 @@ public class ReservationNotificationSupport {
     @Transactional
     public void sendInterruption(User user, Machine machine) {
         var notification = Notification.createInterruptionNotification(user, machine);
-        notificationRepository.save(notification);
-        log.info("Interruption notification sent to user {} for machine {}", user.getId(), machine.getName());
-
-        final var fcmTitle = machine.getType().getDescription() + " 중단 알림";
-        final var fcmBody = NotificationType.INTERRUPTION.formatMessage(machine.getName(), machine.getType());
-        fcmNotificationSupport.send(user, fcmTitle, fcmBody);
+        persistAndSend(user, notification, machine.getType().getDescription() + " 중단 알림");
     }
 
     /**
@@ -58,12 +49,7 @@ public class ReservationNotificationSupport {
     @Transactional
     public void sendPauseTimeout(User user, Machine machine) {
         var notification = Notification.createPauseTimeoutNotification(user, machine);
-        notificationRepository.save(notification);
-        log.info("Pause timeout notification sent to user {} for machine {}", user.getId(), machine.getName());
-
-        final var fcmTitle = machine.getType().getDescription() + " 일시정지 초과 알림";
-        final var fcmBody = NotificationType.PAUSE_TIMEOUT.formatMessage(machine.getName(), machine.getType());
-        fcmNotificationSupport.send(user, fcmTitle, fcmBody);
+        persistAndSend(user, notification, machine.getType().getDescription() + " 일시정지 초과 알림");
     }
 
     /**
@@ -72,12 +58,7 @@ public class ReservationNotificationSupport {
     @Transactional
     public void sendAutoCancellation(User user, Machine machine) {
         var notification = Notification.createAutoCancellationNotification(user, machine);
-        notificationRepository.save(notification);
-        log.info("Auto cancellation notification sent to user {} for machine {}", user.getId(), machine.getName());
-
-        final var fcmTitle = "예약 자동 취소 알림";
-        final var fcmBody = NotificationType.AUTO_CANCELLED.formatMessage(machine.getName());
-        fcmNotificationSupport.send(user, fcmTitle, fcmBody);
+        persistAndSend(user, notification, "예약 자동 취소 알림");
     }
 
     /**
@@ -86,11 +67,7 @@ public class ReservationNotificationSupport {
     @Transactional
     public void sendStarted(User user, Machine machine, LocalDateTime expectedCompletionTime) {
         var notification = Notification.createStartedNotification(user, machine, expectedCompletionTime);
-        notificationRepository.save(notification);
-        log.info("Start notification sent to user {} for machine {}", user.getId(), machine.getName());
-
-        final var fcmTitle = machine.getType().getDescription() + " 시작 알림";
-        fcmNotificationSupport.send(user, fcmTitle, notification.getMessage());
+        persistAndSend(user, notification, machine.getType().getDescription() + " 시작 알림");
     }
 
     /**
@@ -99,10 +76,22 @@ public class ReservationNotificationSupport {
     @Transactional
     public void sendTimeoutWarning(User user, Machine machine) {
         var notification = Notification.createTimeoutWarningNotification(user, machine);
-        notificationRepository.save(notification);
-        log.info("Timeout warning notification sent to user {} for machine {}", user.getId(), machine.getName());
+        persistAndSend(user, notification, "예약 취소 경고");
+    }
 
-        final var fcmTitle = "예약 취소 경고";
+    private void persistAndSend(final User user, final Notification notification, final String fcmTitle) {
+        notificationRepository.save(notification);
+        enforceNotificationLimit(user);
+        log.info("Notification sent userId={} type={}", user.getId(), notification.getType());
         fcmNotificationSupport.send(user, fcmTitle, notification.getMessage());
+    }
+
+    private void enforceNotificationLimit(final User user) {
+        final long count = notificationRepository.countByUser(user);
+        if (count > MAX_NOTIFICATIONS_PER_USER) {
+            final int deleted = notificationRepository.deleteOldestByUserExceedingLimit(user.getId(),
+                    MAX_NOTIFICATIONS_PER_USER);
+            log.info("Excess notifications removed userId={} deletedCount={}", user.getId(), deleted);
+        }
     }
 }

--- a/src/test/java/team/washer/server/v2/domain/notification/service/DeleteAllNotificationsServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/service/DeleteAllNotificationsServiceTest.java
@@ -1,0 +1,111 @@
+package team.washer.server.v2.domain.notification.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.notification.repository.NotificationRepository;
+import team.washer.server.v2.domain.notification.service.impl.DeleteAllNotificationsServiceImpl;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeleteAllNotificationsServiceImpl 클래스의")
+class DeleteAllNotificationsServiceTest {
+
+    @InjectMocks
+    private DeleteAllNotificationsServiceImpl deleteAllNotificationsService;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CurrentUserProvider currentUserProvider;
+
+    private static final Long USER_ID = 1L;
+
+    private User createUser() {
+        return User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3).build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("사용자가 존재할 때")
+        class Context_with_existing_user {
+
+            @Test
+            @DisplayName("해당 사용자의 모든 알림을 삭제해야 한다")
+            void it_deletes_all_notifications() {
+                // Given
+                when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+                User user = createUser();
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(notificationRepository.deleteAllByUser(user)).willReturn(5);
+
+                // When
+                deleteAllNotificationsService.execute();
+
+                // Then
+                then(notificationRepository).should(times(1)).deleteAllByUser(user);
+            }
+        }
+
+        @Nested
+        @DisplayName("사용자에게 알림이 없을 때")
+        class Context_with_no_notifications {
+
+            @Test
+            @DisplayName("삭제 건수가 0이어도 정상 처리되어야 한다")
+            void it_succeeds_with_zero_deletions() {
+                // Given
+                when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+                User user = createUser();
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(notificationRepository.deleteAllByUser(user)).willReturn(0);
+
+                // When
+                deleteAllNotificationsService.execute();
+
+                // Then
+                then(notificationRepository).should(times(1)).deleteAllByUser(user);
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 사용자 ID로 요청할 때")
+        class Context_with_nonexistent_user_id {
+
+            @Test
+            @DisplayName("ExpectedException을 던져야 한다")
+            void it_throws_expected_exception() {
+                // Given
+                when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+                given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+                // When & Then
+                assertThatThrownBy(() -> deleteAllNotificationsService.execute()).isInstanceOf(ExpectedException.class)
+                        .hasMessage("사용자를 찾을 수 없습니다").hasFieldOrPropertyWithValue("statusCode", HttpStatus.NOT_FOUND);
+
+                then(notificationRepository).shouldHaveNoInteractions();
+            }
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/notification/service/QueryNotificationListServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/service/QueryNotificationListServiceTest.java
@@ -1,0 +1,127 @@
+package team.washer.server.v2.domain.notification.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.notification.dto.response.NotificationListResDto;
+import team.washer.server.v2.domain.notification.entity.Notification;
+import team.washer.server.v2.domain.notification.enums.NotificationType;
+import team.washer.server.v2.domain.notification.repository.NotificationRepository;
+import team.washer.server.v2.domain.notification.service.impl.QueryNotificationListServiceImpl;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("QueryNotificationListServiceImpl 클래스의")
+class QueryNotificationListServiceTest {
+
+    @InjectMocks
+    private QueryNotificationListServiceImpl queryNotificationListService;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CurrentUserProvider currentUserProvider;
+
+    private static final Long USER_ID = 1L;
+
+    private User createUser() {
+        return User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3).build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("사용자에게 알림이 존재할 때")
+        class Context_with_notifications {
+
+            @Test
+            @DisplayName("알림 목록을 최신순으로 반환해야 한다")
+            void it_returns_notification_list() {
+                // Given
+                when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+                User user = createUser();
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+                Notification notification1 = Notification.builder().user(user).type(NotificationType.COMPLETION)
+                        .message("WASHER-3F-L1의 세탁이 완료되었습니다.").build();
+                Notification notification2 = Notification.builder().user(user).type(NotificationType.STARTED)
+                        .message("WASHER-3F-L1의 세탁이 시작되었습니다.").build();
+
+                given(notificationRepository.findByUserOrderByCreatedAtDesc(user))
+                        .willReturn(List.of(notification1, notification2));
+
+                // When
+                NotificationListResDto result = queryNotificationListService.execute();
+
+                // Then
+                assertThat(result.notifications()).hasSize(2);
+                assertThat(result.notifications().get(0).type()).isEqualTo(NotificationType.COMPLETION);
+                assertThat(result.notifications().get(0).message()).isEqualTo("WASHER-3F-L1의 세탁이 완료되었습니다.");
+                assertThat(result.notifications().get(1).type()).isEqualTo(NotificationType.STARTED);
+                then(notificationRepository).should(times(1)).findByUserOrderByCreatedAtDesc(user);
+            }
+        }
+
+        @Nested
+        @DisplayName("사용자에게 알림이 없을 때")
+        class Context_with_no_notifications {
+
+            @Test
+            @DisplayName("빈 목록을 반환해야 한다")
+            void it_returns_empty_list() {
+                // Given
+                when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+                User user = createUser();
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+                given(notificationRepository.findByUserOrderByCreatedAtDesc(user)).willReturn(Collections.emptyList());
+
+                // When
+                NotificationListResDto result = queryNotificationListService.execute();
+
+                // Then
+                assertThat(result.notifications()).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 사용자 ID로 요청할 때")
+        class Context_with_nonexistent_user_id {
+
+            @Test
+            @DisplayName("ExpectedException을 던져야 한다")
+            void it_throws_expected_exception() {
+                // Given
+                when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+                given(userRepository.findById(USER_ID)).willReturn(Optional.empty());
+
+                // When & Then
+                assertThatThrownBy(() -> queryNotificationListService.execute()).isInstanceOf(ExpectedException.class)
+                        .hasMessage("사용자를 찾을 수 없습니다").hasFieldOrPropertyWithValue("statusCode", HttpStatus.NOT_FOUND);
+
+                then(notificationRepository).shouldHaveNoInteractions();
+            }
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupportTest.java
@@ -59,7 +59,8 @@ class ReservationNotificationSupportTest {
                 reservationNotificationSupport.sendCompletion(user, machine);
 
                 // Then
-                then(notificationRepository).should(never()).deleteOldestByUserExceedingLimit(anyLong(), anyInt());
+                then(notificationRepository).should(never()).deleteOldestByUserExceedingLimit(any(User.class),
+                        anyInt());
             }
         }
 
@@ -81,7 +82,8 @@ class ReservationNotificationSupportTest {
                 reservationNotificationSupport.sendCompletion(user, machine);
 
                 // Then
-                then(notificationRepository).should(never()).deleteOldestByUserExceedingLimit(anyLong(), anyInt());
+                then(notificationRepository).should(never()).deleteOldestByUserExceedingLimit(any(User.class),
+                        anyInt());
             }
         }
 
@@ -98,13 +100,13 @@ class ReservationNotificationSupportTest {
                 given(notificationRepository.save(any(Notification.class)))
                         .willAnswer(invocation -> invocation.getArgument(0));
                 given(notificationRepository.countByUser(user)).willReturn(31L);
-                given(notificationRepository.deleteOldestByUserExceedingLimit(user.getId(), 30)).willReturn(1);
+                given(notificationRepository.deleteOldestByUserExceedingLimit(user, 30)).willReturn(1);
 
                 // When
                 reservationNotificationSupport.sendCompletion(user, machine);
 
                 // Then
-                then(notificationRepository).should(times(1)).deleteOldestByUserExceedingLimit(user.getId(), 30);
+                then(notificationRepository).should(times(1)).deleteOldestByUserExceedingLimit(user, 30);
             }
         }
     }

--- a/src/test/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupportTest.java
@@ -1,0 +1,111 @@
+package team.washer.server.v2.domain.notification.support;
+
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.notification.entity.Notification;
+import team.washer.server.v2.domain.notification.repository.NotificationRepository;
+import team.washer.server.v2.domain.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReservationNotificationSupport 클래스의")
+class ReservationNotificationSupportTest {
+
+    @InjectMocks
+    private ReservationNotificationSupport reservationNotificationSupport;
+
+    @Mock
+    private NotificationRepository notificationRepository;
+
+    @Mock
+    private FcmNotificationSupport fcmNotificationSupport;
+
+    private User createUser() {
+        return User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3).build();
+    }
+
+    private Machine createMachine() {
+        return Machine.builder().name("WASHER-3F-L1").type(MachineType.WASHER).floor(3).build();
+    }
+
+    @Nested
+    @DisplayName("알림 저장 후 30개 제한 로직은")
+    class Describe_notification_limit {
+
+        @Nested
+        @DisplayName("알림 개수가 30개 이하일 때")
+        class Context_with_count_under_limit {
+
+            @Test
+            @DisplayName("초과 알림 삭제를 수행하지 않아야 한다")
+            void it_does_not_delete_excess() {
+                // Given
+                User user = createUser();
+                Machine machine = createMachine();
+                given(notificationRepository.save(any(Notification.class)))
+                        .willAnswer(invocation -> invocation.getArgument(0));
+                given(notificationRepository.countByUser(user)).willReturn(25L);
+
+                // When
+                reservationNotificationSupport.sendCompletion(user, machine);
+
+                // Then
+                then(notificationRepository).should(never()).deleteOldestByUserExceedingLimit(anyLong(), anyInt());
+            }
+        }
+
+        @Nested
+        @DisplayName("알림 개수가 정확히 30개일 때")
+        class Context_with_count_at_limit {
+
+            @Test
+            @DisplayName("초과 알림 삭제를 수행하지 않아야 한다")
+            void it_does_not_delete_excess() {
+                // Given
+                User user = createUser();
+                Machine machine = createMachine();
+                given(notificationRepository.save(any(Notification.class)))
+                        .willAnswer(invocation -> invocation.getArgument(0));
+                given(notificationRepository.countByUser(user)).willReturn(30L);
+
+                // When
+                reservationNotificationSupport.sendCompletion(user, machine);
+
+                // Then
+                then(notificationRepository).should(never()).deleteOldestByUserExceedingLimit(anyLong(), anyInt());
+            }
+        }
+
+        @Nested
+        @DisplayName("알림 개수가 30개를 초과할 때")
+        class Context_with_count_over_limit {
+
+            @Test
+            @DisplayName("초과 알림을 삭제해야 한다")
+            void it_deletes_excess_notifications() {
+                // Given
+                User user = createUser();
+                Machine machine = createMachine();
+                given(notificationRepository.save(any(Notification.class)))
+                        .willAnswer(invocation -> invocation.getArgument(0));
+                given(notificationRepository.countByUser(user)).willReturn(31L);
+                given(notificationRepository.deleteOldestByUserExceedingLimit(user.getId(), 30)).willReturn(1);
+
+                // When
+                reservationNotificationSupport.sendCompletion(user, machine);
+
+                // Then
+                then(notificationRepository).should(times(1)).deleteOldestByUserExceedingLimit(user.getId(), 30);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

FCM 푸시 발송 및 DB 저장 기능만 제공하던 알림 시스템에 알림 목록 조회 API와 전체 삭제 API를 추가했습니다. 유저당 최대 30개 알림만 보관되도록 생성 시 자동 정리 로직도 함께 적용했으며, `ReservationNotificationSupport`의 발송 메서드 공통 패턴을 private 헬퍼로 통합했습니다.

## 본문

### 작업 이유

FCM 푸시 수신 여부와 무관하게 사용자가 앱에서 알림 내역을 직접 확인할 수 있는 엔드포인트가 필요했습니다. 알림이 무제한으로 누적되는 문제를 방지하기 위해 유저당 30개 제한도 함께 도입했습니다.

### 추가된 API

#### `GET /api/v2/notifications` - 알림 목록 조회

- 인증: Bearer JWT 필요
- 응답: 현재 사용자의 알림을 최신순으로 반환 (최대 30개)

응답 형식:
```json
{
  "notifications": [
    {
      "id": 1,
      "type": "COMPLETION",
      "message": "WASHER-3F-L1의 세탁이 완료되었습니다.",
      "createdAt": "2026-03-30T14:30:00"
    }
  ]
}
```

`type` 가능 값: `COMPLETION`, `MALFUNCTION`, `WARNING`, `INTERRUPTION`, `AUTO_CANCELLED`, `PAUSE_TIMEOUT`, `STARTED`, `TIMEOUT_WARNING`

에러 응답: `401` 인증 필요, `404` 사용자 없음

---

#### `DELETE /api/v2/notifications` - 전체 알림 삭제

- 인증: Bearer JWT 필요
- 동작: 현재 사용자의 모든 알림을 DB에서 물리 삭제

응답 형식:
```json
{
  "message": "알림이 모두 삭제되었습니다."
}
```

에러 응답: `401` 인증 필요, `404` 사용자 없음

---

### 구현 방식

**알림 30개 제한 및 발송 공통 패턴 통합 (`ReservationNotificationSupport`)**

기존 6개의 발송 메서드가 각각 `save → enforceLimit → log → FCM 발송` 패턴을 중복 구현하고 있었습니다. 이를 `persistAndSend(User, Notification, String fcmTitle)` private 메서드로 추출하여 각 public 메서드는 알림 생성과 FCM 제목 구성만 담당하도록 변경했습니다.

```java
private void persistAndSend(final User user, final Notification notification, final String fcmTitle) {
    notificationRepository.save(notification);
    enforceNotificationLimit(user);
    log.info("Notification sent userId={} type={}", user.getId(), notification.getType());
    fcmNotificationSupport.send(user, fcmTitle, notification.getMessage());
}
```

30개 제한은 `enforceNotificationLimit`에서 처리합니다. 저장 후 `countByUser`로 개수를 확인하고, 초과 시 네이티브 쿼리로 오래된 알림을 삭제합니다. MySQL의 DELETE-FROM 서브쿼리 참조 제약으로 인해 이중 서브쿼리 구조를 사용했습니다.

```sql
DELETE FROM notifications
WHERE user_id = :userId AND id NOT IN (
  SELECT id FROM (
    SELECT id FROM notifications WHERE user_id = :userId
    ORDER BY created_at DESC LIMIT :limit
  ) AS keep_ids
)
```

**서비스 분리**

단일 책임 원칙에 따라 조회(`QueryNotificationListService`)와 삭제(`DeleteAllNotificationsService`) 서비스를 별도로 분리했습니다.

**isRead 필드 처리**

기존 `isRead` 필드 및 관련 리포지토리 메서드는 이번 기능과 무관하여 수정하지 않았습니다. 스키마 변경이 필요한 정리 작업은 별도 태스크로 분리합니다.

### 신규 파일

| 파일 | 설명 |
|------|------|
| `controller/NotificationController.java` | 알림 목록 조회 / 전체 삭제 컨트롤러 |
| `dto/response/NotificationResDto.java` | 알림 단건 응답 DTO |
| `dto/response/NotificationListResDto.java` | 알림 목록 응답 DTO |
| `service/QueryNotificationListService.java` | 목록 조회 서비스 인터페이스 |
| `service/impl/QueryNotificationListServiceImpl.java` | 목록 조회 서비스 구현 |
| `service/DeleteAllNotificationsService.java` | 전체 삭제 서비스 인터페이스 |
| `service/impl/DeleteAllNotificationsServiceImpl.java` | 전체 삭제 서비스 구현 |

### 수정 파일

| 파일 | 변경 내용 |
|------|----------|
| `repository/NotificationRepository.java` | `countByUser`, `deleteAllByUser`, `deleteOldestByUserExceedingLimit` 추가 |
| `support/ReservationNotificationSupport.java` | `persistAndSend` 헬퍼 추출, 30개 제한 로직 통합 |

### 현재 상태

- 전체 테스트 통과
- `GET /api/v2/notifications`, `DELETE /api/v2/notifications` 엔드포인트 동작
- 기존 FCM 토큰 엔드포인트(`POST/DELETE /api/v2/notifications/fcm-token`) 영향 없음
