### PR TITLE
v20260526.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ tasks.compileTestJava {
 }
 
 group = "team.washer"
-version = "v20260522.0"
+version = "v20260526.0"
 
 springBoot {
     buildInfo()

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
@@ -33,8 +33,6 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
     private static final Sort DEFAULT_SORT = Sort
             .by(Order.asc("floor"), Order.desc("type"), Order.asc("position"), Order.asc("number"));
 
-    private static final int FEMALE_FLOOR = 5;
-
     private final MachineRepository machineRepository;
     private final ReservationRepository reservationRepository;
     private final DeviceStatusQuerySupport deviceStatusQuerySupport;
@@ -46,9 +44,7 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
         final var user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
-        if (user.getFloor() == FEMALE_FLOOR) {
-            throw new ExpectedException("1~4층 기숙사생이 아니라면 서비스를 이용할 수 없습니다.", HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS);
-        }
+        user.validateFloorRestriction();
 
         log.info("Querying all machines status");
 

--- a/src/main/java/team/washer/server/v2/domain/malfunction/service/impl/CreateMalfunctionReportServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/malfunction/service/impl/CreateMalfunctionReportServiceImpl.java
@@ -25,8 +25,6 @@ import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 @RequiredArgsConstructor
 public class CreateMalfunctionReportServiceImpl implements CreateMalfunctionReportService {
 
-    private static final int FEMALE_FLOOR = 5;
-
     private final MalfunctionReportRepository malfunctionReportRepository;
     private final UserRepository userRepository;
     private final MachineRepository machineRepository;
@@ -39,9 +37,7 @@ public class CreateMalfunctionReportServiceImpl implements CreateMalfunctionRepo
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
-        if (user.getFloor() == FEMALE_FLOOR) {
-            throw new ExpectedException("1~4층 기숙사생이 아니라면 서비스를 이용할 수 없습니다.", HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS);
-        }
+        user.validateFloorRestriction();
 
         final Machine machine = machineRepository.findById(reqDto.machineId())
                 .orElseThrow(() -> new ExpectedException("기기를 찾을 수 없습니다", HttpStatus.NOT_FOUND));

--- a/src/main/java/team/washer/server/v2/domain/malfunction/service/impl/CreateMalfunctionReportServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/malfunction/service/impl/CreateMalfunctionReportServiceImpl.java
@@ -25,6 +25,8 @@ import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 @RequiredArgsConstructor
 public class CreateMalfunctionReportServiceImpl implements CreateMalfunctionReportService {
 
+    private static final int FEMALE_FLOOR = 5;
+
     private final MalfunctionReportRepository malfunctionReportRepository;
     private final UserRepository userRepository;
     private final MachineRepository machineRepository;
@@ -37,6 +39,10 @@ public class CreateMalfunctionReportServiceImpl implements CreateMalfunctionRepo
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
+        if (user.getFloor() == FEMALE_FLOOR) {
+            throw new ExpectedException("1~4층 기숙사생이 아니라면 서비스를 이용할 수 없습니다.", HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS);
+        }
+
         final Machine machine = machineRepository.findById(reqDto.machineId())
                 .orElseThrow(() -> new ExpectedException("기기를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
@@ -44,7 +50,10 @@ public class CreateMalfunctionReportServiceImpl implements CreateMalfunctionRepo
                 .description(reqDto.description()).reportedAt(LocalDateTime.now()).build();
 
         final MalfunctionReport saved = malfunctionReportRepository.save(report);
-        log.info("고장 신고 생성 완료: reportId={}, machineId={}, userId={}", saved.getId(), machine.getId(), userId);
+        log.info("Malfunction report created reportId={} machineId={} userId={}",
+                saved.getId(),
+                machine.getId(),
+                userId);
 
         return toResDto(saved);
     }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
@@ -30,8 +30,6 @@ import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 @RequiredArgsConstructor
 public class CreateReservationServiceImpl implements CreateReservationService {
 
-    private static final int FEMALE_FLOOR = 5;
-
     private final ReservationRepository reservationRepository;
     private final UserRepository userRepository;
     private final MachineRepository machineRepository;
@@ -46,9 +44,7 @@ public class CreateReservationServiceImpl implements CreateReservationService {
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
-        if (user.getFloor() == FEMALE_FLOOR) {
-            throw new ExpectedException("1~4층 기숙사생이 아니라면 서비스를 이용할 수 없습니다.", HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS);
-        }
+        user.validateFloorRestriction();
 
         final Machine machine = machineRepository.findById(reqDto.machineId())
                 .orElseThrow(() -> new ExpectedException("기기를 찾을 수 없습니다", HttpStatus.NOT_FOUND));

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
@@ -30,6 +30,8 @@ import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 @RequiredArgsConstructor
 public class CreateReservationServiceImpl implements CreateReservationService {
 
+    private static final int FEMALE_FLOOR = 5;
+
     private final ReservationRepository reservationRepository;
     private final UserRepository userRepository;
     private final MachineRepository machineRepository;
@@ -43,6 +45,10 @@ public class CreateReservationServiceImpl implements CreateReservationService {
         final var userId = currentUserProvider.getCurrentUserId();
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        if (user.getFloor() == FEMALE_FLOOR) {
+            throw new ExpectedException("1~4층 기숙사생이 아니라면 서비스를 이용할 수 없습니다.", HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS);
+        }
 
         final Machine machine = machineRepository.findById(reqDto.machineId())
                 .orElseThrow(() -> new ExpectedException("기기를 찾을 수 없습니다", HttpStatus.NOT_FOUND));

--- a/src/main/java/team/washer/server/v2/domain/user/entity/User.java
+++ b/src/main/java/team/washer/server/v2/domain/user/entity/User.java
@@ -211,6 +211,15 @@ public class User extends BaseEntity {
     }
 
     /**
+     * 5층(여학생) 사용자의 서비스 접근을 제한합니다. 5층 사용자이면 예외를 발생시킵니다.
+     */
+    public void validateFloorRestriction() {
+        if (this.floor == 5) {
+            throw new ExpectedException("1~4층 기숙사생이 아니라면 서비스를 이용할 수 없습니다.", HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS);
+        }
+    }
+
+    /**
      * 패널티 상태를 검증합니다. 패널티 기간이 유효하면 예외를 발생시킵니다.
      *
      * @param penaltyExpiresAt

--- a/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
@@ -60,8 +60,7 @@ class QueryAllMachinesStatusServiceTest {
 
     private static final Long USER_ID = 1L;
 
-    private void givenUserOnFloor(int floor) {
-        when(user.getFloor()).thenReturn(floor);
+    private void givenUserMocked() {
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
     }
 
@@ -73,7 +72,7 @@ class QueryAllMachinesStatusServiceTest {
         @DisplayName("sorted=true이면 정렬된 기기 목록과 SmartThings 상태를 성공적으로 조회한다")
         void execute_ShouldReturnSortedMachinesStatus_WhenSortedIsTrue() {
             // Given
-            givenUserOnFloor(3);
+            givenUserMocked();
 
             var machine1 = Machine.builder().name("W-3F-L1").type(MachineType.WASHER).deviceId("device-1").floor(3)
                     .position(Position.LEFT).number(1).status(MachineStatus.NORMAL)
@@ -114,7 +113,7 @@ class QueryAllMachinesStatusServiceTest {
         @DisplayName("sorted=false이면 정렬 없이 기기 목록과 SmartThings 상태를 조회한다")
         void execute_ShouldReturnUnsortedMachinesStatus_WhenSortedIsFalse() {
             // Given
-            givenUserOnFloor(2);
+            givenUserMocked();
 
             var machine1 = Machine.builder().name("W-3F-L1").type(MachineType.WASHER).deviceId("device-1").floor(3)
                     .position(Position.LEFT).number(1).status(MachineStatus.NORMAL)
@@ -135,7 +134,7 @@ class QueryAllMachinesStatusServiceTest {
         @DisplayName("기기가 없으면 빈 리스트를 반환한다")
         void execute_ShouldReturnEmptyList_WhenNoMachinesExist() {
             // Given
-            givenUserOnFloor(1);
+            givenUserMocked();
             when(machineRepository.findAll(any(Sort.class))).thenReturn(List.of());
 
             // When
@@ -154,7 +153,9 @@ class QueryAllMachinesStatusServiceTest {
         @DisplayName("5층 사용자가 조회하면 예외가 발생한다")
         void execute_ShouldThrowException_WhenUserIsOnFloor5() {
             // Given
-            givenUserOnFloor(5);
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            doThrow(new ExpectedException("1~4층 기숙사생이 아니라면 서비스를 이용할 수 없습니다.", HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS))
+                    .when(user).validateFloorRestriction();
 
             // When & Then
             assertThatThrownBy(() -> queryAllMachinesStatusService.execute(USER_ID, true))
@@ -166,12 +167,10 @@ class QueryAllMachinesStatusServiceTest {
         @Test
         @DisplayName("1~4층 사용자는 정상적으로 조회할 수 있다")
         void execute_ShouldSucceed_WhenUserIsOnFloor1To4() {
-            for (int floor = 1; floor <= 4; floor++) {
-                givenUserOnFloor(floor);
-                when(machineRepository.findAll(any(Sort.class))).thenReturn(List.of());
+            givenUserMocked();
+            when(machineRepository.findAll(any(Sort.class))).thenReturn(List.of());
 
-                assertThatNoException().isThrownBy(() -> queryAllMachinesStatusService.execute(USER_ID, true));
-            }
+            assertThatNoException().isThrownBy(() -> queryAllMachinesStatusService.execute(USER_ID, true));
         }
     }
 
@@ -185,7 +184,7 @@ class QueryAllMachinesStatusServiceTest {
         }
 
         private void givenMachineWithReservation(Machine machine, Reservation reservationOrNull) {
-            givenUserOnFloor(3);
+            givenUserMocked();
             when(machineRepository.findAll(any(Sort.class))).thenReturn(List.of(machine));
             when(deviceStatusQuerySupport.queryAllDevicesStatus(any())).thenReturn(Map.of());
             when(reservationRepository.findActiveReservationByMachineId(any()))

--- a/src/test/java/team/washer/server/v2/domain/malfunction/service/CreateMalfunctionReportServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/malfunction/service/CreateMalfunctionReportServiceTest.java
@@ -127,6 +127,39 @@ class CreateMalfunctionReportServiceTest {
         }
 
         @Nested
+        @DisplayName("5층(여학생) 사용자가 신고할 때")
+        class Context_with_female_floor_user {
+
+            @Test
+            @DisplayName("ExpectedException이 발생해야 한다")
+            void it_throws_expected_exception() {
+                // Given
+                Long userId = 1L;
+                Long machineId = 1L;
+                CreateMalfunctionReportReqDto reqDto = new CreateMalfunctionReportReqDto(machineId, "고장 신고");
+
+                User user = User.builder().name("박지수").studentId("20210002").roomNumber("501").grade(2).floor(5)
+                        .penaltyCount(0).build();
+
+                given(currentUserProvider.getCurrentUserId()).willReturn(userId);
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+                // When & Then
+                assertThatThrownBy(() -> createMalfunctionReportService.execute(reqDto))
+                        .isInstanceOf(ExpectedException.class).hasMessage("1~4층 기숙사생이 아니라면 서비스를 이용할 수 없습니다.")
+                        .satisfies(exception -> {
+                            ExpectedException expectedException = (ExpectedException) exception;
+                            assertThat(expectedException.getStatusCode())
+                                    .isEqualTo(HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS);
+                        });
+
+                then(userRepository).should(times(1)).findById(userId);
+                then(machineRepository).shouldHaveNoInteractions();
+                then(malfunctionReportRepository).shouldHaveNoInteractions();
+            }
+        }
+
+        @Nested
         @DisplayName("존재하지 않는 기기 ID로 신고할 때")
         class Context_with_invalid_machine_id {
 

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 
 import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.machine.entity.Machine;
@@ -211,6 +212,25 @@ class CreateReservationServiceTest {
             // When & Then
             assertThatThrownBy(() -> createReservationService.execute(reqDto)).isInstanceOf(ExpectedException.class)
                     .hasMessageContaining("1인 1예약");
+        }
+
+        @Test
+        @DisplayName("5층(여학생) 사용자가 예약을 시도하면 예외를 발생시킨다")
+        void execute_ShouldThrowException_WhenUserIsOnFemaleFloor() {
+            // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+            final var reqDto = new CreateReservationReqDto(1L);
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            when(user.getFloor()).thenReturn(5);
+
+            // When & Then
+            assertThatThrownBy(() -> createReservationService.execute(reqDto)).isInstanceOf(ExpectedException.class)
+                    .hasMessage("1~4층 기숙사생이 아니라면 서비스를 이용할 수 없습니다.")
+                    .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                            .isEqualTo(HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS));
+
+            verify(machineRepository, never()).findById(any());
         }
 
         @Test

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
@@ -222,7 +222,8 @@ class CreateReservationServiceTest {
             final var reqDto = new CreateReservationReqDto(1L);
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
-            when(user.getFloor()).thenReturn(5);
+            doThrow(new ExpectedException("1~4층 기숙사생이 아니라면 서비스를 이용할 수 없습니다.", HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS))
+                    .when(user).validateFloorRestriction();
 
             // When & Then
             assertThatThrownBy(() -> createReservationService.execute(reqDto)).isInstanceOf(ExpectedException.class)


### PR DESCRIPTION
## 개요

기기 현황 조회에만 적용되어 있던 5층(여학생) 접근 제한이 예약 생성과 고장 신고 서비스에는 누락되어 있었다. 두 서비스에 동일한 제한 로직을 추가하고 관련 테스트 케이스를 보완했다.

## 본문

### 작업 이유

`QueryAllMachinesStatusServiceImpl`에는 5층 사용자가 요청할 경우 HTTP 451을 반환하는 제한이 구현되어 있었으나, `CreateReservationServiceImpl`과 `CreateMalfunctionReportServiceImpl`에는 동일한 제한이 없었다. 이로 인해 5층 사용자가 예약 생성 및 고장 신고 API를 정상적으로 호출할 수 있는 상태였다.

### 구현 방식

두 서비스 모두 사용자 조회 직후, 이후 로직 진행 전에 `user.getFloor() == FEMALE_FLOOR(5)` 조건을 확인하여 해당하면 `ExpectedException`(HTTP 451)을 던지도록 했다. 상수 `FEMALE_FLOOR = 5`는 각 서비스 클래스 내에 선언했다.

`CreateMalfunctionReportServiceImpl`의 로그 메시지가 한국어로 작성되어 있어 영어로 수정했다.

### 현재 상태

- `CreateReservationServiceImpl`: 5층 사용자가 예약 생성 시도 시 HTTP 451 반환
- `CreateMalfunctionReportServiceImpl`: 5층 사용자가 고장 신고 시도 시 HTTP 451 반환
- `CreateReservationServiceTest`: 5층 사용자 접근 제한 테스트 케이스 추가
- `CreateMalfunctionReportServiceTest`: 5층 사용자 접근 제한 테스트 케이스 추가