### PR TITLE
[global] 기기 수동 동기화 엔드포인트 및 prod Swagger 경로 난독화 기능

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/smartthings/controller/AdminSmartThingsDeviceController.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/controller/AdminSmartThingsDeviceController.java
@@ -35,8 +35,9 @@ public class AdminSmartThingsDeviceController {
      * @return 동기화 실행 결과
      */
     @PostMapping("/sync")
-    @Operation(summary = "기기 목록 수동 동기화", description = "SmartThings 전체 기기 목록을 즉시 재동기화합니다. "
-            + "오발 방지를 위해 본문의 확인 키 값으로 반드시 true를 전달해야 하며, 접수 후 3초 뒤에 실행됩니다.")
+    @Operation(summary = "기기 목록 수동 동기화", description = "SmartThings 전체 기기 목록을 재동기화합니다. "
+            + "오발 방지를 위해 본문의 확인 키 값으로 반드시 true를 전달해야 합니다. "
+            + "요청 스레드를 블로킹하지 않고 즉시 접수하며, 접수 후 5초 창 안에 들어온 요청은 하나로 통합되어 백그라운드에서 한 번만 실행됩니다.")
     public DeviceSyncTriggerResDto syncDevices(@Valid @RequestBody TriggerDeviceSyncReqDto request) {
         return triggerManualDeviceSyncService.execute(request);
     }

--- a/src/main/java/team/washer/server/v2/domain/smartthings/controller/AdminSmartThingsDeviceController.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/controller/AdminSmartThingsDeviceController.java
@@ -1,0 +1,43 @@
+package team.washer.server.v2.domain.smartthings.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.smartthings.dto.request.TriggerDeviceSyncReqDto;
+import team.washer.server.v2.domain.smartthings.dto.response.DeviceSyncTriggerResDto;
+import team.washer.server.v2.domain.smartthings.service.TriggerManualDeviceSyncService;
+
+/**
+ * SmartThings 기기 관리 컨트롤러 (관리자용)
+ *
+ * <p>
+ * 자동 동기화 스케줄러와 별개로, 관리자가 임의 시점에 기기 목록 동기화를 수동으로 촉발할 수 있습니다.
+ */
+@RestController
+@RequestMapping("/api/v2/admin/smartthings/devices")
+@RequiredArgsConstructor
+@Tag(name = "Admin SmartThings Device", description = "SmartThings 기기 관리 API (관리자용)")
+public class AdminSmartThingsDeviceController {
+
+    private final TriggerManualDeviceSyncService triggerManualDeviceSyncService;
+
+    /**
+     * 기기 목록 수동 동기화
+     *
+     * @param request
+     *            실행 확인 키를 담은 요청 본문
+     * @return 동기화 실행 결과
+     */
+    @PostMapping("/sync")
+    @Operation(summary = "기기 목록 수동 동기화", description = "SmartThings 전체 기기 목록을 즉시 재동기화합니다. "
+            + "오발 방지를 위해 본문의 확인 키 값으로 반드시 true를 전달해야 하며, 접수 후 3초 뒤에 실행됩니다.")
+    public DeviceSyncTriggerResDto syncDevices(@Valid @RequestBody TriggerDeviceSyncReqDto request) {
+        return triggerManualDeviceSyncService.execute(request);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/dto/request/TriggerDeviceSyncReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/dto/request/TriggerDeviceSyncReqDto.java
@@ -1,0 +1,17 @@
+package team.washer.server.v2.domain.smartthings.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 기기 목록 수동 동기화 요청 DTO
+ *
+ * <p>
+ * 오발 방지를 위해 본문의 키 자체가 경고 문구이며, 값으로 {@code true}가 전달되어야만 동기화가 실행됩니다. 값이 누락되거나
+ * {@code false}이면 예외가 발생합니다.
+ */
+@Schema(description = "기기 목록 수동 동기화 요청")
+public record TriggerDeviceSyncReqDto(
+        @Schema(description = "실행 확인 키. 값으로 true를 전달해야만 동기화가 실행됩니다.", example = "true", requiredMode = Schema.RequiredMode.REQUIRED) @JsonProperty("정말 실행하시겠습니까 이 작업은 SmartThings 전체 기기 목록을 즉시 재동기화하며 누락된 기기를 비활성화하는 결과를 촉발합니다") Boolean confirmed) {
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/DeviceSyncTriggerResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/DeviceSyncTriggerResDto.java
@@ -1,0 +1,13 @@
+package team.washer.server.v2.domain.smartthings.dto.response;
+
+import java.time.Instant;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 기기 목록 수동 동기화 실행 결과 DTO
+ */
+@Schema(description = "기기 목록 수동 동기화 실행 결과")
+public record DeviceSyncTriggerResDto(@Schema(description = "처리 결과 메시지") String message,
+        @Schema(description = "동기화 실행 시각") Instant executedAt) {
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/DeviceSyncTriggerResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/DeviceSyncTriggerResDto.java
@@ -5,9 +5,11 @@ import java.time.Instant;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
- * 기기 목록 수동 동기화 실행 결과 DTO
+ * 기기 목록 수동 동기화 접수 결과 DTO
  */
-@Schema(description = "기기 목록 수동 동기화 실행 결과")
+@Schema(description = "기기 목록 수동 동기화 접수 결과")
 public record DeviceSyncTriggerResDto(@Schema(description = "처리 결과 메시지") String message,
-        @Schema(description = "동기화 실행 시각") Instant executedAt) {
+        @Schema(description = "새 실행 창을 예약했으면 true, 기존 예약에 통합되었으면 false") boolean newlyScheduled,
+        @Schema(description = "동기화 실행 예정 시각") Instant scheduledAt,
+        @Schema(description = "현재 창에 통합된 누적 요청 수") int pendingRequestCount) {
 }

--- a/src/main/java/team/washer/server/v2/domain/smartthings/service/TriggerManualDeviceSyncService.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/service/TriggerManualDeviceSyncService.java
@@ -1,0 +1,12 @@
+package team.washer.server.v2.domain.smartthings.service;
+
+import team.washer.server.v2.domain.smartthings.dto.request.TriggerDeviceSyncReqDto;
+import team.washer.server.v2.domain.smartthings.dto.response.DeviceSyncTriggerResDto;
+
+/**
+ * 관리자가 임의 시점에 SmartThings 기기 목록 동기화를 수동으로 촉발하는 서비스
+ */
+public interface TriggerManualDeviceSyncService {
+
+    DeviceSyncTriggerResDto execute(TriggerDeviceSyncReqDto request);
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/TriggerManualDeviceSyncServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/TriggerManualDeviceSyncServiceImpl.java
@@ -1,0 +1,61 @@
+package team.washer.server.v2.domain.smartthings.service.impl;
+
+import java.time.Instant;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.smartthings.dto.request.TriggerDeviceSyncReqDto;
+import team.washer.server.v2.domain.smartthings.dto.response.DeviceSyncTriggerResDto;
+import team.washer.server.v2.domain.smartthings.service.SyncSmartThingsDevicesService;
+import team.washer.server.v2.domain.smartthings.service.TriggerManualDeviceSyncService;
+
+/**
+ * 기기 목록 수동 동기화 촉발 서비스 구현체
+ *
+ * <p>
+ * 확인 키 값이 {@code true}인지 검증한 뒤, 즉시 폭주를 완충하기 위해 3초 대기한 후 실제 동기화를
+ * {@link SyncSmartThingsDevicesService}에 위임합니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TriggerManualDeviceSyncServiceImpl implements TriggerManualDeviceSyncService {
+
+    private static final long ACCEPTANCE_DELAY_MS = 3000L;
+
+    private final SyncSmartThingsDevicesService syncSmartThingsDevicesService;
+
+    @Override
+    public DeviceSyncTriggerResDto execute(final TriggerDeviceSyncReqDto request) {
+        if (request.confirmed() == null || !request.confirmed()) {
+            log.warn("manual device sync rejected confirmed={}", request.confirmed());
+            throw new ExpectedException("실행 확인 값이 올바르지 않습니다. 확인 키의 값으로 true 를 보내야 합니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        log.info("manual device sync requested delayMs={}", ACCEPTANCE_DELAY_MS);
+        waitBeforeExecution();
+
+        syncSmartThingsDevicesService.execute();
+        final var executedAt = Instant.now();
+        log.info("manual device sync executed executedAt={}", executedAt);
+
+        return new DeviceSyncTriggerResDto("기기 목록 동기화를 실행했습니다.", executedAt);
+    }
+
+    /**
+     * 접수 후 실제 실행까지 3초간 대기합니다.
+     */
+    private void waitBeforeExecution() {
+        try {
+            Thread.sleep(ACCEPTANCE_DELAY_MS);
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            log.error("manual device sync interrupted during delay", e);
+            throw new ExpectedException("동기화 대기 중 인터럽트가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/TriggerManualDeviceSyncServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/TriggerManualDeviceSyncServiceImpl.java
@@ -1,7 +1,5 @@
 package team.washer.server.v2.domain.smartthings.service.impl;
 
-import java.time.Instant;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
@@ -10,24 +8,22 @@ import lombok.extern.slf4j.Slf4j;
 import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.smartthings.dto.request.TriggerDeviceSyncReqDto;
 import team.washer.server.v2.domain.smartthings.dto.response.DeviceSyncTriggerResDto;
-import team.washer.server.v2.domain.smartthings.service.SyncSmartThingsDevicesService;
 import team.washer.server.v2.domain.smartthings.service.TriggerManualDeviceSyncService;
+import team.washer.server.v2.domain.smartthings.support.DeviceSyncCoalescer;
 
 /**
  * 기기 목록 수동 동기화 촉발 서비스 구현체
  *
  * <p>
- * 확인 키 값이 {@code true}인지 검증한 뒤, 즉시 폭주를 완충하기 위해 3초 대기한 후 실제 동기화를
- * {@link SyncSmartThingsDevicesService}에 위임합니다.
+ * 확인 키 값이 {@code true}인지 검증한 뒤, HTTP 스레드를 블로킹하지 않고 {@link DeviceSyncCoalescer}에
+ * 요청을 접수한다. 실제 동기화는 5초 창 안의 요청을 통합하여 백그라운드에서 한 번만 실행된다.
  */
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class TriggerManualDeviceSyncServiceImpl implements TriggerManualDeviceSyncService {
 
-    private static final long ACCEPTANCE_DELAY_MS = 3000L;
-
-    private final SyncSmartThingsDevicesService syncSmartThingsDevicesService;
+    private final DeviceSyncCoalescer deviceSyncCoalescer;
 
     @Override
     public DeviceSyncTriggerResDto execute(final TriggerDeviceSyncReqDto request) {
@@ -36,26 +32,19 @@ public class TriggerManualDeviceSyncServiceImpl implements TriggerManualDeviceSy
             throw new ExpectedException("실행 확인 값이 올바르지 않습니다. 확인 키의 값으로 true 를 보내야 합니다.", HttpStatus.BAD_REQUEST);
         }
 
-        log.info("manual device sync requested delayMs={}", ACCEPTANCE_DELAY_MS);
-        waitBeforeExecution();
+        final var submission = deviceSyncCoalescer.submit();
+        log.info("manual device sync accepted newlyScheduled={} scheduledAt={} pendingRequestCount={}",
+                submission.newlyScheduled(),
+                submission.scheduledAt(),
+                submission.pendingRequestCount());
 
-        syncSmartThingsDevicesService.execute();
-        final var executedAt = Instant.now();
-        log.info("manual device sync executed executedAt={}", executedAt);
+        final var message = submission.newlyScheduled()
+                ? "기기 목록 동기화를 예약했습니다. 약 5초 후 실행됩니다."
+                : "이미 예약된 동기화 요청에 통합되었습니다.";
 
-        return new DeviceSyncTriggerResDto("기기 목록 동기화를 실행했습니다.", executedAt);
-    }
-
-    /**
-     * 접수 후 실제 실행까지 3초간 대기합니다.
-     */
-    private void waitBeforeExecution() {
-        try {
-            Thread.sleep(ACCEPTANCE_DELAY_MS);
-        } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
-            log.error("manual device sync interrupted during delay", e);
-            throw new ExpectedException("동기화 대기 중 인터럽트가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
-        }
+        return new DeviceSyncTriggerResDto(message,
+                submission.newlyScheduled(),
+                submission.scheduledAt(),
+                submission.pendingRequestCount());
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/DeviceSyncCoalescer.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/DeviceSyncCoalescer.java
@@ -1,0 +1,96 @@
+package team.washer.server.v2.domain.smartthings.support;
+
+import java.time.Instant;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.smartthings.service.SyncSmartThingsDevicesService;
+
+/**
+ * 기기 동기화 요청을 인메모리로 통합(coalesce)하는 단일 실행(single-flight) 큐
+ *
+ * <p>
+ * permitAll로 공개된 수동 동기화 엔드포인트가 블로킹이나 폭주에 취약하지 않도록, HTTP 스레드를 점유하지 않고 요청을 즉시
+ * 접수한다. 첫 요청은 5초 뒤 실행을 예약하며, 그 5초 창(window) 안에 도착해 아직 처리되지 않은 후속 요청은 새 실행을 만들지
+ * 않고 기존 예약에 통합된다. 창이 만료되어 실행이 시작되면 다음 요청부터 새 창이 열린다.
+ */
+@Component
+@Slf4j
+public class DeviceSyncCoalescer {
+
+    private static final long WINDOW_MILLIS = 5000L;
+
+    private final TaskScheduler taskScheduler;
+    private final SyncSmartThingsDevicesService syncSmartThingsDevicesService;
+    private final Object lock = new Object();
+
+    private PendingWindow pending;
+
+    public DeviceSyncCoalescer(@Qualifier("customTaskScheduler") final TaskScheduler taskScheduler,
+            final SyncSmartThingsDevicesService syncSmartThingsDevicesService) {
+        this.taskScheduler = taskScheduler;
+        this.syncSmartThingsDevicesService = syncSmartThingsDevicesService;
+    }
+
+    /**
+     * 동기화 요청을 접수한다. 진행 중(미실행)인 창이 있으면 통합하고, 없으면 새 창을 예약한다.
+     *
+     * @return 신규 예약 여부, 실행 예정 시각, 현재 창에 통합된 누적 요청 수
+     */
+    public Submission submit() {
+        synchronized (lock) {
+            if (pending != null) {
+                final var count = pending.requestCount().incrementAndGet();
+                log.info("device sync coalesced into pending window scheduledAt={} pendingRequestCount={}",
+                        pending.scheduledAt(),
+                        count);
+                return new Submission(false, pending.scheduledAt(), count);
+            }
+            final var scheduledAt = Instant.now().plusMillis(WINDOW_MILLIS);
+            final var requestCount = new AtomicInteger(1);
+            final ScheduledFuture<?> future = taskScheduler.schedule(this::runWindow, scheduledAt);
+            pending = new PendingWindow(scheduledAt, requestCount, future);
+            log.info("device sync window scheduled scheduledAt={} windowMs={}", scheduledAt, WINDOW_MILLIS);
+            return new Submission(true, scheduledAt, 1);
+        }
+    }
+
+    /**
+     * 창이 만료되어 실행되는 시점. 현재 창을 닫아 이후 요청은 새 창을 열도록 하고, 통합된 요청 전체에 대해 동기화를 한 번만 실행한다.
+     */
+    private void runWindow() {
+        final int totalRequests;
+        synchronized (lock) {
+            totalRequests = pending != null ? pending.requestCount().get() : 0;
+            pending = null;
+        }
+        try {
+            log.info("device sync window firing coalescedRequestCount={}", totalRequests);
+            syncSmartThingsDevicesService.execute();
+            log.info("device sync window completed coalescedRequestCount={}", totalRequests);
+        } catch (final Exception e) {
+            log.error("device sync window failed coalescedRequestCount={}", totalRequests, e);
+        }
+    }
+
+    private record PendingWindow(Instant scheduledAt, AtomicInteger requestCount, ScheduledFuture<?> future) {
+    }
+
+    /**
+     * 동기화 요청 접수 결과
+     *
+     * @param newlyScheduled
+     *            새 실행 창을 예약했으면 true, 기존 창에 통합되었으면 false
+     * @param scheduledAt
+     *            동기화 실행 예정 시각
+     * @param pendingRequestCount
+     *            현재 창에 통합된 누적 요청 수
+     */
+    public record Submission(boolean newlyScheduled, Instant scheduledAt, int pendingRequestCount) {
+    }
+}

--- a/src/main/java/team/washer/server/v2/global/config/swagger/ObfuscatedSwaggerPathNotifier.java
+++ b/src/main/java/team/washer/server/v2/global/config/swagger/ObfuscatedSwaggerPathNotifier.java
@@ -1,0 +1,55 @@
+package team.washer.server.v2.global.config.swagger;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Profile;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.global.thirdparty.discord.data.DiscordEmbed;
+import team.washer.server.v2.global.thirdparty.discord.data.DiscordField;
+import team.washer.server.v2.global.thirdparty.discord.data.DiscordWebhookPayload;
+import team.washer.server.v2.global.thirdparty.discord.data.EmbedColor;
+import team.washer.server.v2.global.thirdparty.feign.client.DiscordWebhookClient;
+
+/**
+ * prod 기동 시 {@link SwaggerPathObfuscator}가 난독화한 Swagger 경로를 Discord로 통지하는 컴포넌트
+ */
+@Slf4j
+@Component
+@Profile("prod")
+@RequiredArgsConstructor
+public class ObfuscatedSwaggerPathNotifier {
+
+    private final Environment environment;
+    private final DiscordWebhookClient discordWebhookClient;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void notifyObfuscatedSwaggerPath() {
+        final var swaggerUiPath = environment.getProperty("springdoc.swagger-ui.path", "/swagger-ui.html");
+        final var apiDocsPath = environment.getProperty("springdoc.api-docs.path", "/v3/api-docs");
+
+        log.info("obfuscated swagger paths swaggerUi={} apiDocs={}", swaggerUiPath, apiDocsPath);
+
+        try {
+            final var embed = DiscordEmbed.builder().title("🔐 Swagger 경로 난독화 적용")
+                    .description("이번 부팅에 적용된 Swagger 문서 경로입니다. 외부에 노출되지 않도록 주의하세요.")
+                    .color(EmbedColor.WARNING.getColor())
+                    .fields(List.of(
+                            DiscordField.builder().name("Swagger UI").value("`" + swaggerUiPath + "`").inline(false)
+                                    .build(),
+                            DiscordField.builder().name("API Docs").value("`" + apiDocsPath + "`").inline(false)
+                                    .build()))
+                    .timestamp(Instant.now().toString()).build();
+
+            discordWebhookClient.sendMessage(DiscordWebhookPayload.embedMessage(embed));
+        } catch (final Exception e) {
+            log.error("failed to notify obfuscated swagger path to discord", e);
+        }
+    }
+}

--- a/src/main/java/team/washer/server/v2/global/config/swagger/SwaggerPathObfuscator.java
+++ b/src/main/java/team/washer/server/v2/global/config/swagger/SwaggerPathObfuscator.java
@@ -1,0 +1,51 @@
+package team.washer.server.v2.global.config.swagger;
+
+import java.security.SecureRandom;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.boot.EnvironmentPostProcessor;
+import org.springframework.boot.SpringApplication;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+
+/**
+ * prod 프로파일에서 Swagger 문서 경로를 부팅마다 랜덤 시크릿 경로로 난독화하는 EnvironmentPostProcessor
+ *
+ * <p>
+ * 예측 가능한 고정 경로({@code /v3/api-docs}, {@code /swagger-ui.html}) 노출을 줄이기 위해,
+ * springdoc 빈 생성 이전에 경로 앞에 랜덤 시크릿 세그먼트를 주입합니다. 변경된 경로는
+ * {@code ObfuscatedSwaggerPathNotifier}가 기동 시 Discord로 통지합니다.
+ */
+public class SwaggerPathObfuscator implements EnvironmentPostProcessor {
+
+    private static final String PROD_PROFILE = "prod";
+    private static final String PROPERTY_SOURCE_NAME = "obfuscatedSwaggerPaths";
+    private static final String API_DOCS_PATH_KEY = "springdoc.api-docs.path";
+    private static final String SWAGGER_UI_PATH_KEY = "springdoc.swagger-ui.path";
+    private static final int SECRET_BYTE_LENGTH = 4;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    @Override
+    public void postProcessEnvironment(final ConfigurableEnvironment environment, final SpringApplication application) {
+        final var prodActive = environment.matchesProfiles(PROD_PROFILE);
+        if (!prodActive) {
+            return;
+        }
+
+        final var secret = generateSecret();
+        final Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put(API_DOCS_PATH_KEY, "/" + secret + "/v3/api-docs");
+        properties.put(SWAGGER_UI_PATH_KEY, "/" + secret + "/swagger-ui.html");
+
+        environment.getPropertySources().addFirst(new MapPropertySource(PROPERTY_SOURCE_NAME, properties));
+    }
+
+    private String generateSecret() {
+        final var bytes = new byte[SECRET_BYTE_LENGTH];
+        secureRandom.nextBytes(bytes);
+        return HexFormat.of().formatHex(bytes);
+    }
+}

--- a/src/main/java/team/washer/server/v2/global/security/config/DomainAuthorizationConfig.java
+++ b/src/main/java/team/washer/server/v2/global/security/config/DomainAuthorizationConfig.java
@@ -1,16 +1,30 @@
 package team.washer.server.v2.global.security.config;
 
+import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.stereotype.Component;
 
+import lombok.RequiredArgsConstructor;
+
 @Component
+@RequiredArgsConstructor
 public class DomainAuthorizationConfig {
+
+    private static final String DEFAULT_API_DOCS_PATH = "/v3/api-docs";
+    private static final String DEFAULT_SWAGGER_UI_PATH = "/swagger-ui.html";
+
+    private final Environment environment;
+
     public void configure(
             AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry authorizeRequests) {
+        // prod 프로파일에서는 SwaggerPathObfuscator가 경로를 난독화하므로 실제 해석된 경로를 허용한다.
+        final var apiDocsPath = environment.getProperty("springdoc.api-docs.path", DEFAULT_API_DOCS_PATH);
+        final var swaggerUiPath = environment.getProperty("springdoc.swagger-ui.path", DEFAULT_SWAGGER_UI_PATH);
+
         authorizeRequests
                 // Swagger UI
-                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .requestMatchers("/swagger-ui/**", swaggerUiPath, apiDocsPath, apiDocsPath + "/**").permitAll()
                 // 헬스 체크
                 .requestMatchers("/api/v2/health", "/api/v2/admin/smartthings/**").permitAll()
                 // 인증 엔드포인트

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.EnvironmentPostProcessor=\
+team.washer.server.v2.global.config.swagger.SwaggerPathObfuscator

--- a/src/test/java/team/washer/server/v2/domain/smartthings/service/TriggerManualDeviceSyncServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/service/TriggerManualDeviceSyncServiceTest.java
@@ -1,0 +1,97 @@
+package team.washer.server.v2.domain.smartthings.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.smartthings.dto.request.TriggerDeviceSyncReqDto;
+import team.washer.server.v2.domain.smartthings.service.impl.TriggerManualDeviceSyncServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TriggerManualDeviceSyncServiceImpl 클래스의")
+class TriggerManualDeviceSyncServiceTest {
+
+    @InjectMocks
+    private TriggerManualDeviceSyncServiceImpl triggerManualDeviceSyncService;
+
+    @Mock
+    private SyncSmartThingsDevicesService syncSmartThingsDevicesService;
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("확인 키 값으로 true가 전달될 때")
+        class Context_with_confirmed_true {
+
+            @Test
+            @DisplayName("3초 대기 후 기기 동기화를 실행하고 결과를 반환해야 한다")
+            void it_executes_sync_after_delay() {
+                // Given
+                var request = new TriggerDeviceSyncReqDto(true);
+
+                // When
+                var startedAt = System.currentTimeMillis();
+                var result = triggerManualDeviceSyncService.execute(request);
+                var elapsed = System.currentTimeMillis() - startedAt;
+
+                // Then
+                then(syncSmartThingsDevicesService).should(times(1)).execute();
+                assertThat(elapsed).isGreaterThanOrEqualTo(3000L);
+                assertThat(result.message()).isEqualTo("기기 목록 동기화를 실행했습니다.");
+                assertThat(result.executedAt()).isNotNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("확인 키 값으로 false가 전달될 때")
+        class Context_with_confirmed_false {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 BAD_REQUEST 상태를 반환하며 동기화를 실행하지 않아야 한다")
+            void it_throws_bad_request_and_skips_sync() {
+                // Given
+                var request = new TriggerDeviceSyncReqDto(false);
+
+                // When & Then
+                assertThatThrownBy(() -> triggerManualDeviceSyncService.execute(request))
+                        .isInstanceOf(ExpectedException.class)
+                        .hasMessage("실행 확인 값이 올바르지 않습니다. 확인 키의 값으로 true 를 보내야 합니다.")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.BAD_REQUEST));
+
+                then(syncSmartThingsDevicesService).shouldHaveNoInteractions();
+            }
+        }
+
+        @Nested
+        @DisplayName("확인 키 값이 누락될 때")
+        class Context_with_confirmed_null {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 BAD_REQUEST 상태를 반환하며 동기화를 실행하지 않아야 한다")
+            void it_throws_bad_request_for_null() {
+                // Given
+                var request = new TriggerDeviceSyncReqDto(null);
+
+                // When & Then
+                assertThatThrownBy(() -> triggerManualDeviceSyncService.execute(request))
+                        .isInstanceOf(ExpectedException.class)
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.BAD_REQUEST));
+
+                then(syncSmartThingsDevicesService).shouldHaveNoInteractions();
+            }
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/smartthings/service/TriggerManualDeviceSyncServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/service/TriggerManualDeviceSyncServiceTest.java
@@ -3,6 +3,8 @@ package team.washer.server.v2.domain.smartthings.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.Instant;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.smartthings.dto.request.TriggerDeviceSyncReqDto;
 import team.washer.server.v2.domain.smartthings.service.impl.TriggerManualDeviceSyncServiceImpl;
+import team.washer.server.v2.domain.smartthings.support.DeviceSyncCoalescer;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("TriggerManualDeviceSyncServiceImpl 클래스의")
@@ -24,32 +27,54 @@ class TriggerManualDeviceSyncServiceTest {
     private TriggerManualDeviceSyncServiceImpl triggerManualDeviceSyncService;
 
     @Mock
-    private SyncSmartThingsDevicesService syncSmartThingsDevicesService;
+    private DeviceSyncCoalescer deviceSyncCoalescer;
 
     @Nested
     @DisplayName("execute 메서드는")
     class Describe_execute {
 
         @Nested
-        @DisplayName("확인 키 값으로 true가 전달될 때")
-        class Context_with_confirmed_true {
+        @DisplayName("확인 키 값으로 true가 전달되어 새로 예약될 때")
+        class Context_with_confirmed_true_newly_scheduled {
 
             @Test
-            @DisplayName("3초 대기 후 기기 동기화를 실행하고 결과를 반환해야 한다")
-            void it_executes_sync_after_delay() {
+            @DisplayName("코얼레서에 접수하고 예약 결과를 반환해야 한다")
+            void it_submits_and_returns_scheduled_result() {
                 // Given
-                var request = new TriggerDeviceSyncReqDto(true);
+                var scheduledAt = Instant.now().plusSeconds(5);
+                given(deviceSyncCoalescer.submit())
+                        .willReturn(new DeviceSyncCoalescer.Submission(true, scheduledAt, 1));
 
                 // When
-                var startedAt = System.currentTimeMillis();
-                var result = triggerManualDeviceSyncService.execute(request);
-                var elapsed = System.currentTimeMillis() - startedAt;
+                var result = triggerManualDeviceSyncService.execute(new TriggerDeviceSyncReqDto(true));
 
                 // Then
-                then(syncSmartThingsDevicesService).should(times(1)).execute();
-                assertThat(elapsed).isGreaterThanOrEqualTo(3000L);
-                assertThat(result.message()).isEqualTo("기기 목록 동기화를 실행했습니다.");
-                assertThat(result.executedAt()).isNotNull();
+                then(deviceSyncCoalescer).should(times(1)).submit();
+                assertThat(result.newlyScheduled()).isTrue();
+                assertThat(result.scheduledAt()).isEqualTo(scheduledAt);
+                assertThat(result.pendingRequestCount()).isEqualTo(1);
+                assertThat(result.message()).contains("예약");
+            }
+        }
+
+        @Nested
+        @DisplayName("이미 예약된 요청에 통합될 때")
+        class Context_coalesced {
+
+            @Test
+            @DisplayName("newlyScheduled=false와 통합 메시지를 반환해야 한다")
+            void it_returns_coalesced_result() {
+                // Given
+                given(deviceSyncCoalescer.submit())
+                        .willReturn(new DeviceSyncCoalescer.Submission(false, Instant.now().plusSeconds(3), 2));
+
+                // When
+                var result = triggerManualDeviceSyncService.execute(new TriggerDeviceSyncReqDto(true));
+
+                // Then
+                assertThat(result.newlyScheduled()).isFalse();
+                assertThat(result.pendingRequestCount()).isEqualTo(2);
+                assertThat(result.message()).contains("통합");
             }
         }
 
@@ -58,19 +83,16 @@ class TriggerManualDeviceSyncServiceTest {
         class Context_with_confirmed_false {
 
             @Test
-            @DisplayName("ExpectedException이 발생하고 BAD_REQUEST 상태를 반환하며 동기화를 실행하지 않아야 한다")
-            void it_throws_bad_request_and_skips_sync() {
-                // Given
-                var request = new TriggerDeviceSyncReqDto(false);
-
+            @DisplayName("ExpectedException(BAD_REQUEST)이 발생하고 접수하지 않아야 한다")
+            void it_throws_bad_request_and_skips_submit() {
                 // When & Then
-                assertThatThrownBy(() -> triggerManualDeviceSyncService.execute(request))
+                assertThatThrownBy(() -> triggerManualDeviceSyncService.execute(new TriggerDeviceSyncReqDto(false)))
                         .isInstanceOf(ExpectedException.class)
                         .hasMessage("실행 확인 값이 올바르지 않습니다. 확인 키의 값으로 true 를 보내야 합니다.")
                         .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
                                 .isEqualTo(HttpStatus.BAD_REQUEST));
 
-                then(syncSmartThingsDevicesService).shouldHaveNoInteractions();
+                then(deviceSyncCoalescer).shouldHaveNoInteractions();
             }
         }
 
@@ -79,18 +101,15 @@ class TriggerManualDeviceSyncServiceTest {
         class Context_with_confirmed_null {
 
             @Test
-            @DisplayName("ExpectedException이 발생하고 BAD_REQUEST 상태를 반환하며 동기화를 실행하지 않아야 한다")
+            @DisplayName("ExpectedException(BAD_REQUEST)이 발생하고 접수하지 않아야 한다")
             void it_throws_bad_request_for_null() {
-                // Given
-                var request = new TriggerDeviceSyncReqDto(null);
-
                 // When & Then
-                assertThatThrownBy(() -> triggerManualDeviceSyncService.execute(request))
+                assertThatThrownBy(() -> triggerManualDeviceSyncService.execute(new TriggerDeviceSyncReqDto(null)))
                         .isInstanceOf(ExpectedException.class)
                         .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
                                 .isEqualTo(HttpStatus.BAD_REQUEST));
 
-                then(syncSmartThingsDevicesService).shouldHaveNoInteractions();
+                then(deviceSyncCoalescer).shouldHaveNoInteractions();
             }
         }
     }

--- a/src/test/java/team/washer/server/v2/domain/smartthings/support/DeviceSyncCoalescerTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/support/DeviceSyncCoalescerTest.java
@@ -1,0 +1,111 @@
+package team.washer.server.v2.domain.smartthings.support;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.TaskScheduler;
+
+import team.washer.server.v2.domain.smartthings.service.SyncSmartThingsDevicesService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeviceSyncCoalescer 클래스의")
+class DeviceSyncCoalescerTest {
+
+    @Mock
+    private TaskScheduler taskScheduler;
+
+    @Mock
+    private SyncSmartThingsDevicesService syncSmartThingsDevicesService;
+
+    @Captor
+    private ArgumentCaptor<Runnable> runnableCaptor;
+
+    private DeviceSyncCoalescer deviceSyncCoalescer;
+
+    @BeforeEach
+    void setUp() {
+        deviceSyncCoalescer = new DeviceSyncCoalescer(taskScheduler, syncSmartThingsDevicesService);
+    }
+
+    @Nested
+    @DisplayName("submit 메서드는")
+    class Describe_submit {
+
+        @Nested
+        @DisplayName("진행 중인 창이 없을 때")
+        class Context_no_pending_window {
+
+            @Test
+            @DisplayName("새 실행 창을 예약하고 newlyScheduled=true를 반환해야 한다")
+            void it_schedules_new_window() {
+                // When
+                var submission = deviceSyncCoalescer.submit();
+
+                // Then
+                assertThat(submission.newlyScheduled()).isTrue();
+                assertThat(submission.pendingRequestCount()).isEqualTo(1);
+                then(taskScheduler).should(times(1)).schedule(any(Runnable.class), any(Instant.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("이미 진행 중인 창이 있을 때")
+        class Context_with_pending_window {
+
+            @Test
+            @DisplayName("새 예약 없이 기존 창에 통합하고 누적 요청 수를 증가시켜야 한다")
+            void it_coalesces_into_existing_window() {
+                // Given
+                var first = deviceSyncCoalescer.submit();
+
+                // When
+                var second = deviceSyncCoalescer.submit();
+
+                // Then
+                assertThat(first.newlyScheduled()).isTrue();
+                assertThat(second.newlyScheduled()).isFalse();
+                assertThat(second.pendingRequestCount()).isEqualTo(2);
+                assertThat(second.scheduledAt()).isEqualTo(first.scheduledAt());
+                then(taskScheduler).should(times(1)).schedule(any(Runnable.class), any(Instant.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("예약된 창이 실행될 때")
+        class Context_window_fires {
+
+            @Test
+            @DisplayName("통합된 요청에 대해 동기화를 한 번만 실행하고 이후 요청은 새 창을 열어야 한다")
+            void it_executes_once_then_reopens_window() {
+                // Given
+                deviceSyncCoalescer.submit();
+                deviceSyncCoalescer.submit(); // 기존 창에 통합 (예약은 1회만)
+                then(taskScheduler).should(times(1)).schedule(runnableCaptor.capture(), any(Instant.class));
+
+                // When: 창 실행
+                runnableCaptor.getValue().run();
+
+                // Then: 동기화는 한 번만 실행
+                then(syncSmartThingsDevicesService).should(times(1)).execute();
+
+                // When: 실행 후 새 요청
+                var afterFire = deviceSyncCoalescer.submit();
+
+                // Then: 새 창이 예약되어야 한다 (총 2회 예약)
+                assertThat(afterFire.newlyScheduled()).isTrue();
+                then(taskScheduler).should(times(2)).schedule(any(Runnable.class), any(Instant.class));
+            }
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/global/config/swagger/SwaggerPathObfuscatorTest.java
+++ b/src/test/java/team/washer/server/v2/global/config/swagger/SwaggerPathObfuscatorTest.java
@@ -1,0 +1,62 @@
+package team.washer.server.v2.global.config.swagger;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.mock.env.MockEnvironment;
+
+@DisplayName("SwaggerPathObfuscator 클래스의")
+class SwaggerPathObfuscatorTest {
+
+    private final SwaggerPathObfuscator swaggerPathObfuscator = new SwaggerPathObfuscator();
+
+    @Nested
+    @DisplayName("postProcessEnvironment 메서드는")
+    class Describe_postProcessEnvironment {
+
+        @Nested
+        @DisplayName("prod 프로파일이 활성화된 경우")
+        class Context_with_prod_profile {
+
+            @Test
+            @DisplayName("springdoc 경로를 랜덤 시크릿이 포함된 경로로 난독화해야 한다")
+            void it_obfuscates_swagger_paths() {
+                // Given
+                var environment = new MockEnvironment();
+                environment.setActiveProfiles("prod");
+
+                // When
+                swaggerPathObfuscator.postProcessEnvironment(environment, new SpringApplication());
+
+                // Then
+                var apiDocsPath = environment.getProperty("springdoc.api-docs.path");
+                var swaggerUiPath = environment.getProperty("springdoc.swagger-ui.path");
+                assertThat(apiDocsPath).matches("/[0-9a-f]{8}/v3/api-docs");
+                assertThat(swaggerUiPath).matches("/[0-9a-f]{8}/swagger-ui\\.html");
+            }
+        }
+
+        @Nested
+        @DisplayName("prod 프로파일이 아닌 경우")
+        class Context_without_prod_profile {
+
+            @Test
+            @DisplayName("springdoc 경로를 변경하지 않아야 한다")
+            void it_does_not_change_paths() {
+                // Given
+                var environment = new MockEnvironment();
+                environment.setActiveProfiles("local");
+
+                // When
+                swaggerPathObfuscator.postProcessEnvironment(environment, new SpringApplication());
+
+                // Then
+                assertThat(environment.getProperty("springdoc.api-docs.path")).isNull();
+                assertThat(environment.getProperty("springdoc.swagger-ui.path")).isNull();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

자동 동기화 스케줄러와 별개로 관리자가 임의 시점에 SmartThings 기기 목록 동기화를 촉발할 수 있는 엔드포인트를 추가했습니다. 또한 prod 환경에서 Swagger 문서 경로를 부팅마다 랜덤 시크릿 경로로 난독화하고 변경된 경로를 Discord로 통지하는 기능을 추가했습니다.

## 본문

### 1. 기기 목록 수동 동기화 엔드포인트
- `POST /api/v2/admin/smartthings/devices/sync` 신규 추가 (`AdminSmartThingsDeviceController`)
- 오발 방지를 위해 본문의 **확인 키 값이 `true`가 아니면**(`null`/`false` 포함) `ExpectedException(400)` 발생
  ```json
  { "정말 실행하시겠습니까 이 작업은 SmartThings 전체 기기 목록을 즉시 재동기화하며 누락된 기기를 비활성화하는 결과를 촉발합니다": true }
  ```
- 확인 통과 시 서비스에서 **3초 대기** 후 기존 `SyncSmartThingsDevicesService.execute()`에 위임 (동기화 본체 로직은 재사용)
- 인증 정책: `/api/v2/admin/smartthings/**`는 OAuth 콜백 때문에 이미 `permitAll`이며, 확인 키가 실질적 가드 역할

### 2. prod Swagger 경로 난독화 + Discord 통지
- `SwaggerPathObfuscator`(`EnvironmentPostProcessor`): prod 프로파일에서만 부팅마다 8자리 hex 시크릿을 생성해 `springdoc.api-docs.path` / `springdoc.swagger-ui.path`를 `/{secret}/...`로 주입 (`META-INF/spring.factories`로 등록)
- `DomainAuthorizationConfig`: 하드코딩된 Swagger 경로 대신 `Environment`에서 해석된 경로를 동적으로 `permitAll` (비prod는 기본값 유지로 회귀 없음)
- `ObfuscatedSwaggerPathNotifier`(`@Profile("prod")`, `ApplicationReadyEvent`): 적용된 경로를 `WARNING` 임베드로 Discord 웹훅 전송, 전송 실패는 흡수
- Spring Boot 4 대응: deprecated된 `org.springframework.boot.env.EnvironmentPostProcessor` 대신 `org.springframework.boot.EnvironmentPostProcessor` 사용

### 테스트
- `TriggerManualDeviceSyncServiceTest`: true→3초 후 실행 / false·null→400+미실행
- `SwaggerPathObfuscatorTest`: prod→경로 난독화 / 비prod→무변경
- `./gradlew spotlessApply` 후 전체 테스트 통과

> ⚠️ prod 실엔드투엔드(실제 기동 후 난독 경로 접근/Discord 수신)는 로컬에서 원격 mysql/redis 의존으로 확인하지 못했습니다. 실배포 환경에서 부팅 로그(`obfuscated swagger paths ...`)와 Discord 임베드로 최종 확인이 필요합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
