### PR TITLE
[user] 예약 시간 제한 변경 및 DataGSM 역할 연동

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
@@ -34,11 +34,11 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 
     @Override
     public Page<Reservation> findReservationHistory(Long userId,
-                                                    ReservationStatus status,
-                                                    LocalDateTime startDate,
-                                                    LocalDateTime endDate,
-                                                    MachineType machineType,
-                                                    Pageable pageable) {
+            ReservationStatus status,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            MachineType machineType,
+            Pageable pageable) {
 
         List<Reservation> results = jpaQueryFactory.selectFrom(reservation).leftJoin(reservation.user, user).fetchJoin()
                 .leftJoin(reservation.machine, machine).fetchJoin()
@@ -65,9 +65,9 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 
     @Override
     public boolean existsConflictingReservation(Long machineId,
-                                                LocalDateTime startTime,
-                                                LocalDateTime endTime,
-                                                Long excludeReservationId) {
+            LocalDateTime startTime,
+            LocalDateTime endTime,
+            Long excludeReservationId) {
 
         return jpaQueryFactory.selectFrom(reservation)
                 .where(reservation.machine.id.eq(machineId),
@@ -98,8 +98,8 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 
     @Override
     public List<Reservation> findExpiredReservations(ReservationStatus status,
-                                                     LocalDateTime threshold,
-                                                     LocalDateTime recentCutoff) {
+            LocalDateTime threshold,
+            LocalDateTime recentCutoff) {
 
         return jpaQueryFactory.selectFrom(reservation)
                 .where(reservation.status.eq(status),
@@ -110,12 +110,12 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 
     @Override
     public Page<Reservation> findAllWithFilters(String userName,
-                                                String machineName,
-                                                ReservationStatus status,
-                                                LocalDateTime startDate,
-                                                LocalDateTime endDate,
-                                                MachineType machineType,
-                                                Pageable pageable) {
+            String machineName,
+            ReservationStatus status,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            MachineType machineType,
+            Pageable pageable) {
 
         final var latestReservationIds = JPAExpressions.select(latestReservation.id.max()).from(latestReservation)
                 .where(StringUtils.hasText(userName) ? latestReservation.user.name.contains(userName) : null,
@@ -127,14 +127,12 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
                 .groupBy(latestReservation.machine.id);
 
         final var content = jpaQueryFactory.selectFrom(reservation).leftJoin(reservation.user, user).fetchJoin()
-                .leftJoin(reservation.machine, machine).fetchJoin()
-                .where(reservation.id.in(latestReservationIds))
+                .leftJoin(reservation.machine, machine).fetchJoin().where(reservation.id.in(latestReservationIds))
                 .orderBy(reservation.createdAt.desc()).offset(pageable.getOffset()).limit(pageable.getPageSize())
                 .fetch();
 
         final var total = jpaQueryFactory.select(reservation.count()).from(reservation)
-                .where(reservation.id.in(latestReservationIds))
-                .fetchOne();
+                .where(reservation.id.in(latestReservationIds)).fetchOne();
 
         final var count = total != null ? total : 0L;
 
@@ -143,10 +141,10 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
 
     @Override
     public Page<Reservation> findMachineReservationHistory(Long machineId,
-                                                           ReservationStatus status,
-                                                           LocalDateTime startDate,
-                                                           LocalDateTime endDate,
-                                                           Pageable pageable) {
+            ReservationStatus status,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            Pageable pageable) {
 
         List<Reservation> results = jpaQueryFactory.selectFrom(reservation).leftJoin(reservation.user, user).fetchJoin()
                 .leftJoin(reservation.machine, machine).fetchJoin()

--- a/src/main/java/team/washer/server/v2/domain/user/entity/User.java
+++ b/src/main/java/team/washer/server/v2/domain/user/entity/User.java
@@ -260,4 +260,17 @@ public class User extends BaseEntity {
             this.floor = floor;
         }
     }
+
+    /**
+     * 일반 사용자를 기숙사자치위원회로 승격합니다. 이미 기숙사자치위원회이거나 관리자인 경우 권한을 변경하지 않습니다.
+     *
+     * @return 실제로 승격이 이루어지면 true, 권한 변경이 없으면 false
+     */
+    public boolean promoteToDormitoryCouncil() {
+        if (this.role != UserRole.USER) {
+            return false;
+        }
+        this.role = UserRole.DORMITORY_COUNCIL;
+        return true;
+    }
 }

--- a/src/main/java/team/washer/server/v2/domain/user/entity/User.java
+++ b/src/main/java/team/washer/server/v2/domain/user/entity/User.java
@@ -169,8 +169,8 @@ public class User extends BaseEntity {
     /**
      * 예약 시간에 대한 시간 제한 규칙을 검증합니다. 규칙을 위반하면 예외를 발생시킵니다.
      * <p>
-     * 월~목, 일요일은 학년별 예약 가능 시작 시각이 적용됩니다. 금요일과 토요일은 제한 없이 예약 가능합니다. 기숙사자치위원회 및 관리자는
-     * 시간 제한을 우회합니다.
+     * 월~목은 전 학년 공통 시작 시각이, 일요일은 학년별 시작 시각이 적용됩니다. 금요일과 토요일은 제한 없이 예약 가능합니다.
+     * 기숙사자치위원회 및 관리자는 시간 제한을 우회합니다.
      *
      * @param startTime
      *            예약 시작 시간
@@ -184,11 +184,17 @@ public class User extends BaseEntity {
         final LocalTime time = startTime.toLocalTime();
 
         switch (dayOfWeek) {
-            case MONDAY, TUESDAY, WEDNESDAY, THURSDAY, SUNDAY -> {
-                final LocalTime gradeStartTime = resolveGradeStartTime();
-                if (time.isBefore(gradeStartTime)) {
+            case MONDAY, TUESDAY, WEDNESDAY, THURSDAY -> {
+                if (time.isBefore(TimeRestrictionConstants.WEEKDAY_START_TIME)) {
                     throw new ExpectedException(
-                            String.format("%d학년은 %s 이후에만 예약할 수 있습니다", this.grade, gradeStartTime.toString()),
+                            String.format("%s 이후에만 예약할 수 있습니다", TimeRestrictionConstants.WEEKDAY_START_TIME),
+                            HttpStatus.BAD_REQUEST);
+                }
+            }
+            case SUNDAY -> {
+                final LocalTime gradeStartTime = resolveSundayGradeStartTime();
+                if (time.isBefore(gradeStartTime)) {
+                    throw new ExpectedException(String.format("%d학년은 %s 이후에만 예약할 수 있습니다", this.grade, gradeStartTime),
                             HttpStatus.BAD_REQUEST);
                 }
             }
@@ -198,15 +204,15 @@ public class User extends BaseEntity {
     }
 
     /**
-     * 학년에 따른 예약 가능 시작 시각을 반환합니다.
+     * 일요일 학년에 따른 예약 가능 시작 시각을 반환합니다.
      *
-     * @return 학년별 예약 시작 시각
+     * @return 일요일 학년별 예약 시작 시각
      */
-    private LocalTime resolveGradeStartTime() {
+    private LocalTime resolveSundayGradeStartTime() {
         return switch (this.grade) {
-            case 1 -> TimeRestrictionConstants.GRADE_1_START_TIME;
-            case 2 -> TimeRestrictionConstants.GRADE_2_START_TIME;
-            default -> TimeRestrictionConstants.GRADE_3_START_TIME;
+            case 1 -> TimeRestrictionConstants.SUNDAY_GRADE_1_START_TIME;
+            case 2 -> TimeRestrictionConstants.SUNDAY_GRADE_2_START_TIME;
+            default -> TimeRestrictionConstants.SUNDAY_GRADE_3_START_TIME;
         };
     }
 

--- a/src/main/java/team/washer/server/v2/domain/user/listener/DormitoryCouncilRoleSyncListener.java
+++ b/src/main/java/team/washer/server/v2/domain/user/listener/DormitoryCouncilRoleSyncListener.java
@@ -1,0 +1,36 @@
+package team.washer.server.v2.domain.user.listener;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.user.service.SyncDormitoryCouncilRoleService;
+
+/**
+ * 애플리케이션 기동 완료 시 기숙사자치위원회 권한을 1회 동기화하는 백필 리스너.
+ * <p>
+ * 회원가입 시점의 DataGSM 역할 매핑이 도입되기 전에 가입해 일반 사용자로 등록된 기존 기자위 학생을 보정하기 위한 일회성 코드입니다.
+ * 멱등하게 동작하므로 재기동마다 안전하게 재실행되며, 운영 환경에서 한 번 정상 실행된 이후에는 제거해야 합니다.
+ *
+ * @deprecated 일회성 백필 용도이므로 운영 1회 실행 후 클래스 전체를 삭제할 것
+ */
+@Deprecated
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DormitoryCouncilRoleSyncListener {
+
+    private final SyncDormitoryCouncilRoleService syncDormitoryCouncilRoleService;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void syncDormitoryCouncilRoleOnStartup() {
+        try {
+            final int promoted = syncDormitoryCouncilRoleService.execute();
+            log.info("startup dormitory council role sync done promoted={}", promoted);
+        } catch (Exception e) {
+            log.error("startup dormitory council role sync failed", e);
+        }
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/user/repository/UserRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package team.washer.server.v2.domain.user.repository;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -10,12 +11,15 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.enums.UserRole;
 import team.washer.server.v2.domain.user.repository.custom.UserRepositoryCustom;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
 
     Optional<User> findByStudentId(String studentId);
+
+    List<User> findByRoleAndStudentIdIn(UserRole role, Collection<String> studentIds);
 
     boolean existsByStudentId(String studentId);
 

--- a/src/main/java/team/washer/server/v2/domain/user/service/SyncDormitoryCouncilRoleService.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/SyncDormitoryCouncilRoleService.java
@@ -1,0 +1,14 @@
+package team.washer.server.v2.domain.user.service;
+
+// TODO: 현재 유일한 호출부는 일회성 백필 리스너(DormitoryCouncilRoleSyncListener, @Deprecated)다.
+// 리스너 제거 시 이 서비스(및 DataGsmOpenApiClient)도 함께 삭제하거나 관리자용 수동 동기화 엔드포인트로 재구성할 것.
+public interface SyncDormitoryCouncilRoleService {
+
+    /**
+     * DataGSM OpenAPI에서 기숙사 관리(DORMITORY_MANAGER) 역할 학생을 조회해 일치하는 일반 사용자를 기숙사자치위원회로
+     * 승격합니다.
+     *
+     * @return 실제로 승격된 사용자 수
+     */
+    int execute();
+}

--- a/src/main/java/team/washer/server/v2/domain/user/service/impl/SyncDormitoryCouncilRoleServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/impl/SyncDormitoryCouncilRoleServiceImpl.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,21 +28,34 @@ public class SyncDormitoryCouncilRoleServiceImpl implements SyncDormitoryCouncil
     private final DataGsmOpenApiClient dataGsmOpenApiClient;
     private final DataGsmEnvironment dataGsmEnvironment;
     private final UserRepository userRepository;
+    private final TransactionTemplate transactionTemplate;
 
     @Override
-    @Transactional
     public int execute() {
         if (!dataGsmEnvironment.hasApiKey()) {
             log.warn("dormitory council role sync skipped reason=missing_api_key");
             return 0;
         }
 
+        // 외부 API 호출은 DB 커넥션 점유를 피하기 위해 트랜잭션 밖에서 수행한다.
         final Set<String> managerStudentIds = fetchDormitoryManagerStudentIds();
         if (managerStudentIds.isEmpty()) {
             log.info("dormitory council role sync no_targets fetched=0");
             return 0;
         }
 
+        final Integer promoted = transactionTemplate.execute(status -> promoteCandidates(managerStudentIds));
+        return promoted != null ? promoted : 0;
+    }
+
+    /**
+     * 학번 집합에 해당하는 일반 사용자를 기숙사자치위원회로 승격합니다. DB 조회와 수정만 트랜잭션 내에서 수행됩니다.
+     *
+     * @param managerStudentIds
+     *            기숙사 관리 역할 학생의 학번 집합
+     * @return 실제로 승격된 사용자 수
+     */
+    private int promoteCandidates(final Set<String> managerStudentIds) {
         final List<User> candidates = userRepository.findByRoleAndStudentIdIn(UserRole.USER, managerStudentIds);
         int promoted = 0;
         for (final User user : candidates) {
@@ -70,7 +83,8 @@ public class SyncDormitoryCouncilRoleServiceImpl implements SyncDormitoryCouncil
         do {
             final DataGsmStudentSearchResDto response = dataGsmOpenApiClient
                     .searchStudents(dataGsmEnvironment.apiKey(), DORMITORY_MANAGER_ROLE, true, page, PAGE_SIZE);
-            if (response == null || response.data() == null || response.data().students() == null) {
+            if (response == null || response.data() == null || response.data().students() == null
+                    || response.data().students().isEmpty()) {
                 break;
             }
             for (final DataGsmStudentSearchResDto.Student student : response.data().students()) {

--- a/src/main/java/team/washer/server/v2/domain/user/service/impl/SyncDormitoryCouncilRoleServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/impl/SyncDormitoryCouncilRoleServiceImpl.java
@@ -1,0 +1,87 @@
+package team.washer.server.v2.domain.user.service.impl;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.enums.UserRole;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.domain.user.service.SyncDormitoryCouncilRoleService;
+import team.washer.server.v2.global.thirdparty.datagsm.config.DataGsmEnvironment;
+import team.washer.server.v2.global.thirdparty.datagsm.dto.response.DataGsmStudentSearchResDto;
+import team.washer.server.v2.global.thirdparty.datagsm.feign.DataGsmOpenApiClient;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SyncDormitoryCouncilRoleServiceImpl implements SyncDormitoryCouncilRoleService {
+
+    private static final String DORMITORY_MANAGER_ROLE = "DORMITORY_MANAGER";
+    private static final int PAGE_SIZE = 300;
+
+    private final DataGsmOpenApiClient dataGsmOpenApiClient;
+    private final DataGsmEnvironment dataGsmEnvironment;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public int execute() {
+        if (!dataGsmEnvironment.hasApiKey()) {
+            log.warn("dormitory council role sync skipped reason=missing_api_key");
+            return 0;
+        }
+
+        final Set<String> managerStudentIds = fetchDormitoryManagerStudentIds();
+        if (managerStudentIds.isEmpty()) {
+            log.info("dormitory council role sync no_targets fetched=0");
+            return 0;
+        }
+
+        final List<User> candidates = userRepository.findByRoleAndStudentIdIn(UserRole.USER, managerStudentIds);
+        int promoted = 0;
+        for (final User user : candidates) {
+            if (user.promoteToDormitoryCouncil()) {
+                promoted++;
+            }
+        }
+
+        log.info("dormitory council role sync completed fetched={} candidates={} promoted={}",
+                managerStudentIds.size(),
+                candidates.size(),
+                promoted);
+        return promoted;
+    }
+
+    /**
+     * DataGSM OpenAPI를 페이지 단위로 순회하며 기숙사 관리 역할 학생의 학번을 수집합니다.
+     *
+     * @return 기숙사 관리 역할 학생의 학번 집합
+     */
+    private Set<String> fetchDormitoryManagerStudentIds() {
+        final Set<String> studentIds = new HashSet<>();
+        int page = 0;
+        int totalPages = 1;
+        do {
+            final DataGsmStudentSearchResDto response = dataGsmOpenApiClient
+                    .searchStudents(dataGsmEnvironment.apiKey(), DORMITORY_MANAGER_ROLE, true, page, PAGE_SIZE);
+            if (response == null || response.data() == null || response.data().students() == null) {
+                break;
+            }
+            for (final DataGsmStudentSearchResDto.Student student : response.data().students()) {
+                if (student.studentNumber() != null) {
+                    studentIds.add(student.studentNumber().toString());
+                }
+            }
+            final Integer responseTotalPages = response.data().totalPages();
+            totalPages = responseTotalPages != null ? responseTotalPages : page + 1;
+            page++;
+        } while (page < totalPages);
+        return studentIds;
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/user/support/UserRegistrationSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/user/support/UserRegistrationSupport.java
@@ -5,7 +5,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import team.themoment.datagsm.sdk.oauth.model.Student;
+import team.themoment.datagsm.sdk.oauth.model.StudentRole;
 import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.enums.UserRole;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 
 /**
@@ -24,8 +26,26 @@ public class UserRegistrationSupport {
     public User register(Student student) {
         User user = User.builder().studentId(student.getStudentNumber().toString()).name(student.getName())
                 .roomNumber(student.getDormitoryRoom().toString()).grade(student.getGrade())
-                .floor(student.getDormitoryFloor()).build();
+                .floor(student.getDormitoryFloor()).role(mapRole(student.getRole())).build();
         userRepository.save(user);
         return user;
+    }
+
+    /**
+     * DataGSM 학생 역할을 서비스 사용자 권한으로 변환합니다. 기숙사 관리는 기숙사자치위원회로 매핑되며, 학생회와 일반 학생 및 역할
+     * 미상은 일반 사용자로 매핑됩니다. 관리자 권한은 DataGSM에서 부여되지 않으며 별도로 지정합니다.
+     *
+     * @param role
+     *            DataGSM 학생 역할(null 가능)
+     * @return 매핑된 서비스 사용자 권한
+     */
+    private UserRole mapRole(final StudentRole role) {
+        if (role == null) {
+            return UserRole.USER;
+        }
+        return switch (role) {
+            case DORMITORY_MANAGER -> UserRole.DORMITORY_COUNCIL;
+            default -> UserRole.USER;
+        };
     }
 }

--- a/src/main/java/team/washer/server/v2/global/common/constants/TimeRestrictionConstants.java
+++ b/src/main/java/team/washer/server/v2/global/common/constants/TimeRestrictionConstants.java
@@ -6,12 +6,15 @@ public final class TimeRestrictionConstants {
     private TimeRestrictionConstants() {
     }
 
-    /** 1학년 예약 가능 시작 시각 */
-    public static final LocalTime GRADE_1_START_TIME = LocalTime.of(19, 50);
+    /** 월~목 예약 가능 시작 시각 (전 학년 공통) */
+    public static final LocalTime WEEKDAY_START_TIME = LocalTime.of(21, 20);
 
-    /** 2학년 예약 가능 시작 시각 */
-    public static final LocalTime GRADE_2_START_TIME = LocalTime.of(20, 10);
+    /** 일요일 1학년 예약 가능 시작 시각 */
+    public static final LocalTime SUNDAY_GRADE_1_START_TIME = LocalTime.of(20, 0);
 
-    /** 3학년 이상 예약 가능 시작 시각 */
-    public static final LocalTime GRADE_3_START_TIME = LocalTime.of(20, 30);
+    /** 일요일 2학년 예약 가능 시작 시각 */
+    public static final LocalTime SUNDAY_GRADE_2_START_TIME = LocalTime.of(20, 20);
+
+    /** 일요일 3학년 이상 예약 가능 시작 시각 */
+    public static final LocalTime SUNDAY_GRADE_3_START_TIME = LocalTime.of(20, 40);
 }

--- a/src/main/java/team/washer/server/v2/global/thirdparty/datagsm/config/DataGsmEnvironment.java
+++ b/src/main/java/team/washer/server/v2/global/thirdparty/datagsm/config/DataGsmEnvironment.java
@@ -3,7 +3,7 @@ package team.washer.server.v2.global.thirdparty.datagsm.config;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "third-party.datagsm")
-public record DataGsmEnvironment(String clientId, String clientSecret, String redirectUri) {
+public record DataGsmEnvironment(String clientId, String clientSecret, String redirectUri, String apiKey) {
     public DataGsmEnvironment {
         if (clientSecret == null || clientSecret.isBlank()) {
             throw new IllegalArgumentException("DataGsm OAuth Client Secret is required");
@@ -14,5 +14,14 @@ public record DataGsmEnvironment(String clientId, String clientSecret, String re
         if (redirectUri == null || redirectUri.isBlank()) {
             throw new IllegalArgumentException("DataGsm OAuth Redirect URI is required");
         }
+    }
+
+    /**
+     * OpenAPI 호출용 API 키가 설정되어 있는지 여부를 반환합니다.
+     *
+     * @return API 키가 존재하면 true
+     */
+    public boolean hasApiKey() {
+        return apiKey != null && !apiKey.isBlank();
     }
 }

--- a/src/main/java/team/washer/server/v2/global/thirdparty/datagsm/dto/response/DataGsmStudentSearchResDto.java
+++ b/src/main/java/team/washer/server/v2/global/thirdparty/datagsm/dto/response/DataGsmStudentSearchResDto.java
@@ -1,0 +1,29 @@
+package team.washer.server.v2.global.thirdparty.datagsm.dto.response;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * DataGSM OpenAPI 학생 목록 조회 응답 DTO
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DataGsmStudentSearchResDto(@JsonProperty("status") String status, @JsonProperty("code") Integer code,
+        @JsonProperty("message") String message, @JsonProperty("data") Data data) {
+
+    /**
+     * 페이지네이션 메타데이터와 학생 목록을 담는 데이터 항목
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Data(@JsonProperty("totalPages") Integer totalPages,
+            @JsonProperty("totalElements") Long totalElements, @JsonProperty("students") List<Student> students) {
+    }
+
+    /**
+     * 승격 판단에 필요한 학생 정보(학번, 역할)
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Student(@JsonProperty("studentNumber") Integer studentNumber, @JsonProperty("role") String role) {
+    }
+}

--- a/src/main/java/team/washer/server/v2/global/thirdparty/datagsm/feign/DataGsmOpenApiClient.java
+++ b/src/main/java/team/washer/server/v2/global/thirdparty/datagsm/feign/DataGsmOpenApiClient.java
@@ -1,0 +1,20 @@
+package team.washer.server.v2.global.thirdparty.datagsm.feign;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import team.washer.server.v2.global.thirdparty.datagsm.dto.response.DataGsmStudentSearchResDto;
+
+@FeignClient(name = "datagsm-openapi", url = "${third-party.datagsm.openapi-url:https://openapi.datagsm.kr}")
+public interface DataGsmOpenApiClient {
+
+    @GetMapping(value = "/v1/students", produces = MediaType.APPLICATION_JSON_VALUE)
+    DataGsmStudentSearchResDto searchStudents(@RequestHeader("X-API-KEY") String apiKey,
+            @RequestParam("role") String role,
+            @RequestParam("onlyEnrolled") boolean onlyEnrolled,
+            @RequestParam("page") int page,
+            @RequestParam("size") int size);
+}

--- a/src/main/java/team/washer/server/v2/global/thirdparty/feign/config/FeignConfig.java
+++ b/src/main/java/team/washer/server/v2/global/thirdparty/feign/config/FeignConfig.java
@@ -11,7 +11,7 @@ import feign.jackson.JacksonEncoder;
 import team.washer.server.v2.global.thirdparty.feign.error.FeignErrorDecoder;
 
 @EnableFeignClients(basePackages = {"team.washer.server.v2.global.thirdparty.feign",
-        "team.washer.server.v2.global.thirdparty.smartthings"})
+        "team.washer.server.v2.global.thirdparty.smartthings", "team.washer.server.v2.global.thirdparty.datagsm"})
 @Configuration
 public class FeignConfig {
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,8 @@ third-party:
     client-secret: ${THIRD_PARTY_DATAGSM_CLIENT_SECRET:your-client-secret}
     client-id: ${THIRD_PARTY_DATAGSM_CLIENT_ID:your-client-id}
     redirect-uri: ${THIRD_PARTY_DATAGSM_REDIRECT_URI:http://localhost:8080/api/v2/admin/datagsm/oauth/callback}
+    api-key: ${THIRD_PARTY_DATAGSM_API_KEY:}
+    openapi-url: ${THIRD_PARTY_DATAGSM_OPENAPI_URL:https://openapi.datagsm.kr}
   fcm:
     service-account-json: ${THIRD_PARTY_FCM_SERVICE_ACCOUNT_JSON:}
 reservation:

--- a/src/test/java/team/washer/server/v2/domain/user/entity/UserTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/entity/UserTest.java
@@ -175,4 +175,42 @@ class UserTest {
             }
         }
     }
+
+    @Nested
+    @DisplayName("promoteToDormitoryCouncil 메서드는")
+    class Describe_promoteToDormitoryCouncil {
+
+        @Test
+        @DisplayName("일반 사용자를 기숙사자치위원회로 승격하고 true를 반환한다")
+        void it_promotes_user() {
+            final User user = createUser(3, UserRole.USER);
+
+            final boolean promoted = user.promoteToDormitoryCouncil();
+
+            assertThat(promoted).isTrue();
+            assertThat(user.getRole()).isEqualTo(UserRole.DORMITORY_COUNCIL);
+        }
+
+        @Test
+        @DisplayName("이미 기숙사자치위원회면 변경 없이 false를 반환한다")
+        void it_keeps_council() {
+            final User user = createUser(3, UserRole.DORMITORY_COUNCIL);
+
+            final boolean promoted = user.promoteToDormitoryCouncil();
+
+            assertThat(promoted).isFalse();
+            assertThat(user.getRole()).isEqualTo(UserRole.DORMITORY_COUNCIL);
+        }
+
+        @Test
+        @DisplayName("관리자는 강등 없이 false를 반환한다")
+        void it_keeps_admin() {
+            final User user = createUser(3, UserRole.ADMIN);
+
+            final boolean promoted = user.promoteToDormitoryCouncil();
+
+            assertThat(promoted).isFalse();
+            assertThat(user.getRole()).isEqualTo(UserRole.ADMIN);
+        }
+    }
 }

--- a/src/test/java/team/washer/server/v2/domain/user/entity/UserTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/entity/UserTest.java
@@ -1,0 +1,178 @@
+package team.washer.server.v2.domain.user.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.user.enums.UserRole;
+
+@DisplayName("User 엔티티의")
+class UserTest {
+
+    // 2026-06-08(월), 06-09(화), 06-07(일), 06-05(금), 06-06(토)
+    private User createUser(final Integer grade, final UserRole role) {
+        return User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(grade).floor(3).penaltyCount(0)
+                .role(role).build();
+    }
+
+    @Nested
+    @DisplayName("validateTimeRestriction 메서드는")
+    class Describe_validateTimeRestriction {
+
+        @Nested
+        @DisplayName("월~목요일 일반 사용자일 때 (전 학년 공통 21:20)")
+        class Context_weekday_user {
+
+            @Test
+            @DisplayName("21:20 이전이면 예외를 던진다")
+            void it_throws_before_2120() {
+                final User user = createUser(1, UserRole.USER);
+                final LocalDateTime time = LocalDateTime.of(2026, 6, 8, 21, 19);
+
+                assertThatThrownBy(() -> user.validateTimeRestriction(time)).isInstanceOf(ExpectedException.class)
+                        .hasMessageContaining("21:20");
+            }
+
+            @Test
+            @DisplayName("21:20 정각이면 통과한다")
+            void it_passes_at_2120() {
+                final User user = createUser(1, UserRole.USER);
+                final LocalDateTime time = LocalDateTime.of(2026, 6, 8, 21, 20);
+
+                assertThatCode(() -> user.validateTimeRestriction(time)).doesNotThrowAnyException();
+            }
+
+            @Test
+            @DisplayName("21:21 이후이면 통과한다")
+            void it_passes_after_2120() {
+                final User user = createUser(3, UserRole.USER);
+                final LocalDateTime time = LocalDateTime.of(2026, 6, 9, 21, 21);
+
+                assertThatCode(() -> user.validateTimeRestriction(time)).doesNotThrowAnyException();
+            }
+
+            @Test
+            @DisplayName("학년과 무관하게 동일한 21:20 기준이 적용된다")
+            void it_applies_same_time_regardless_of_grade() {
+                final User grade3 = createUser(3, UserRole.USER);
+                final LocalDateTime time = LocalDateTime.of(2026, 6, 8, 21, 19);
+
+                assertThatThrownBy(() -> grade3.validateTimeRestriction(time)).isInstanceOf(ExpectedException.class)
+                        .hasMessageContaining("21:20");
+            }
+        }
+
+        @Nested
+        @DisplayName("일요일 일반 사용자일 때 (학년별)")
+        class Context_sunday_user {
+
+            @Test
+            @DisplayName("1학년은 20:00 이전이면 예외를 던진다")
+            void it_throws_grade1_before_2000() {
+                final User user = createUser(1, UserRole.USER);
+                final LocalDateTime time = LocalDateTime.of(2026, 6, 7, 19, 59);
+
+                assertThatThrownBy(() -> user.validateTimeRestriction(time)).isInstanceOf(ExpectedException.class)
+                        .hasMessageContaining("1학년").hasMessageContaining("20:00");
+            }
+
+            @Test
+            @DisplayName("1학년은 20:00 정각이면 통과한다")
+            void it_passes_grade1_at_2000() {
+                final User user = createUser(1, UserRole.USER);
+                final LocalDateTime time = LocalDateTime.of(2026, 6, 7, 20, 0);
+
+                assertThatCode(() -> user.validateTimeRestriction(time)).doesNotThrowAnyException();
+            }
+
+            @Test
+            @DisplayName("2학년은 20:20 이전이면 예외를 던진다")
+            void it_throws_grade2_before_2020() {
+                final User user = createUser(2, UserRole.USER);
+                final LocalDateTime time = LocalDateTime.of(2026, 6, 7, 20, 19);
+
+                assertThatThrownBy(() -> user.validateTimeRestriction(time)).isInstanceOf(ExpectedException.class)
+                        .hasMessageContaining("2학년").hasMessageContaining("20:20");
+            }
+
+            @Test
+            @DisplayName("2학년은 20:20 정각이면 통과한다")
+            void it_passes_grade2_at_2020() {
+                final User user = createUser(2, UserRole.USER);
+                final LocalDateTime time = LocalDateTime.of(2026, 6, 7, 20, 20);
+
+                assertThatCode(() -> user.validateTimeRestriction(time)).doesNotThrowAnyException();
+            }
+
+            @Test
+            @DisplayName("3학년은 20:40 이전이면 예외를 던진다")
+            void it_throws_grade3_before_2040() {
+                final User user = createUser(3, UserRole.USER);
+                final LocalDateTime time = LocalDateTime.of(2026, 6, 7, 20, 39);
+
+                assertThatThrownBy(() -> user.validateTimeRestriction(time)).isInstanceOf(ExpectedException.class)
+                        .hasMessageContaining("3학년").hasMessageContaining("20:40");
+            }
+
+            @Test
+            @DisplayName("3학년은 20:40 정각이면 통과한다")
+            void it_passes_grade3_at_2040() {
+                final User user = createUser(3, UserRole.USER);
+                final LocalDateTime time = LocalDateTime.of(2026, 6, 7, 20, 40);
+
+                assertThatCode(() -> user.validateTimeRestriction(time)).doesNotThrowAnyException();
+            }
+        }
+
+        @Nested
+        @DisplayName("금요일과 토요일에는")
+        class Context_weekend {
+
+            @Test
+            @DisplayName("금요일 00:00에도 제한 없이 통과한다")
+            void it_passes_friday_midnight() {
+                final User user = createUser(1, UserRole.USER);
+                final LocalDateTime time = LocalDateTime.of(2026, 6, 5, 0, 0);
+
+                assertThatCode(() -> user.validateTimeRestriction(time)).doesNotThrowAnyException();
+            }
+
+            @Test
+            @DisplayName("토요일 00:00에도 제한 없이 통과한다")
+            void it_passes_saturday_midnight() {
+                final User user = createUser(3, UserRole.USER);
+                final LocalDateTime time = LocalDateTime.of(2026, 6, 6, 0, 0);
+
+                assertThatCode(() -> user.validateTimeRestriction(time)).doesNotThrowAnyException();
+            }
+        }
+
+        @Nested
+        @DisplayName("기숙사자치위원회와 관리자는")
+        class Context_bypass {
+
+            @Test
+            @DisplayName("기숙사자치위원회는 월요일 제한 시각 이전에도 통과한다")
+            void it_bypasses_for_dormitory_council() {
+                final User user = createUser(1, UserRole.DORMITORY_COUNCIL);
+                final LocalDateTime time = LocalDateTime.of(2026, 6, 8, 0, 0);
+
+                assertThatCode(() -> user.validateTimeRestriction(time)).doesNotThrowAnyException();
+            }
+
+            @Test
+            @DisplayName("관리자는 일요일 제한 시각 이전에도 통과한다")
+            void it_bypasses_for_admin() {
+                final User user = createUser(3, UserRole.ADMIN);
+                final LocalDateTime time = LocalDateTime.of(2026, 6, 7, 0, 0);
+
+                assertThatCode(() -> user.validateTimeRestriction(time)).doesNotThrowAnyException();
+            }
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/user/service/SyncDormitoryCouncilRoleServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/service/SyncDormitoryCouncilRoleServiceTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.enums.UserRole;
@@ -38,7 +40,11 @@ class SyncDormitoryCouncilRoleServiceTest {
                 "client-secret",
                 "redirect-uri",
                 apiKey);
-        return new SyncDormitoryCouncilRoleServiceImpl(dataGsmOpenApiClient, environment, userRepository);
+        final TransactionTemplate transactionTemplate = new TransactionTemplate(mock(PlatformTransactionManager.class));
+        return new SyncDormitoryCouncilRoleServiceImpl(dataGsmOpenApiClient,
+                environment,
+                userRepository,
+                transactionTemplate);
     }
 
     private User createUser(final String studentId, final UserRole role) {

--- a/src/test/java/team/washer/server/v2/domain/user/service/SyncDormitoryCouncilRoleServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/service/SyncDormitoryCouncilRoleServiceTest.java
@@ -1,0 +1,129 @@
+package team.washer.server.v2.domain.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.enums.UserRole;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.domain.user.service.impl.SyncDormitoryCouncilRoleServiceImpl;
+import team.washer.server.v2.global.thirdparty.datagsm.config.DataGsmEnvironment;
+import team.washer.server.v2.global.thirdparty.datagsm.dto.response.DataGsmStudentSearchResDto;
+import team.washer.server.v2.global.thirdparty.datagsm.dto.response.DataGsmStudentSearchResDto.Data;
+import team.washer.server.v2.global.thirdparty.datagsm.dto.response.DataGsmStudentSearchResDto.Student;
+import team.washer.server.v2.global.thirdparty.datagsm.feign.DataGsmOpenApiClient;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SyncDormitoryCouncilRoleServiceImpl 클래스의")
+class SyncDormitoryCouncilRoleServiceTest {
+
+    @Mock
+    private DataGsmOpenApiClient dataGsmOpenApiClient;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private SyncDormitoryCouncilRoleServiceImpl createService(final String apiKey) {
+        final DataGsmEnvironment environment = new DataGsmEnvironment("client-id",
+                "client-secret",
+                "redirect-uri",
+                apiKey);
+        return new SyncDormitoryCouncilRoleServiceImpl(dataGsmOpenApiClient, environment, userRepository);
+    }
+
+    private User createUser(final String studentId, final UserRole role) {
+        return User.builder().name("김철수").studentId(studentId).roomNumber("301").grade(3).floor(3).penaltyCount(0)
+                .role(role).build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Test
+        @DisplayName("API 키가 없으면 외부 호출 없이 0을 반환한다")
+        void it_skips_without_api_key() {
+            final SyncDormitoryCouncilRoleServiceImpl service = createService("");
+
+            final int promoted = service.execute();
+
+            assertThat(promoted).isZero();
+            then(dataGsmOpenApiClient).shouldHaveNoInteractions();
+            then(userRepository).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("기숙사 관리 역할 학생과 일치하는 일반 사용자를 승격하고 승격 수를 반환한다")
+        void it_promotes_matching_users() {
+            final SyncDormitoryCouncilRoleServiceImpl service = createService("api-key");
+            given(dataGsmOpenApiClient
+                    .searchStudents(eq("api-key"), eq("DORMITORY_MANAGER"), eq(true), eq(0), anyInt()))
+                    .willReturn(new DataGsmStudentSearchResDto("OK",
+                            200,
+                            "OK",
+                            new Data(1,
+                                    2L,
+                                    List.of(new Student(1101, "DORMITORY_MANAGER"),
+                                            new Student(1102, "DORMITORY_MANAGER")))));
+            final User user1 = createUser("1101", UserRole.USER);
+            final User user2 = createUser("1102", UserRole.USER);
+            given(userRepository.findByRoleAndStudentIdIn(eq(UserRole.USER), anyCollection()))
+                    .willReturn(List.of(user1, user2));
+
+            final int promoted = service.execute();
+
+            assertThat(promoted).isEqualTo(2);
+            assertThat(user1.getRole()).isEqualTo(UserRole.DORMITORY_COUNCIL);
+            assertThat(user2.getRole()).isEqualTo(UserRole.DORMITORY_COUNCIL);
+        }
+
+        @Test
+        @DisplayName("여러 페이지에 걸친 학생을 모두 조회한다")
+        void it_traverses_all_pages() {
+            final SyncDormitoryCouncilRoleServiceImpl service = createService("api-key");
+            given(dataGsmOpenApiClient
+                    .searchStudents(eq("api-key"), eq("DORMITORY_MANAGER"), eq(true), eq(0), anyInt()))
+                    .willReturn(new DataGsmStudentSearchResDto("OK",
+                            200,
+                            "OK",
+                            new Data(2, 2L, List.of(new Student(1101, "DORMITORY_MANAGER")))));
+            given(dataGsmOpenApiClient
+                    .searchStudents(eq("api-key"), eq("DORMITORY_MANAGER"), eq(true), eq(1), anyInt()))
+                    .willReturn(new DataGsmStudentSearchResDto("OK",
+                            200,
+                            "OK",
+                            new Data(2, 2L, List.of(new Student(1102, "DORMITORY_MANAGER")))));
+            given(userRepository.findByRoleAndStudentIdIn(eq(UserRole.USER), anyCollection()))
+                    .willReturn(List.of(createUser("1101", UserRole.USER), createUser("1102", UserRole.USER)));
+
+            final int promoted = service.execute();
+
+            assertThat(promoted).isEqualTo(2);
+            then(dataGsmOpenApiClient).should(times(2)).searchStudents(any(), any(), anyBoolean(), anyInt(), anyInt());
+        }
+
+        @Test
+        @DisplayName("기숙사 관리 역할 학생이 없으면 0을 반환한다")
+        void it_returns_zero_when_no_managers() {
+            final SyncDormitoryCouncilRoleServiceImpl service = createService("api-key");
+            given(dataGsmOpenApiClient
+                    .searchStudents(eq("api-key"), eq("DORMITORY_MANAGER"), eq(true), eq(0), anyInt()))
+                    .willReturn(new DataGsmStudentSearchResDto("OK", 200, "OK", new Data(1, 0L, List.of())));
+
+            final int promoted = service.execute();
+
+            assertThat(promoted).isZero();
+            then(userRepository).shouldHaveNoInteractions();
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/user/support/UserRegistrationSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/support/UserRegistrationSupportTest.java
@@ -1,0 +1,76 @@
+package team.washer.server.v2.domain.user.support;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import team.themoment.datagsm.sdk.oauth.model.Student;
+import team.themoment.datagsm.sdk.oauth.model.StudentRole;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.enums.UserRole;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserRegistrationSupport 클래스의")
+class UserRegistrationSupportTest {
+
+    @InjectMocks
+    private UserRegistrationSupport userRegistrationSupport;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private Student createStudent(final StudentRole role) {
+        final Student student = new Student();
+        student.setStudentNumber(20210001);
+        student.setName("김철수");
+        student.setDormitoryRoom(301);
+        student.setGrade(3);
+        student.setDormitoryFloor(3);
+        student.setRole(role);
+        return student;
+    }
+
+    @Nested
+    @DisplayName("register 메서드는")
+    class Describe_register {
+
+        @Test
+        @DisplayName("DORMITORY_MANAGER 학생은 기숙사자치위원회로 등록한다")
+        void it_maps_dormitory_manager_to_council() {
+            final User user = userRegistrationSupport.register(createStudent(StudentRole.DORMITORY_MANAGER));
+
+            assertThat(user.getRole()).isEqualTo(UserRole.DORMITORY_COUNCIL);
+        }
+
+        @Test
+        @DisplayName("STUDENT_COUNCIL 학생은 일반 사용자로 등록한다")
+        void it_maps_student_council_to_user() {
+            final User user = userRegistrationSupport.register(createStudent(StudentRole.STUDENT_COUNCIL));
+
+            assertThat(user.getRole()).isEqualTo(UserRole.USER);
+        }
+
+        @Test
+        @DisplayName("GENERAL_STUDENT 학생은 일반 사용자로 등록한다")
+        void it_maps_general_student_to_user() {
+            final User user = userRegistrationSupport.register(createStudent(StudentRole.GENERAL_STUDENT));
+
+            assertThat(user.getRole()).isEqualTo(UserRole.USER);
+        }
+
+        @Test
+        @DisplayName("역할 정보가 없으면 일반 사용자로 등록한다")
+        void it_maps_null_role_to_user() {
+            final User user = userRegistrationSupport.register(createStudent(null));
+
+            assertThat(user.getRole()).isEqualTo(UserRole.USER);
+        }
+    }
+}


### PR DESCRIPTION
## 개요

기숙사자치위원회(기자위)와 관리자는 예약 시간 제한을 우회하도록 설계되어 있으나, 회원가입 시 `DataGSM` 역할을 반영하지 않아 모든 사용자가 `USER`로 등록되어 우회가 실제로 동작하지 않던 문제를 수정하였습니다. 더불어 예약 시간 제한 규칙을 변경하고, 기존에 잘못 등록된 기자위 학생을 보정하는 일회성 자동 승격 백필을 추가하였습니다.

## 본문

### 예약 시간 제한 규칙 변경 (`User.validateTimeRestriction`)
- 월~목은 전 학년 공통 `21:20` 기준으로 변경하였습니다.
- 일요일은 학년별 기준을 각 10분씩 늦춰 1학년 `20:00`, 2학년 `20:20`, 3학년 이상 `20:40`으로 변경하였습니다.
- 금·토요일 무제한 정책은 유지하였습니다.
- `TimeRestrictionConstants`에 `WEEKDAY_START_TIME`을 추가하고 학년별 상수를 일요일 전용으로 정리하였습니다.
- 기자위·관리자 우회 로직(`canBypassTimeRestrictions`)은 그대로 유지되며, 변경 사항은 일반 사용자에게만 적용됩니다.

### 회원가입 시 `DataGSM` 역할 미반영 수정 (`UserRegistrationSupport`)
- `register`에서 `Student.getRole()`을 읽지 않아 모든 신규 사용자가 `UserRole.USER`로 등록되던 문제를 수정하였습니다.
- `StudentRole.DORMITORY_MANAGER`는 `UserRole.DORMITORY_COUNCIL`로, `STUDENT_COUNCIL`·`GENERAL_STUDENT` 및 미상은 `USER`로 매핑하였습니다.
- 관리자 권한은 `DataGSM`에서 부여되지 않으며 별도로 지정합니다.

### `DataGSM` OpenAPI 기반 자동 승격 백필 추가
- 애플리케이션 기동 완료 시 `DormitoryCouncilRoleSyncListener`가 1회 실행되어, OpenAPI `GET /v1/students?role=DORMITORY_MANAGER`로 조회한 학생과 일치하는 기존 일반 사용자를 `DORMITORY_COUNCIL`로 승격합니다.
- 단방향 승격만 수행하며 관리자와 기존 기자위 권한은 변경하지 않습니다. 멱등하게 동작하여 재기동 시 안전합니다.
- 역할 매핑이 도입되기 전에 가입한 기존 기자위 학생을 보정하기 위한 일회성 코드이므로 `DormitoryCouncilRoleSyncListener`에 `@Deprecated`를 명시하였으며, 운영 1회 실행 후 제거 대상입니다.
- `DataGsmOpenApiClient`(`@FeignClient`)와 `DataGsmStudentSearchResDto`를 추가하고, `DataGsmEnvironment`에 `apiKey`·`hasApiKey`를 추가하였습니다. API 키 미설정 시 백필은 경고 로그만 남기고 건너뜁니다.

### 테스트
- `UserTest`에 시간 제한 경계값과 승격 메서드 검증을 추가하였습니다.
- `UserRegistrationSupportTest`에 역할 매핑 검증을 추가하였습니다.
- `SyncDormitoryCouncilRoleServiceTest`에 승격 로직과 페이지네이션 검증을 추가하였습니다.
- 전체 테스트 252개가 통과합니다.

### 기타
- `ReservationRepositoryCustomImpl`의 `spotless` 포맷을 정리하였습니다.
