### PR TITLE
[auth] Refresh Token 조회 실패 수정

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/auth/entity/redis/RefreshTokenEntity.java
+++ b/src/main/java/team/washer/server/v2/domain/auth/entity/redis/RefreshTokenEntity.java
@@ -3,6 +3,7 @@ package team.washer.server.v2.domain.auth.entity.redis;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
+import org.springframework.data.redis.core.index.Indexed;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,6 +20,7 @@ public class RefreshTokenEntity {
     @Id
     private Long userId;
 
+    @Indexed
     private String token;
 
     @TimeToLive

--- a/src/main/java/team/washer/server/v2/global/config/RedisConfig.java
+++ b/src/main/java/team/washer/server/v2/global/config/RedisConfig.java
@@ -1,0 +1,17 @@
+package team.washer.server.v2.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+/**
+ * Redis 리포지토리 설정.
+ *
+ * <p>
+ * {@code @Indexed} 보조 인덱스를 사용하는 엔티티가 TTL로 만료될 때, keyspace 만료 이벤트를 수신하여 보조 인덱스를
+ * 함께 정리하도록 한다. 이 설정이 없으면 만료된 엔티티의 보조 인덱스 Set이 정리되지 않아 메모리 누수가 발생할 수 있다.
+ */
+@Configuration
+@EnableRedisRepositories(basePackages = "team.washer.server.v2", enableKeyspaceEvents = EnableKeyspaceEvents.ON_STARTUP)
+public class RedisConfig {
+}


### PR DESCRIPTION
## 개요

로그인 직후 발급받은 Refresh Token으로 토큰을 갱신할 수 없던 문제를 수정했습니다. 모든 Refresh Token 갱신 요청이 401로 실패하던 버그를 해결합니다.

## 본문

### 작업 이유
`RefreshTokenServiceImpl`은 `RefreshTokenRedisRepository.findByToken(token)`으로 저장된 Refresh Token을 조회합니다. 그러나 Spring Data Redis에서 `@Id`가 아닌 필드로 파생 쿼리를 수행하려면 해당 필드에 secondary index가 존재해야 합니다.

`RefreshTokenEntity.token` 필드에 `@Indexed`가 누락되어 있어 인덱스가 생성되지 않았고, 그 결과 `findByToken`이 항상 빈 `Optional`을 반환하여 정상적으로 발급된 토큰조차 `유효하지 않은 Refresh Token입니다.` (401) 예외로 실패했습니다.

### 구현 방식
- `RefreshTokenEntity.token` 필드에 `@Indexed`를 추가하여 `findByToken` 조회용 secondary index가 생성되도록 했습니다.

### 현재 상태
인덱스가 정상 생성되어 Refresh Token 갱신 플로우가 의도대로 동작합니다.

> ⚠️ 적용 전 Redis에 저장된 기존 토큰들은 인덱스가 없으므로, 배포 후 사용자는 한 번 다시 로그인해야 갱신이 동작합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
