### PR TITLE
[reservation] 관리자 예약 조회 시 기기별 최신 예약만 반환하도록 수정

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
@@ -14,10 +14,12 @@ import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.reservation.entity.QReservation;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.custom.ReservationRepositoryCustom;
@@ -113,25 +115,24 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
             MachineType machineType,
             Pageable pageable) {
 
+        QReservation latestReservation = new QReservation("latestReservation");
+
+        final var latestReservationIds = JPAExpressions.select(latestReservation.id.max()).from(latestReservation)
+                .where(StringUtils.hasText(userName) ? latestReservation.user.name.contains(userName) : null,
+                        StringUtils.hasText(machineName) ? latestReservation.machine.name.contains(machineName) : null,
+                        startDate != null ? latestReservation.startTime.goe(startDate) : null,
+                        endDate != null ? latestReservation.startTime.loe(endDate) : null,
+                        machineType != null ? latestReservation.machine.type.eq(machineType) : null)
+                .groupBy(latestReservation.machine.id);
+
         final var content = jpaQueryFactory.selectFrom(reservation).leftJoin(reservation.user, user).fetchJoin()
                 .leftJoin(reservation.machine, machine).fetchJoin()
-                .where(userNameContains(userName),
-                        machineNameContains(machineName),
-                        statusEquals(status),
-                        startTimeAfter(startDate),
-                        startTimeBefore(endDate),
-                        machineTypeEquals(machineType))
+                .where(reservation.id.in(latestReservationIds), statusEquals(status))
                 .orderBy(reservation.createdAt.desc()).offset(pageable.getOffset()).limit(pageable.getPageSize())
                 .fetch();
 
         final var total = jpaQueryFactory.select(reservation.count()).from(reservation)
-                .where(userNameContains(userName),
-                        machineNameContains(machineName),
-                        statusEquals(status),
-                        startTimeAfter(startDate),
-                        startTimeBefore(endDate),
-                        machineTypeEquals(machineType))
-                .fetchOne();
+                .where(reservation.id.in(latestReservationIds), statusEquals(status)).fetchOne();
 
         final var count = total != null ? total : 0L;
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
@@ -28,15 +28,17 @@ import team.washer.server.v2.domain.reservation.repository.custom.ReservationRep
 @RequiredArgsConstructor
 public class ReservationRepositoryCustomImpl implements ReservationRepositoryCustom {
 
+    private static final QReservation latestReservation = new QReservation("latestReservation");
+
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
     public Page<Reservation> findReservationHistory(Long userId,
-            ReservationStatus status,
-            LocalDateTime startDate,
-            LocalDateTime endDate,
-            MachineType machineType,
-            Pageable pageable) {
+                                                    ReservationStatus status,
+                                                    LocalDateTime startDate,
+                                                    LocalDateTime endDate,
+                                                    MachineType machineType,
+                                                    Pageable pageable) {
 
         List<Reservation> results = jpaQueryFactory.selectFrom(reservation).leftJoin(reservation.user, user).fetchJoin()
                 .leftJoin(reservation.machine, machine).fetchJoin()
@@ -63,9 +65,9 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 
     @Override
     public boolean existsConflictingReservation(Long machineId,
-            LocalDateTime startTime,
-            LocalDateTime endTime,
-            Long excludeReservationId) {
+                                                LocalDateTime startTime,
+                                                LocalDateTime endTime,
+                                                Long excludeReservationId) {
 
         return jpaQueryFactory.selectFrom(reservation)
                 .where(reservation.machine.id.eq(machineId),
@@ -96,8 +98,8 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 
     @Override
     public List<Reservation> findExpiredReservations(ReservationStatus status,
-            LocalDateTime threshold,
-            LocalDateTime recentCutoff) {
+                                                     LocalDateTime threshold,
+                                                     LocalDateTime recentCutoff) {
 
         return jpaQueryFactory.selectFrom(reservation)
                 .where(reservation.status.eq(status),
@@ -114,8 +116,6 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
                                                 LocalDateTime endDate,
                                                 MachineType machineType,
                                                 Pageable pageable) {
-
-        QReservation latestReservation = new QReservation("latestReservation");
 
         final var latestReservationIds = JPAExpressions.select(latestReservation.id.max()).from(latestReservation)
                 .where(StringUtils.hasText(userName) ? latestReservation.user.name.contains(userName) : null,
@@ -143,10 +143,10 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 
     @Override
     public Page<Reservation> findMachineReservationHistory(Long machineId,
-            ReservationStatus status,
-            LocalDateTime startDate,
-            LocalDateTime endDate,
-            Pageable pageable) {
+                                                           ReservationStatus status,
+                                                           LocalDateTime startDate,
+                                                           LocalDateTime endDate,
+                                                           Pageable pageable) {
 
         List<Reservation> results = jpaQueryFactory.selectFrom(reservation).leftJoin(reservation.user, user).fetchJoin()
                 .leftJoin(reservation.machine, machine).fetchJoin()

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
@@ -108,18 +108,19 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 
     @Override
     public Page<Reservation> findAllWithFilters(String userName,
-            String machineName,
-            ReservationStatus status,
-            LocalDateTime startDate,
-            LocalDateTime endDate,
-            MachineType machineType,
-            Pageable pageable) {
+                                                String machineName,
+                                                ReservationStatus status,
+                                                LocalDateTime startDate,
+                                                LocalDateTime endDate,
+                                                MachineType machineType,
+                                                Pageable pageable) {
 
         QReservation latestReservation = new QReservation("latestReservation");
 
         final var latestReservationIds = JPAExpressions.select(latestReservation.id.max()).from(latestReservation)
                 .where(StringUtils.hasText(userName) ? latestReservation.user.name.contains(userName) : null,
                         StringUtils.hasText(machineName) ? latestReservation.machine.name.contains(machineName) : null,
+                        status != null ? latestReservation.status.eq(status) : null,
                         startDate != null ? latestReservation.startTime.goe(startDate) : null,
                         endDate != null ? latestReservation.startTime.loe(endDate) : null,
                         machineType != null ? latestReservation.machine.type.eq(machineType) : null)
@@ -127,12 +128,13 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 
         final var content = jpaQueryFactory.selectFrom(reservation).leftJoin(reservation.user, user).fetchJoin()
                 .leftJoin(reservation.machine, machine).fetchJoin()
-                .where(reservation.id.in(latestReservationIds), statusEquals(status))
+                .where(reservation.id.in(latestReservationIds))
                 .orderBy(reservation.createdAt.desc()).offset(pageable.getOffset()).limit(pageable.getPageSize())
                 .fetch();
 
         final var total = jpaQueryFactory.select(reservation.count()).from(reservation)
-                .where(reservation.id.in(latestReservationIds), statusEquals(status)).fetchOne();
+                .where(reservation.id.in(latestReservationIds))
+                .fetchOne();
 
         final var count = total != null ? total : 0L;
 


### PR DESCRIPTION
## 개요

관리자 예약 조회 API `/api/v2/admin/reservations`에서 동일한 기기의 예약 이력이 모두 반환되던 문제를 수정했습니다.

## 본문

기존에는 하나의 기기에 대해 `RESERVED`, `RUNNING`, `COMPLETED` 등의 상태 이력이 모두 조회되어 관리자 화면에서 동일 기기가 중복 노출되었습니다. 이를 해결하기 위해 기기별 최신 예약 데이터만 조회하도록 QueryDSL 쿼리를 수정했습니다.