### PR TITLE
[smartthings] SmartThings 액세스 토큰 조회 API 추가

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/smartthings/controller/SmartThingsTokenController.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/controller/SmartThingsTokenController.java
@@ -1,0 +1,32 @@
+package team.washer.server.v2.domain.smartthings.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsAccessTokenResDto;
+import team.washer.server.v2.domain.smartthings.service.QuerySmartThingsAccessTokenService;
+
+/**
+ * SmartThings 토큰 조회 컨트롤러
+ *
+ * <p>
+ * 인증된 사용자가 현재 유효한 SmartThings 액세스 토큰을 조회할 수 있습니다.
+ */
+@RestController
+@RequestMapping("/api/v2/smartthings/token")
+@RequiredArgsConstructor
+@Tag(name = "SmartThings Token", description = "SmartThings 토큰 API")
+public class SmartThingsTokenController {
+
+    private final QuerySmartThingsAccessTokenService querySmartThingsAccessTokenService;
+
+    @GetMapping
+    @Operation(summary = "SmartThings 액세스 토큰 조회", description = "현재 유효한 SmartThings 액세스 토큰과 만료 시각을 반환합니다. 인증된 사용자만 접근할 수 있습니다.")
+    public SmartThingsAccessTokenResDto getAccessToken() {
+        return querySmartThingsAccessTokenService.execute();
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsAccessTokenResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsAccessTokenResDto.java
@@ -1,0 +1,15 @@
+package team.washer.server.v2.domain.smartthings.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * SmartThings 액세스 토큰 조회 응답 DTO
+ */
+@Schema(description = "SmartThings 액세스 토큰 조회 응답")
+public record SmartThingsAccessTokenResDto(
+        @Schema(description = "SmartThings 액세스 토큰", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...") String accessToken,
+
+        @Schema(description = "토큰 만료 시각") LocalDateTime expiresAt) {
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/service/QuerySmartThingsAccessTokenService.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/service/QuerySmartThingsAccessTokenService.java
@@ -1,0 +1,11 @@
+package team.washer.server.v2.domain.smartthings.service;
+
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsAccessTokenResDto;
+
+/**
+ * 현재 유효한 SmartThings 액세스 토큰을 조회하는 서비스
+ */
+public interface QuerySmartThingsAccessTokenService {
+
+    SmartThingsAccessTokenResDto execute();
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/QuerySmartThingsAccessTokenServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/QuerySmartThingsAccessTokenServiceImpl.java
@@ -1,0 +1,38 @@
+package team.washer.server.v2.domain.smartthings.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsAccessTokenResDto;
+import team.washer.server.v2.domain.smartthings.repository.SmartThingsTokenRepository;
+import team.washer.server.v2.domain.smartthings.service.QuerySmartThingsAccessTokenService;
+
+/**
+ * SmartThings 액세스 토큰 조회 서비스 구현체
+ *
+ * <p>
+ * 단일 토큰을 조회하여 유효성을 검증한 뒤 액세스 토큰과 만료 시각을 반환한다. 토큰이 없거나 만료된 경우 예외를 발생시킨다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class QuerySmartThingsAccessTokenServiceImpl implements QuerySmartThingsAccessTokenService {
+
+    private final SmartThingsTokenRepository tokenRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public SmartThingsAccessTokenResDto execute() {
+        final var token = tokenRepository.findSingletonToken()
+                .orElseThrow(() -> new ExpectedException("SmartThings 토큰이 존재하지 않습니다", HttpStatus.NOT_FOUND));
+        if (!token.isValid()) {
+            throw new ExpectedException("SmartThings 토큰이 만료되었거나 유효하지 않습니다", HttpStatus.NOT_FOUND);
+        }
+        log.info("smartthings access token queried expiresAt={}", token.getExpiresAt());
+        return new SmartThingsAccessTokenResDto(token.getAccessToken(), token.getExpiresAt());
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/smartthings/service/QuerySmartThingsAccessTokenServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/service/QuerySmartThingsAccessTokenServiceTest.java
@@ -1,0 +1,104 @@
+package team.washer.server.v2.domain.smartthings.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.smartthings.entity.SmartThingsToken;
+import team.washer.server.v2.domain.smartthings.repository.SmartThingsTokenRepository;
+import team.washer.server.v2.domain.smartthings.service.impl.QuerySmartThingsAccessTokenServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("QuerySmartThingsAccessTokenServiceImpl 클래스의")
+class QuerySmartThingsAccessTokenServiceTest {
+
+    @InjectMocks
+    private QuerySmartThingsAccessTokenServiceImpl querySmartThingsAccessTokenService;
+
+    @Mock
+    private SmartThingsTokenRepository smartThingsTokenRepository;
+
+    private SmartThingsToken createValidToken() {
+        return SmartThingsToken.builder().accessToken("valid-access").refreshToken("valid-refresh")
+                .expiresAt(LocalDateTime.now().plusHours(2)).build();
+    }
+
+    private SmartThingsToken createExpiredToken() {
+        return SmartThingsToken.builder().accessToken("expired-access").refreshToken("expired-refresh")
+                .expiresAt(LocalDateTime.now().minusMinutes(1)).build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("유효한 토큰이 있을 때")
+        class Context_with_valid_token {
+
+            @Test
+            @DisplayName("액세스 토큰과 만료 시각을 반환해야 한다")
+            void it_returns_access_token() {
+                // Given
+                var validToken = createValidToken();
+                given(smartThingsTokenRepository.findSingletonToken()).willReturn(Optional.of(validToken));
+
+                // When
+                var result = querySmartThingsAccessTokenService.execute();
+
+                // Then
+                assertThat(result.accessToken()).isEqualTo("valid-access");
+                assertThat(result.expiresAt()).isEqualTo(validToken.getExpiresAt());
+            }
+        }
+
+        @Nested
+        @DisplayName("저장된 토큰이 없을 때")
+        class Context_with_no_token {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 NOT_FOUND 상태를 반환해야 한다")
+            void it_throws_not_found_exception() {
+                // Given
+                given(smartThingsTokenRepository.findSingletonToken()).willReturn(Optional.empty());
+
+                // When & Then
+                assertThatThrownBy(() -> querySmartThingsAccessTokenService.execute())
+                        .isInstanceOf(ExpectedException.class).hasMessage("SmartThings 토큰이 존재하지 않습니다")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.NOT_FOUND));
+            }
+        }
+
+        @Nested
+        @DisplayName("토큰이 만료되었을 때")
+        class Context_with_expired_token {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 NOT_FOUND 상태를 반환해야 한다")
+            void it_throws_not_found_exception() {
+                // Given
+                var expiredToken = createExpiredToken();
+                given(smartThingsTokenRepository.findSingletonToken()).willReturn(Optional.of(expiredToken));
+
+                // When & Then
+                assertThatThrownBy(() -> querySmartThingsAccessTokenService.execute())
+                        .isInstanceOf(ExpectedException.class).hasMessage("SmartThings 토큰이 만료되었거나 유효하지 않습니다")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.NOT_FOUND));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요
인증된 사용자가 현재 유효한 SmartThings 액세스 토큰을 조회할 수 있는 신규 API를 추가했습니다.

## 변경 사항
- `GET /api/v2/smartthings/token` 엔드포인트 추가 (`SmartThingsTokenController`)
- 단일 책임 서비스 `QuerySmartThingsAccessTokenService` + 구현체 추가
- 응답 DTO `SmartThingsAccessTokenResDto` (accessToken, expiresAt) 추가
- 서비스 단위 테스트 추가 (유효 토큰 / 토큰 없음 / 만료 케이스)

## 인증
- 별도 권한 규칙 없이 `anyRequest().authenticated()`에 적용되어 **인증된 사용자만** 접근 가능합니다.

## 동작
- 단일 SmartThings 토큰 조회 후 유효성 검증
- 토큰 미존재 또는 만료 시 `404 NOT_FOUND` 반환

## 참고
이 엔드포인트는 인증된 모든 사용자에게 SmartThings 액세스 토큰을 노출합니다. 특정 권한(예: 관리자)으로 제한이 필요한 경우 별도 논의가 필요합니다.

## 테스트
- `QuerySmartThingsAccessTokenServiceTest` 통과 (failures=0, errors=0)
- `./gradlew compileJava`, `spotlessApply` 통과