### PR TITLE
[reservation] 관리자 예약 차단 기간 연장 API 추가

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/notification/entity/Notification.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/entity/Notification.java
@@ -1,6 +1,7 @@
 package team.washer.server.v2.domain.notification.entity;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -197,6 +198,23 @@ public class Notification extends BaseEntity {
 
         return Notification.builder().user(user).machine(machine).type(NotificationType.CANCELLATION_BLOCKED)
                 .message(message).isRead(false).build();
+    }
+
+    /**
+     * 예약 차단 연장 알림을 생성합니다.
+     *
+     * @param user
+     *            알림 수신 사용자
+     * @param newExpiryAt
+     *            새 차단 만료 시각
+     * @return 생성된 차단 연장 알림
+     */
+    public static Notification createBlockExtensionNotification(User user, LocalDateTime newExpiryAt) {
+        String formatted = newExpiryAt.format(DateTimeFormatter.ofPattern("MM월 dd일 HH시 mm분"));
+        String message = "관리자에 의해 예약 차단 기간이 연장되었습니다. " + formatted + "까지 해당 호실의 예약이 제한됩니다.";
+
+        return Notification.builder().user(user).type(NotificationType.CANCELLATION_BLOCKED).message(message)
+                .isRead(false).build();
     }
 
     /**

--- a/src/main/java/team/washer/server/v2/domain/notification/entity/Notification.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/entity/Notification.java
@@ -1,7 +1,6 @@
 package team.washer.server.v2.domain.notification.entity;
 
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -210,10 +209,9 @@ public class Notification extends BaseEntity {
      * @return 생성된 차단 연장 알림
      */
     public static Notification createBlockExtensionNotification(User user, LocalDateTime newExpiryAt) {
-        String formatted = newExpiryAt.format(DateTimeFormatter.ofPattern("MM월 dd일 HH시 mm분"));
-        String message = "관리자에 의해 예약 차단 기간이 연장되었습니다. " + formatted + "까지 해당 호실의 예약이 제한됩니다.";
+        String message = NotificationType.CANCELLATION_BLOCK_EXTENDED.formatMessage(newExpiryAt);
 
-        return Notification.builder().user(user).type(NotificationType.CANCELLATION_BLOCKED).message(message)
+        return Notification.builder().user(user).type(NotificationType.CANCELLATION_BLOCK_EXTENDED).message(message)
                 .isRead(false).build();
     }
 

--- a/src/main/java/team/washer/server/v2/domain/notification/enums/NotificationType.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/enums/NotificationType.java
@@ -22,9 +22,12 @@ public enum NotificationType {
                                                             "예약 취소 경고",
                                                             "{machineName}의 예약이 시간 초과로 자동 취소되었습니다.\n첫 번째라 패널티는 없습니다. 다음부터는 패널티가 부과됩니다."), CANCELLATION_BLOCKED(
                                                                     "예약 차단 알림",
-                                                                    "48시간 내 예약 취소가 누적되어 해당 호실의 예약이 48시간 동안 제한됩니다.");
+                                                                    "48시간 내 예약 취소가 누적되어 해당 호실의 예약이 48시간 동안 제한됩니다."), CANCELLATION_BLOCK_EXTENDED(
+                                                                            "예약 차단 연장 알림",
+                                                                            "관리자에 의해 예약 차단 기간이 연장되었습니다. {expiryAt}까지 해당 호실의 예약이 제한됩니다.");
 
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+    private static final DateTimeFormatter EXPIRY_FORMATTER = DateTimeFormatter.ofPattern("MM월 dd일 HH시 mm분");
 
     private final String description;
     private final String messageTemplate;
@@ -45,5 +48,9 @@ public enum NotificationType {
         var formatted = completionTime != null ? completionTime.format(TIME_FORMATTER) : "미정";
         return messageTemplate.replace("{machineName}", machineName).replace("{action}", machineType.getActionNoun())
                 .replace("{completionTime}", formatted);
+    }
+
+    public String formatMessage(LocalDateTime expiryAt) {
+        return messageTemplate.replace("{expiryAt}", expiryAt.format(EXPIRY_FORMATTER));
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupport.java
@@ -88,6 +88,15 @@ public class ReservationNotificationSupport {
         persistAndSend(user, notification, "예약 차단 알림");
     }
 
+    /**
+     * 예약 차단 연장 알림을 전송한다.
+     */
+    @Transactional
+    public void sendBlockExtension(User user, LocalDateTime newExpiryAt) {
+        var notification = Notification.createBlockExtensionNotification(user, newExpiryAt);
+        persistAndSend(user, notification, "예약 차단 알림");
+    }
+
     private void persistAndSend(final User user, final Notification notification, final String fcmTitle) {
         notificationRepository.save(notification);
         enforceNotificationLimit(user);

--- a/src/main/java/team/washer/server/v2/domain/reservation/controller/AdminReservationController.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/controller/AdminReservationController.java
@@ -9,10 +9,12 @@ import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import team.themoment.sdk.response.CommonApiResponse;
 import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.reservation.dto.request.ExtendBlockReqDto;
 import team.washer.server.v2.domain.reservation.dto.response.AdminCancellationResDto;
 import team.washer.server.v2.domain.reservation.dto.response.AdminMachineHistoryResDto;
 import team.washer.server.v2.domain.reservation.dto.response.AdminReservationListResDto;
@@ -29,6 +31,7 @@ public class AdminReservationController {
 
     private final QueryPenaltyStatusService queryPenaltyStatusService;
     private final ClearUserPenaltyService clearUserPenaltyService;
+    private final ExtendCancellationBlockService extendCancellationBlockService;
     private final QueryAllReservationsService queryAllReservationsService;
     private final AdminCancelReservationService adminCancelReservationService;
     private final QueryAdminMachineHistoryService queryAdminMachineHistoryService;
@@ -46,6 +49,15 @@ public class AdminReservationController {
 
         clearUserPenaltyService.execute(userId);
         return CommonApiResponse.success("사용자 패널티가 해제되었습니다.");
+    }
+
+    @PatchMapping("/users/{userId}/penalty/block")
+    @Operation(summary = "예약 차단 기간 연장", description = "특정 사용자의 예약 차단 기간을 일 단위로 연장합니다. ADMIN 권한이 필요합니다.")
+    public CommonApiResponse extendBlock(@Parameter(description = "사용자 ID") @PathVariable @NotNull Long userId,
+            @Valid @RequestBody ExtendBlockReqDto reqDto) {
+
+        extendCancellationBlockService.execute(userId, reqDto.days());
+        return CommonApiResponse.success("예약 차단 기간이 연장되었습니다.");
     }
 
     @GetMapping

--- a/src/main/java/team/washer/server/v2/domain/reservation/dto/request/ExtendBlockReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/dto/request/ExtendBlockReqDto.java
@@ -1,9 +1,10 @@
 package team.washer.server.v2.domain.reservation.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 @Schema(description = "예약 차단 기간 연장 요청 DTO")
 public record ExtendBlockReqDto(
-        @Min(value = 1, message = "연장 일수는 1일 이상이어야 합니다") @Schema(description = "연장 일수", example = "2") int days) {
+        @Min(value = 1, message = "연장 일수는 1일 이상이어야 합니다") @Max(value = 30, message = "연장 일수는 최대 30일까지 가능합니다") @Schema(description = "연장 일수", example = "2") int days) {
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/dto/request/ExtendBlockReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/dto/request/ExtendBlockReqDto.java
@@ -1,0 +1,9 @@
+package team.washer.server.v2.domain.reservation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+
+@Schema(description = "예약 차단 기간 연장 요청 DTO")
+public record ExtendBlockReqDto(
+        @Min(value = 1, message = "연장 일수는 1일 이상이어야 합니다") @Schema(description = "연장 일수", example = "2") int days) {
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/ExtendCancellationBlockService.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/ExtendCancellationBlockService.java
@@ -1,0 +1,5 @@
+package team.washer.server.v2.domain.reservation.service;
+
+public interface ExtendCancellationBlockService {
+    void execute(Long userId, int days);
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ExtendCancellationBlockServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ExtendCancellationBlockServiceImpl.java
@@ -1,0 +1,58 @@
+package team.washer.server.v2.domain.reservation.service.impl;
+
+import java.time.LocalDateTime;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.notification.support.ReservationNotificationSupport;
+import team.washer.server.v2.domain.reservation.service.ExtendCancellationBlockService;
+import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ExtendCancellationBlockServiceImpl implements ExtendCancellationBlockService {
+
+    private final UserRepository userRepository;
+    private final PenaltyRedisUtil penaltyRedisUtil;
+    private final ReservationNotificationSupport reservationNotificationSupport;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    @Transactional
+    public void execute(final Long userId, final int days) {
+        final var adminId = currentUserProvider.getCurrentUserId();
+        final User admin = userRepository.findById(adminId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        if (!admin.getRole().isAdmin()) {
+            log.warn("Unauthorized block extend attempt by user {} for user {}", adminId, userId);
+            throw new ExpectedException("관리자 권한이 필요합니다.", HttpStatus.FORBIDDEN);
+        }
+
+        final User target = userRepository.findById(userId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        final String roomNumber = target.getRoomNumber();
+        if (roomNumber == null) {
+            throw new ExpectedException("호실 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
+
+        final LocalDateTime newExpiryAt = penaltyRedisUtil.extendBlock(roomNumber, days);
+        log.info("block extended roomNumber={} additionalDays={} newExpiry={} by admin {}",
+                roomNumber,
+                days,
+                newExpiryAt,
+                adminId);
+
+        reservationNotificationSupport.sendBlockExtension(target, newExpiryAt);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/util/PenaltyRedisUtil.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/util/PenaltyRedisUtil.java
@@ -188,6 +188,33 @@ public class PenaltyRedisUtil {
     // ===== 48시간 예약 차단 (호실 단위) =====
 
     /**
+     * 호실 단위 예약 차단 기간을 지정한 일수만큼 연장합니다.
+     *
+     * @param roomNumber
+     *            연장 대상 호실 번호
+     * @param additionalDays
+     *            추가 연장 일수 (1 이상)
+     * @return 연장 후 만료 시각
+     * @throws team.themoment.sdk.exception.ExpectedException
+     *             활성 차단이 없는 경우
+     */
+    public LocalDateTime extendBlock(final String roomNumber, final long additionalDays) {
+        final CancellationBlockEntity existing = cancellationBlockRedisRepository.findById(roomNumber)
+                .orElseThrow(() -> new team.themoment.sdk.exception.ExpectedException("활성화된 예약 차단이 없습니다.",
+                        org.springframework.http.HttpStatus.BAD_REQUEST));
+
+        final long currentTtl = existing.getTtl() != null ? existing.getTtl() : 0L;
+        final long additionalSeconds = additionalDays * 24L * 3600L;
+        final long newTtl = currentTtl + additionalSeconds;
+
+        cancellationBlockRedisRepository
+                .save(CancellationBlockEntity.builder().roomNumber(roomNumber).ttl(newTtl).build());
+        log.info("block extended roomNumber={} additionalDays={} newTtlSeconds={}", roomNumber, additionalDays, newTtl);
+
+        return LocalDateTime.now().plusSeconds(newTtl);
+    }
+
+    /**
      * 48시간 예약 차단을 호실 단위로 적용합니다.
      */
     public void applyBlock(final String roomNumber) {

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ExtendCancellationBlockServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ExtendCancellationBlockServiceTest.java
@@ -1,0 +1,221 @@
+package team.washer.server.v2.domain.reservation.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.notification.support.ReservationNotificationSupport;
+import team.washer.server.v2.domain.reservation.service.impl.ExtendCancellationBlockServiceImpl;
+import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.enums.UserRole;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ExtendCancellationBlockServiceImpl 클래스의")
+class ExtendCancellationBlockServiceTest {
+
+    @InjectMocks
+    private ExtendCancellationBlockServiceImpl extendCancellationBlockService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PenaltyRedisUtil penaltyRedisUtil;
+
+    @Mock
+    private ReservationNotificationSupport reservationNotificationSupport;
+
+    @Mock
+    private CurrentUserProvider currentUserProvider;
+
+    private User createAdmin() {
+        return User.builder().name("관리자").studentId("20210001").roomNumber("301").grade(3).floor(3).role(UserRole.ADMIN)
+                .build();
+    }
+
+    private User createUser() {
+        return User.builder().name("일반사용자").studentId("20210002").roomNumber("302").grade(3).floor(3)
+                .role(UserRole.USER).build();
+    }
+
+    private User createUserWithoutRoom() {
+        return User.builder().name("호실없는사용자").studentId("20210003").grade(3).floor(3).role(UserRole.USER).build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("관리자가 활성 차단 중인 호실 사용자에게 연장 요청할 때")
+        class Context_with_valid_block_extension {
+
+            @Test
+            @DisplayName("차단 기간을 연장하고 사용자에게 알림을 전송해야 한다")
+            void it_extends_block_and_sends_notification() {
+                // Given
+                var adminId = 1L;
+                var targetId = 2L;
+                var days = 2;
+                var newExpiry = LocalDateTime.now().plusDays(days);
+                var admin = createAdmin();
+                var target = createUser();
+
+                given(currentUserProvider.getCurrentUserId()).willReturn(adminId);
+                given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+                given(userRepository.findById(targetId)).willReturn(Optional.of(target));
+                given(penaltyRedisUtil.extendBlock(target.getRoomNumber(), days)).willReturn(newExpiry);
+
+                // When
+                extendCancellationBlockService.execute(targetId, days);
+
+                // Then
+                then(penaltyRedisUtil).should(times(1)).extendBlock(target.getRoomNumber(), days);
+                then(reservationNotificationSupport).should(times(1)).sendBlockExtension(target, newExpiry);
+            }
+        }
+
+        @Nested
+        @DisplayName("일반 사용자가 연장을 시도할 때")
+        class Context_with_regular_user_extending {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 FORBIDDEN 상태를 반환해야 한다")
+            void it_throws_forbidden_exception() {
+                // Given
+                var userId = 2L;
+                var user = createUser();
+                given(currentUserProvider.getCurrentUserId()).willReturn(userId);
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+                // When & Then
+                assertThatThrownBy(() -> extendCancellationBlockService.execute(3L, 1))
+                        .isInstanceOf(ExpectedException.class).hasMessage("관리자 권한이 필요합니다.")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.FORBIDDEN));
+
+                then(penaltyRedisUtil).shouldHaveNoInteractions();
+                then(reservationNotificationSupport).shouldHaveNoInteractions();
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 관리자 ID로 요청할 때")
+        class Context_with_nonexistent_admin {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 NOT_FOUND 상태를 반환해야 한다")
+            void it_throws_not_found_for_admin() {
+                // Given
+                var adminId = 999L;
+                given(currentUserProvider.getCurrentUserId()).willReturn(adminId);
+                given(userRepository.findById(adminId)).willReturn(Optional.empty());
+
+                // When & Then
+                assertThatThrownBy(() -> extendCancellationBlockService.execute(1L, 1))
+                        .isInstanceOf(ExpectedException.class).hasMessage("사용자를 찾을 수 없습니다.")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.NOT_FOUND));
+
+                then(penaltyRedisUtil).shouldHaveNoInteractions();
+                then(reservationNotificationSupport).shouldHaveNoInteractions();
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 대상 사용자 ID로 요청할 때")
+        class Context_with_nonexistent_target_user {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 NOT_FOUND 상태를 반환해야 한다")
+            void it_throws_not_found_for_target() {
+                // Given
+                var adminId = 1L;
+                var targetId = 999L;
+                var admin = createAdmin();
+                given(currentUserProvider.getCurrentUserId()).willReturn(adminId);
+                given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+                given(userRepository.findById(targetId)).willReturn(Optional.empty());
+
+                // When & Then
+                assertThatThrownBy(() -> extendCancellationBlockService.execute(targetId, 1))
+                        .isInstanceOf(ExpectedException.class).hasMessage("사용자를 찾을 수 없습니다.")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.NOT_FOUND));
+
+                then(penaltyRedisUtil).shouldHaveNoInteractions();
+                then(reservationNotificationSupport).shouldHaveNoInteractions();
+            }
+        }
+
+        @Nested
+        @DisplayName("호실 정보가 없는 사용자에게 요청할 때")
+        class Context_with_user_without_room {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 NOT_FOUND 상태를 반환해야 한다")
+            void it_throws_not_found_for_room() {
+                // Given
+                var adminId = 1L;
+                var targetId = 2L;
+                var admin = createAdmin();
+                var target = createUserWithoutRoom();
+                given(currentUserProvider.getCurrentUserId()).willReturn(adminId);
+                given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+                given(userRepository.findById(targetId)).willReturn(Optional.of(target));
+
+                // When & Then
+                assertThatThrownBy(() -> extendCancellationBlockService.execute(targetId, 1))
+                        .isInstanceOf(ExpectedException.class).hasMessage("호실 정보를 찾을 수 없습니다.")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.NOT_FOUND));
+
+                then(penaltyRedisUtil).shouldHaveNoInteractions();
+                then(reservationNotificationSupport).shouldHaveNoInteractions();
+            }
+        }
+
+        @Nested
+        @DisplayName("활성 차단이 없는 호실에 연장 요청할 때")
+        class Context_with_no_active_block {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 BAD_REQUEST 상태를 반환해야 한다")
+            void it_throws_bad_request_when_no_active_block() {
+                // Given
+                var adminId = 1L;
+                var targetId = 2L;
+                var admin = createAdmin();
+                var target = createUser();
+                given(currentUserProvider.getCurrentUserId()).willReturn(adminId);
+                given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+                given(userRepository.findById(targetId)).willReturn(Optional.of(target));
+                given(penaltyRedisUtil.extendBlock(target.getRoomNumber(), 1))
+                        .willThrow(new ExpectedException("활성화된 예약 차단이 없습니다.", HttpStatus.BAD_REQUEST));
+
+                // When & Then
+                assertThatThrownBy(() -> extendCancellationBlockService.execute(targetId, 1))
+                        .isInstanceOf(ExpectedException.class).hasMessage("활성화된 예약 차단이 없습니다.")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.BAD_REQUEST));
+
+                then(reservationNotificationSupport).shouldHaveNoInteractions();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

관리자가 48시간 취소 차단 중인 호실의 차단 기간을 일(day) 단위로 추가 연장할 수 있는 API를 추가하였습니다. 연장은 현재 남은 TTL에 누적되며, 연장 완료 시 대상 사용자에게 새 만료 시각을 포함한 알림이 발송됩니다.

## 본문

### 추가된 엔드포인트

```
PATCH /api/v2/admin/reservations/users/{userId}/penalty/block
Body: { "days": 2 }
```

- `userId` 기준으로 호실을 조회하여 `CancellationBlockEntity`의 TTL을 연장합니다.
- `days` 필드는 `@Min(1)` 검증이 적용되며, 상한 제한 없이 관리자가 자유롭게 지정할 수 있습니다.
- 활성 차단이 없는 호실에 요청 시 `400 Bad Request`를 반환합니다.
- 기존 해제 API(`DELETE /users/{userId}/penalty`)와 동일한 패턴을 따릅니다.

### 연장 로직

`PenaltyRedisUtil.extendBlock()`은 `CancellationBlockRedisRepository`에서 현재 엔티티를 조회하여 남은 TTL을 읽은 뒤, 추가 일수(초 환산)를 누적한 새 TTL로 엔티티를 재저장합니다.

```
새 TTL = 현재 남은 TTL + (days × 86400초)
```

### 알림

연장 완료 후 `ReservationNotificationSupport.sendBlockExtension()`을 호출하여 대상 사용자에게 알림을 전송합니다. 알림 타입은 기존 `CANCELLATION_BLOCKED`를 재사용하며, 메시지에 새 만료 시각(`MM월 dd일 HH시 mm분`)을 포함합니다.

### 변경 파일 요약

| 구분 | 파일 | 내용 |
|------|------|------|
| 신규 | `ExtendBlockReqDto` | 요청 DTO (`days`, `@Min(1)`) |
| 신규 | `ExtendCancellationBlockService` | 서비스 인터페이스 |
| 신규 | `ExtendCancellationBlockServiceImpl` | 서비스 구현체 |
| 수정 | `PenaltyRedisUtil` | `extendBlock()` 메서드 추가 |
| 수정 | `Notification` | `createBlockExtensionNotification()` 추가 |
| 수정 | `ReservationNotificationSupport` | `sendBlockExtension()` 추가 |
| 수정 | `AdminReservationController` | `PATCH /users/{userId}/penalty/block` 추가 |
| 신규 | `ExtendCancellationBlockServiceTest` | 단위 테스트 6개 시나리오 |
