### PR TITLE
[smartthings] 기기 상태 오판으로 인한 완료 표시·강제 종료 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ tasks.compileTestJava {
 }
 
 group = "team.washer"
-version = "v20260608.0"
+version = "v20260609.0"
 
 springBoot {
     buildInfo()

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
@@ -130,9 +130,12 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
         if (deviceStatus == null) {
             return false;
         }
-        var machineState = machine.isWasher()
-                ? deviceStatus.getWasherOperatingState()
-                : deviceStatus.getDryerOperatingState();
+        String machineState = null;
+        if (machine.isWasher()) {
+            machineState = deviceStatus.getWasherOperatingState();
+        } else if (machine.isDryer()) {
+            machineState = deviceStatus.getDryerOperatingState();
+        }
         return "run".equalsIgnoreCase(machineState) || "pause".equalsIgnoreCase(machineState);
     }
 

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
@@ -92,7 +92,7 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
                 machine.getName(),
                 machine.getType(),
                 machine.getStatus(),
-                computeAvailability(machine, reservation),
+                computeAvailability(machine, reservation, deviceStatus),
                 operatingState,
                 jobState,
                 switchStatus,
@@ -104,21 +104,36 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
     }
 
     /**
-     * 예약 정보를 기반으로 기기의 가용성을 동적으로 계산한다. machine.availability 필드 대신 예약 상태를 source of
-     * truth로 사용한다.
+     * 예약 정보와 실제 기기 작동 상태를 기반으로 가용성을 동적으로 계산한다. 예약 상태를 우선 source of truth로 사용하되, 예약이
+     * 없어도 SmartThings에서 실제 작동 중(무단 사용)이면 IN_USE로 표시해 중복 예약을 차단한다.
      */
-    private MachineAvailability computeAvailability(Machine machine, Reservation reservation) {
+    private MachineAvailability computeAvailability(Machine machine,
+            Reservation reservation,
+            SmartThingsDeviceStatusResDto deviceStatus) {
         if (machine.getAvailability() == MachineAvailability.UNAVAILABLE) {
             return MachineAvailability.UNAVAILABLE;
         }
         if (reservation == null) {
-            return MachineAvailability.AVAILABLE;
+            return isOperating(machine, deviceStatus) ? MachineAvailability.IN_USE : MachineAvailability.AVAILABLE;
         }
         return switch (reservation.getStatus()) {
             case RUNNING -> MachineAvailability.IN_USE;
             case RESERVED -> MachineAvailability.RESERVED;
             default -> throw new IllegalStateException("활성 예약의 상태가 유효하지 않습니다: " + reservation.getStatus());
         };
+    }
+
+    /**
+     * 기기가 물리적으로 작동 중(run 또는 pause)인지 판정한다. 세탁기/건조기는 타입에 맞는 machineState를 본다.
+     */
+    private boolean isOperating(Machine machine, SmartThingsDeviceStatusResDto deviceStatus) {
+        if (deviceStatus == null) {
+            return false;
+        }
+        var machineState = machine.isWasher()
+                ? deviceStatus.getWasherOperatingState()
+                : deviceStatus.getDryerOperatingState();
+        return "run".equalsIgnoreCase(machineState) || "pause".equalsIgnoreCase(machineState);
     }
 
     private String getOperatingState(Machine machine, SmartThingsDeviceStatusResDto deviceStatus) {

--- a/src/main/java/team/washer/server/v2/domain/smartthings/dto/request/SmartThingsCommandReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/dto/request/SmartThingsCommandReqDto.java
@@ -23,4 +23,22 @@ public record SmartThingsCommandReqDto(@Schema(description = "명령 목록") Li
     public static SmartThingsCommandReqDto powerOn() {
         return new SmartThingsCommandReqDto(List.of(new Command("main", "switch", "on", List.of())));
     }
+
+    /**
+     * 세탁기를 안전하게 정지시킨다. 전원 차단(switch off)과 달리 사이클을 정상 종료하므로 작동 중 기기에 사용한다. 기기에서 원격
+     * 제어(Smart Control)가 활성화되어 있어야 명령이 적용된다.
+     */
+    public static SmartThingsCommandReqDto stopWasher() {
+        return new SmartThingsCommandReqDto(
+                List.of(new Command("main", "washerOperatingState", "setMachineState", List.of("stop"))));
+    }
+
+    /**
+     * 건조기를 안전하게 정지시킨다. 전원 차단(switch off)과 달리 사이클을 정상 종료하므로 작동 중 기기에 사용한다. 기기에서 원격
+     * 제어(Smart Control)가 활성화되어 있어야 명령이 적용된다.
+     */
+    public static SmartThingsCommandReqDto stopDryer() {
+        return new SmartThingsCommandReqDto(
+                List.of(new Command("main", "dryerOperatingState", "setMachineState", List.of("stop"))));
+    }
 }

--- a/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsDeviceStatusResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsDeviceStatusResDto.java
@@ -89,6 +89,25 @@ public record SmartThingsDeviceStatusResDto(
         return js != null ? js.value() : null;
     }
 
+    /** 세탁기 완료 예정 시간 반환 */
+    public String getWasherCompletionTime() {
+        var main = getMainComponent();
+        if (main == null || main.washerOperatingState() == null
+                || main.washerOperatingState().completionTime() == null) {
+            return null;
+        }
+        return main.washerOperatingState().completionTime().value();
+    }
+
+    /** 건조기 완료 예정 시간 반환 */
+    public String getDryerCompletionTime() {
+        var main = getMainComponent();
+        if (main == null || main.dryerOperatingState() == null || main.dryerOperatingState().completionTime() == null) {
+            return null;
+        }
+        return main.dryerOperatingState().completionTime().value();
+    }
+
     /** 완료 예정 시간 반환 (세탁기 우선, 없으면 건조기) */
     public String getCompletionTime() {
         var main = getMainComponent();

--- a/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsDeviceStatusResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsDeviceStatusResDto.java
@@ -15,7 +15,8 @@ public record SmartThingsDeviceStatusResDto(
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record ComponentStatus(@JsonProperty("washerOperatingState") WasherOperatingState washerOperatingState,
             @JsonProperty("dryerOperatingState") DryerOperatingState dryerOperatingState,
-            @JsonProperty("switch") SwitchCapability switchCapability) {
+            @JsonProperty("switch") SwitchCapability switchCapability,
+            @JsonProperty("remoteControlStatus") RemoteControlStatus remoteControlStatus) {
     }
 
     /**
@@ -42,6 +43,14 @@ public record SmartThingsDeviceStatusResDto(
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record SwitchCapability(@JsonProperty("switch") AttributeState switchState) {
+    }
+
+    /**
+     * remoteControlStatus capability 내부 속성. remoteControlEnabled: "true" | "false"
+     * 원격 제어가 비활성화된 기기에는 setMachineState 등 제어 명령이 적용되지 않는다.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record RemoteControlStatus(@JsonProperty("remoteControlEnabled") AttributeState remoteControlEnabled) {
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -131,6 +140,16 @@ public record SmartThingsDeviceStatusResDto(
         }
         var sw = main.switchCapability().switchState();
         return sw != null ? sw.value() : null;
+    }
+
+    /** 원격 제어(Smart Control) 활성화 여부 반환. 명령 전송 가능 여부 판단에 사용한다. */
+    public boolean isRemoteControlEnabled() {
+        var main = getMainComponent();
+        if (main == null || main.remoteControlStatus() == null
+                || main.remoteControlStatus().remoteControlEnabled() == null) {
+            return false;
+        }
+        return "true".equalsIgnoreCase(main.remoteControlStatus().remoteControlEnabled().value());
     }
 
     private ComponentStatus getMainComponent() {

--- a/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/ShutdownIdleMachinesServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/ShutdownIdleMachinesServiceImpl.java
@@ -10,13 +10,14 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
-import team.washer.server.v2.domain.smartthings.dto.request.SmartThingsCommandReqDto;
 import team.washer.server.v2.domain.smartthings.exception.SmartThingsPermissionException;
-import team.washer.server.v2.domain.smartthings.service.SendDeviceCommandService;
 import team.washer.server.v2.domain.smartthings.service.ShutdownIdleMachinesService;
+import team.washer.server.v2.domain.smartthings.support.DeviceShutdownSupport;
+import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
 import team.washer.server.v2.global.thirdparty.discord.service.DiscordErrorNotificationService;
 
 @Service
@@ -26,7 +27,8 @@ public class ShutdownIdleMachinesServiceImpl implements ShutdownIdleMachinesServ
 
     private final MachineRepository machineRepository;
     private final ReservationRepository reservationRepository;
-    private final SendDeviceCommandService sendDeviceCommandService;
+    private final DeviceStatusQuerySupport deviceStatusQuerySupport;
+    private final DeviceShutdownSupport deviceShutdownSupport;
 
     @Autowired(required = false)
     private DiscordErrorNotificationService discordErrorNotificationService;
@@ -43,17 +45,36 @@ public class ShutdownIdleMachinesServiceImpl implements ShutdownIdleMachinesServ
 
         var activeMachineIds = Set.copyOf(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES));
 
-        var offMachines = new ArrayList<String>();
-        var failedMachines = new ArrayList<String>();
-        var skippedCount = 0;
+        var idleCandidates = machines.stream().filter(machine -> !activeMachineIds.contains(machine.getId())).toList();
+        var skippedActiveCount = machines.size() - idleCandidates.size();
+        if (idleCandidates.isEmpty()) {
+            return;
+        }
 
-        for (var machine : machines) {
+        var statusMap = deviceStatusQuerySupport
+                .queryAllDevicesStatus(idleCandidates.stream().map(Machine::getDeviceId).toList());
+
+        var poweredOff = new ArrayList<String>();
+        var unauthorizedStopped = new ArrayList<String>();
+        var unauthorizedSkipped = new ArrayList<String>();
+        var failed = new ArrayList<String>();
+
+        for (var machine : idleCandidates) {
             try {
-                if (activeMachineIds.contains(machine.getId())) {
-                    skippedCount++;
-                } else {
-                    sendDeviceCommandService.execute(machine.getDeviceId(), SmartThingsCommandReqDto.powerOff());
-                    offMachines.add(machine.getName());
+                var status = statusMap.get(machine.getDeviceId());
+                var result = deviceShutdownSupport.shutdown(machine, status);
+                switch (result) {
+                    case POWERED_OFF -> poweredOff.add(machine.getName());
+                    case STOPPED -> {
+                        unauthorizedStopped.add(machine.getName());
+                        log.warn("unauthorized usage detected, machine safely stopped machine={} deviceId={}",
+                                machine.getName(),
+                                machine.getDeviceId());
+                    }
+                    case SKIPPED_REMOTE_DISABLED -> unauthorizedSkipped.add(machine.getName());
+                    case SKIPPED_UNKNOWN -> {
+                        // 상태 불명, 안전을 위해 종료하지 않음
+                    }
                 }
             } catch (SmartThingsPermissionException e) {
                 log.warn("idle shutdown SmartThings permission error detected, stopping batch. machine={} reason={}",
@@ -69,18 +90,24 @@ public class ShutdownIdleMachinesServiceImpl implements ShutdownIdleMachinesServ
                 }
                 break;
             } catch (Exception e) {
-                failedMachines.add(machine.getName());
+                failed.add(machine.getName());
                 log.error("idle shutdown failed to turn off machine={} reason={}", machine.getName(), e.getMessage());
             }
         }
 
-        if (!offMachines.isEmpty() || !failedMachines.isEmpty()) {
-            log.info("idle shutdown batch done. turned_off={} {} skipped_active_reservation={} failed={}{}",
-                    offMachines.size(),
-                    offMachines,
-                    skippedCount,
-                    failedMachines.size(),
-                    failedMachines.isEmpty() ? "" : " " + failedMachines);
+        if (!poweredOff.isEmpty() || !unauthorizedStopped.isEmpty() || !unauthorizedSkipped.isEmpty()
+                || !failed.isEmpty()) {
+            log.info(
+                    "idle shutdown batch done. powered_off={} {} unauthorized_stopped={} {} remote_disabled={} {} skipped_active_reservation={} failed={}{}",
+                    poweredOff.size(),
+                    poweredOff,
+                    unauthorizedStopped.size(),
+                    unauthorizedStopped,
+                    unauthorizedSkipped.size(),
+                    unauthorizedSkipped,
+                    skippedActiveCount,
+                    failed.size(),
+                    failed.isEmpty() ? "" : " " + failed);
         }
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupport.java
@@ -65,12 +65,27 @@ public class DeviceShutdownSupport {
                         machine.getDeviceId());
                 return ShutdownResult.SKIPPED_REMOTE_DISABLED;
             }
-            var stopCommand = machine.isWasher()
-                    ? SmartThingsCommandReqDto.stopWasher()
-                    : SmartThingsCommandReqDto.stopDryer();
+            SmartThingsCommandReqDto stopCommand;
+            if (machine.isWasher()) {
+                stopCommand = SmartThingsCommandReqDto.stopWasher();
+            } else if (machine.isDryer()) {
+                stopCommand = SmartThingsCommandReqDto.stopDryer();
+            } else {
+                log.warn("unknown machine type, skip shutdown machine={} deviceId={}",
+                        machine.getName(),
+                        machine.getDeviceId());
+                return ShutdownResult.SKIPPED_UNKNOWN;
+            }
             sendDeviceCommandService.execute(machine.getDeviceId(), stopCommand);
             log.info("device safely stopped machine={} deviceId={}", machine.getName(), machine.getDeviceId());
             return ShutdownResult.STOPPED;
+        }
+
+        if ("off".equalsIgnoreCase(status.getSwitchStatus())) {
+            log.info("device already powered off, skip command machine={} deviceId={}",
+                    machine.getName(),
+                    machine.getDeviceId());
+            return ShutdownResult.POWERED_OFF;
         }
 
         sendDeviceCommandService.execute(machine.getDeviceId(), SmartThingsCommandReqDto.powerOff());
@@ -82,7 +97,12 @@ public class DeviceShutdownSupport {
      * 기기가 물리적으로 작동 중(run 또는 pause)인지 판정한다. 세탁기/건조기는 타입에 맞는 machineState를 본다.
      */
     private boolean isOperating(Machine machine, SmartThingsDeviceStatusResDto status) {
-        var machineState = machine.isWasher() ? status.getWasherOperatingState() : status.getDryerOperatingState();
+        String machineState = null;
+        if (machine.isWasher()) {
+            machineState = status.getWasherOperatingState();
+        } else if (machine.isDryer()) {
+            machineState = status.getDryerOperatingState();
+        }
         return "run".equalsIgnoreCase(machineState) || "pause".equalsIgnoreCase(machineState);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupport.java
@@ -1,0 +1,88 @@
+package team.washer.server.v2.domain.smartthings.support;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.smartthings.dto.request.SmartThingsCommandReqDto;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.service.SendDeviceCommandService;
+
+/**
+ * 기기를 상황에 맞게 안전하게 종료하는 공통 컴포넌트.
+ *
+ * <p>
+ * 작동 중인 기기를 전원 차단(switch off)으로 끄면 물이 차 있는 상태에서 중단되어 위험하다. 따라서 작동 중인 기기는
+ * setMachineState(stop)으로 사이클을 정상 종료시키고, 이미 멈춘 유휴 기기만 전원을 정리한다. 무단 사용 종료 등 모든
+ * 강제 종료 상황에서 이 컴포넌트를 통해 종료한다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DeviceShutdownSupport {
+
+    private final SendDeviceCommandService sendDeviceCommandService;
+
+    /**
+     * 기기 종료 결과.
+     */
+    public enum ShutdownResult {
+        /** 유휴 기기의 전원을 차단함 */
+        POWERED_OFF,
+        /** 작동 중인 기기를 안전하게 정지시킴 */
+        STOPPED,
+        /** 작동 중이나 원격 제어가 꺼져 있어 종료하지 못함 */
+        SKIPPED_REMOTE_DISABLED,
+        /** 기기 상태를 알 수 없어 종료하지 않음 */
+        SKIPPED_UNKNOWN
+    }
+
+    /**
+     * 기기 상태에 따라 안전하게 종료한다.
+     *
+     * <ul>
+     * <li>작동 중(run/pause): setMachineState(stop)으로 사이클 정상 종료. 원격 제어가 꺼져 있으면 종료하지
+     * 않는다.</li>
+     * <li>유휴(stop/off): switch off로 전원 정리.</li>
+     * <li>상태 불명: 안전을 위해 종료하지 않는다.</li>
+     * </ul>
+     *
+     * @return 종료 처리 결과
+     */
+    public ShutdownResult shutdown(Machine machine, SmartThingsDeviceStatusResDto status) {
+        if (status == null) {
+            log.warn("device status unknown, skip shutdown machine={} deviceId={}",
+                    machine.getName(),
+                    machine.getDeviceId());
+            return ShutdownResult.SKIPPED_UNKNOWN;
+        }
+
+        if (isOperating(machine, status)) {
+            if (!status.isRemoteControlEnabled()) {
+                log.warn("device operating but remote control disabled, cannot stop safely machine={} deviceId={}",
+                        machine.getName(),
+                        machine.getDeviceId());
+                return ShutdownResult.SKIPPED_REMOTE_DISABLED;
+            }
+            var stopCommand = machine.isWasher()
+                    ? SmartThingsCommandReqDto.stopWasher()
+                    : SmartThingsCommandReqDto.stopDryer();
+            sendDeviceCommandService.execute(machine.getDeviceId(), stopCommand);
+            log.info("device safely stopped machine={} deviceId={}", machine.getName(), machine.getDeviceId());
+            return ShutdownResult.STOPPED;
+        }
+
+        sendDeviceCommandService.execute(machine.getDeviceId(), SmartThingsCommandReqDto.powerOff());
+        log.info("idle device powered off machine={} deviceId={}", machine.getName(), machine.getDeviceId());
+        return ShutdownResult.POWERED_OFF;
+    }
+
+    /**
+     * 기기가 물리적으로 작동 중(run 또는 pause)인지 판정한다. 세탁기/건조기는 타입에 맞는 machineState를 본다.
+     */
+    private boolean isOperating(Machine machine, SmartThingsDeviceStatusResDto status) {
+        var machineState = machine.isWasher() ? status.getWasherOperatingState() : status.getDryerOperatingState();
+        return "run".equalsIgnoreCase(machineState) || "pause".equalsIgnoreCase(machineState);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
@@ -1,6 +1,7 @@
 package team.washer.server.v2.domain.smartthings.support;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
@@ -18,6 +19,12 @@ import team.washer.server.v2.global.util.DateTimeUtil;
 @RequiredArgsConstructor
 @Slf4j
 public class MachineStateDetectionSupport {
+
+    /**
+     * completionTime은 항상 한국 시각(Asia/Seoul)으로 변환되므로, 비교 기준 시각도 시스템 타임존과 무관하게 한국 시각으로
+     * 고정한다.
+     */
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
     private final DeviceStatusQuerySupport deviceStatusQuerySupport;
 
@@ -47,7 +54,7 @@ public class MachineStateDetectionSupport {
         if (status == null) {
             return Optional.empty();
         }
-        var now = LocalDateTime.now();
+        var now = LocalDateTime.now(KOREA_ZONE);
 
         var washerCompletion = evaluateCompletion(status.getWasherJobState(),
                 "finish",

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
@@ -44,6 +44,9 @@ public class MachineStateDetectionSupport {
      * 확인한다. 세탁기/건조기는 기기 타입별로 독립 판정한다.
      */
     public Optional<LocalDateTime> isCompleted(SmartThingsDeviceStatusResDto status) {
+        if (status == null) {
+            return Optional.empty();
+        }
         var now = LocalDateTime.now();
 
         var washerCompletion = evaluateCompletion(status.getWasherJobState(),
@@ -75,7 +78,9 @@ public class MachineStateDetectionSupport {
             log.debug("job finished but machine not stopped yet machineState={} jobState={}", machineState, jobState);
             return Optional.empty();
         }
-        var completionTime = DateTimeUtil.parseAndConvertToKoreaTime(completionTimeStr);
+        var completionTime = (completionTimeStr != null && !completionTimeStr.isBlank())
+                ? DateTimeUtil.parseAndConvertToKoreaTime(completionTimeStr)
+                : null;
         if (completionTime != null && completionTime.isAfter(now)) {
             log.debug("job finished but completion time still in future completionTime={} jobState={}",
                     completionTime,

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
@@ -36,18 +36,54 @@ public class MachineStateDetectionSupport {
 
     /**
      * 기기 작업이 완료되었는지 감지하고, 완료된 경우 완료 시각을 반환한다.
+     *
+     * <p>
+     * SmartThings 기기는 메인 사이클이 끝나면 냉각(cooling)·구김방지(wrinklePrevent) 등 잔여 단계가 남아 있어도
+     * jobState를 finish/finished로 먼저 보고하는 경우가 있다. jobState만으로 판정하면 실제 종료 2~4분 전에 완료로
+     * 오인하므로, machineState=stop(물리적 정지)와 completionTime이 현재 시각을 지났는지(잔여시간 0)를 함께
+     * 확인한다. 세탁기/건조기는 기기 타입별로 독립 판정한다.
      */
     public Optional<LocalDateTime> isCompleted(SmartThingsDeviceStatusResDto status) {
-        var washerJobState = status.getWasherJobState();
-        var dryerJobState = status.getDryerJobState();
+        var now = LocalDateTime.now();
 
-        // 세탁기: "finish", 건조기: "finished"
-        var isFinished = "finish".equalsIgnoreCase(washerJobState) || "finished".equalsIgnoreCase(dryerJobState);
-        if (isFinished) {
-            log.debug("Device job is finished");
-            return Optional.ofNullable(DateTimeUtil.parseAndConvertToKoreaTime(status.getCompletionTime()));
+        var washerCompletion = evaluateCompletion(status.getWasherJobState(),
+                "finish",
+                status.getWasherOperatingState(),
+                status.getWasherCompletionTime(),
+                now);
+        if (washerCompletion.isPresent()) {
+            return washerCompletion;
         }
-        return Optional.empty();
+
+        return evaluateCompletion(status
+                .getDryerJobState(), "finished", status.getDryerOperatingState(), status.getDryerCompletionTime(), now);
+    }
+
+    /**
+     * jobState·machineState·completionTime을 종합하여 단일 기기 타입의 완료 여부를 판정한다. 세 조건을 모두
+     * 만족할 때만 완료로 보고, 완료 시각(없으면 현재 시각)을 반환한다.
+     */
+    private Optional<LocalDateTime> evaluateCompletion(String jobState,
+            String finishedJobState,
+            String machineState,
+            String completionTimeStr,
+            LocalDateTime now) {
+        if (!finishedJobState.equalsIgnoreCase(jobState)) {
+            return Optional.empty();
+        }
+        if (!"stop".equalsIgnoreCase(machineState)) {
+            log.debug("job finished but machine not stopped yet machineState={} jobState={}", machineState, jobState);
+            return Optional.empty();
+        }
+        var completionTime = DateTimeUtil.parseAndConvertToKoreaTime(completionTimeStr);
+        if (completionTime != null && completionTime.isAfter(now)) {
+            log.debug("job finished but completion time still in future completionTime={} jobState={}",
+                    completionTime,
+                    jobState);
+            return Optional.empty();
+        }
+        log.debug("device job is completed jobState={} completionTime={}", jobState, completionTime);
+        return Optional.of(completionTime != null ? completionTime : now);
     }
 
     /**

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/TestDeviceCycleRunner.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/TestDeviceCycleRunner.java
@@ -1,7 +1,9 @@
 package team.washer.server.v2.domain.smartthings.support;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
 
+import org.jspecify.annotations.NonNull;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.stereotype.Component;
@@ -34,6 +36,8 @@ public class TestDeviceCycleRunner implements ApplicationRunner {
     private static final int TARGET_DEVICE_COUNT = 3;
     private static final long AFTER_POWER_ON_WAIT_MS = 15_000L;
     private static final long AFTER_SHUTDOWN_WAIT_MS = 10_000L;
+    private static final long MIN_START_DELAY_MS = 0L;
+    private static final long MAX_START_DELAY_MS = 10_000L;
 
     private final MachineRepository machineRepository;
     private final DeviceStatusQuerySupport deviceStatusQuerySupport;
@@ -41,7 +45,7 @@ public class TestDeviceCycleRunner implements ApplicationRunner {
     private final DeviceShutdownSupport deviceShutdownSupport;
 
     @Override
-    public void run(ApplicationArguments args) {
+    public void run(@NonNull ApplicationArguments args) {
         log.info("🚀 [기기 사이클 테스트] 부팅 완료 감지 - 백그라운드에서 테스트를 시작합니다.");
         CompletableFuture.runAsync(this::runCycleTest);
     }
@@ -60,9 +64,11 @@ public class TestDeviceCycleRunner implements ApplicationRunner {
             return;
         }
 
-        for (var machine : machines) {
-            runSingleDevice(machine);
-        }
+        // 각 기기를 병렬로 실행하되, 시작 전 랜덤 지연을 두어 SmartThings 명령 호출을 시간상 분산시키고
+        // 여러 기기가 동시에 작동 중인 상황을 자연스럽게 재현한다.
+        var futures = machines.stream().map(machine -> CompletableFuture.runAsync(() -> runSingleDevice(machine)))
+                .toArray(CompletableFuture[]::new);
+        CompletableFuture.allOf(futures).join();
 
         log.info("════════════════════════════════════════════════════════");
         log.info("✅ [기기 사이클 테스트] 모든 대상 기기 처리를 완료했습니다.");
@@ -72,8 +78,17 @@ public class TestDeviceCycleRunner implements ApplicationRunner {
     private void runSingleDevice(Machine machine) {
         var name = machine.getName();
         var deviceId = machine.getDeviceId();
+
+        var startDelay = ThreadLocalRandom.current().nextLong(MIN_START_DELAY_MS, MAX_START_DELAY_MS + 1);
         log.info("────────────────────────────────────────────────────────");
-        log.info("▶️  [{}] 테스트 시작 (deviceId={}, type={})", name, deviceId, machine.getType());
+        log.info("⏳ [{}] 시작 전 랜덤 대기 {}초 (deviceId={}, type={})",
+                name,
+                startDelay / 1000.0,
+                deviceId,
+                machine.getType());
+        sleep(startDelay);
+
+        log.info("▶️  [{}] 테스트 시작", name);
 
         try {
             logCurrentState(machine, "1️⃣ 시작 전 상태");

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/TestDeviceCycleRunner.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/TestDeviceCycleRunner.java
@@ -1,0 +1,135 @@
+package team.washer.server.v2.domain.smartthings.support;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.smartthings.dto.request.SmartThingsCommandReqDto;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.service.SendDeviceCommandService;
+
+/**
+ * [임시 검증 코드] 실기기 대상 "전원 ON → 안전 종료" 1회성 사이클 테스트 실행기.
+ *
+ * <p>
+ * 애플리케이션 부팅이 완료되면 백그라운드 스레드에서 자동으로 1회 실행됩니다. 원격 제어(Smart Control) 활성화 여부와
+ * {@code setMachineState(stop)} 동작을 실측하기 위한 일회성 코드입니다. 검증이 끝나면 이 클래스를 반드시
+ * 삭제하세요.
+ *
+ * <p>
+ * ⚠️ 주의: 이 코드는 부팅할 때마다 실제 기기에 명령을 전송합니다. switch on은 전원만 켜며 실제 세탁 사이클이 물리적으로
+ * 시작되지 않을 수 있습니다. 핵심 목적은 명령 전달 및 종료 명령 적용 여부 확인입니다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TestDeviceCycleRunner implements ApplicationRunner {
+
+    private static final int TARGET_DEVICE_COUNT = 3;
+    private static final long AFTER_POWER_ON_WAIT_MS = 15_000L;
+    private static final long AFTER_SHUTDOWN_WAIT_MS = 10_000L;
+
+    private final MachineRepository machineRepository;
+    private final DeviceStatusQuerySupport deviceStatusQuerySupport;
+    private final SendDeviceCommandService sendDeviceCommandService;
+    private final DeviceShutdownSupport deviceShutdownSupport;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("🚀 [기기 사이클 테스트] 부팅 완료 감지 - 백그라운드에서 테스트를 시작합니다.");
+        CompletableFuture.runAsync(this::runCycleTest);
+    }
+
+    public void runCycleTest() {
+        var machines = machineRepository.findAll().stream()
+                .filter(machine -> machine.getDeviceId() != null && !machine.getDeviceId().isBlank())
+                .limit(TARGET_DEVICE_COUNT).toList();
+
+        log.info("════════════════════════════════════════════════════════");
+        log.info("🔧 [기기 사이클 테스트] 시작합니다. 대상 기기: {}대", machines.size());
+        log.info("════════════════════════════════════════════════════════");
+
+        if (machines.isEmpty()) {
+            log.warn("⚠️  [기기 사이클 테스트] deviceId가 등록된 기기가 없어 테스트를 중단합니다.");
+            return;
+        }
+
+        for (var machine : machines) {
+            runSingleDevice(machine);
+        }
+
+        log.info("════════════════════════════════════════════════════════");
+        log.info("✅ [기기 사이클 테스트] 모든 대상 기기 처리를 완료했습니다.");
+        log.info("════════════════════════════════════════════════════════");
+    }
+
+    private void runSingleDevice(Machine machine) {
+        var name = machine.getName();
+        var deviceId = machine.getDeviceId();
+        log.info("────────────────────────────────────────────────────────");
+        log.info("▶️  [{}] 테스트 시작 (deviceId={}, type={})", name, deviceId, machine.getType());
+
+        try {
+            logCurrentState(machine, "1️⃣ 시작 전 상태");
+
+            log.info("⚡ [{}] 전원 ON 명령(switch/on)을 전송합니다...", name);
+            sendDeviceCommandService.execute(deviceId, SmartThingsCommandReqDto.powerOn());
+            log.info("⚡ [{}] 전원 ON 명령 전송 완료. {}초 대기합니다.", name, AFTER_POWER_ON_WAIT_MS / 1000);
+            sleep(AFTER_POWER_ON_WAIT_MS);
+
+            var statusBeforeShutdown = logCurrentState(machine, "2️⃣ 작동 시도 후 상태");
+
+            log.info("🛑 [{}] 안전 종료를 시도합니다 (작동 중이면 setMachineState stop, 유휴면 switch off)...", name);
+            var result = deviceShutdownSupport.shutdown(machine, statusBeforeShutdown);
+            log.info("🛑 [{}] 안전 종료 결과: {}", name, describeResult(result));
+            sleep(AFTER_SHUTDOWN_WAIT_MS);
+
+            logCurrentState(machine, "3️⃣ 종료 후 상태");
+            log.info("✔️  [{}] 테스트 완료", name);
+        } catch (Exception e) {
+            log.error("❌ [{}] 테스트 중 오류 발생: {}", name, e.getMessage(), e);
+        }
+    }
+
+    private SmartThingsDeviceStatusResDto logCurrentState(Machine machine, String phase) {
+        try {
+            var status = deviceStatusQuerySupport.queryDeviceStatus(machine.getDeviceId());
+            var machineState = machine.isWasher() ? status.getWasherOperatingState() : status.getDryerOperatingState();
+            var jobState = machine.isWasher() ? status.getWasherJobState() : status.getDryerJobState();
+            log.info("📊 [{}] {} → machineState={}, jobState={}, switch={}, 원격제어={}",
+                    machine.getName(),
+                    phase,
+                    machineState,
+                    jobState,
+                    status.getSwitchStatus(),
+                    status.isRemoteControlEnabled() ? "활성(ON)" : "비활성(OFF)");
+            return status;
+        } catch (Exception e) {
+            log.warn("📊 [{}] {} → 상태 조회 실패: {}", machine.getName(), phase, e.getMessage());
+            return null;
+        }
+    }
+
+    private String describeResult(DeviceShutdownSupport.ShutdownResult result) {
+        return switch (result) {
+            case STOPPED -> "작동 중 → 안전 정지 명령 전송됨 (STOPPED)";
+            case POWERED_OFF -> "유휴 상태 → 전원 차단됨 (POWERED_OFF)";
+            case SKIPPED_REMOTE_DISABLED -> "작동 중이나 원격 제어 비활성 → 종료 못함 (SKIPPED_REMOTE_DISABLED)";
+            case SKIPPED_UNKNOWN -> "상태 불명 → 종료하지 않음 (SKIPPED_UNKNOWN)";
+        };
+    }
+
+    private void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
@@ -91,7 +91,7 @@ class QueryAllMachinesStatusServiceTest {
             var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(null,
                     washerJobAttr,
                     completionTimeAttr);
-            var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null);
+            var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null, null);
             var deviceStatus = new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
 
             when(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1", "device-2")))

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/CancelOverdueReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/CancelOverdueReservationServiceTest.java
@@ -106,7 +106,7 @@ class CancelOverdueReservationServiceTest {
                     "2026-01-26T14:30:00Z",
                     null);
             var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(null, null, completionTimeAttr);
-            var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null);
+            var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null, null);
             var deviceStatus = new SmartThingsDeviceStatusResDto(java.util.Map.of("main", componentStatus));
             when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
             when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class))).thenReturn(true);

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ProcessReservationLifecycleServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ProcessReservationLifecycleServiceTest.java
@@ -64,7 +64,7 @@ class ProcessReservationLifecycleServiceTest {
     private SmartThingsDeviceStatusResDto buildDeviceStatus(String completionTime) {
         var completionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState(completionTime, null, null);
         var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(null, null, completionTimeAttr);
-        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null);
+        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null, null);
         return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
     }
 

--- a/src/test/java/team/washer/server/v2/domain/smartthings/service/ShutdownIdleMachinesServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/service/ShutdownIdleMachinesServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.*;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -24,9 +25,12 @@ import team.washer.server.v2.domain.machine.enums.Position;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
-import team.washer.server.v2.domain.smartthings.dto.request.SmartThingsCommandReqDto;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.domain.smartthings.exception.SmartThingsPermissionException;
 import team.washer.server.v2.domain.smartthings.service.impl.ShutdownIdleMachinesServiceImpl;
+import team.washer.server.v2.domain.smartthings.support.DeviceShutdownSupport;
+import team.washer.server.v2.domain.smartthings.support.DeviceShutdownSupport.ShutdownResult;
+import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ShutdownIdleMachinesServiceImpl 클래스의")
@@ -42,10 +46,15 @@ class ShutdownIdleMachinesServiceTest {
     private ReservationRepository reservationRepository;
 
     @Mock
-    private SendDeviceCommandService sendDeviceCommandService;
+    private DeviceStatusQuerySupport deviceStatusQuerySupport;
+
+    @Mock
+    private DeviceShutdownSupport deviceShutdownSupport;
 
     private static final List<ReservationStatus> ACTIVE_STATUSES = List.of(ReservationStatus.RESERVED,
             ReservationStatus.RUNNING);
+
+    private static final SmartThingsDeviceStatusResDto EMPTY_STATUS = new SmartThingsDeviceStatusResDto(Map.of());
 
     private Machine createMachine(final Long id, final String name, final String deviceId) {
         var machine = Machine.builder().name(name).type(MachineType.WASHER).deviceId(deviceId).floor(2)
@@ -74,7 +83,7 @@ class ShutdownIdleMachinesServiceTest {
 
                 // Then
                 then(reservationRepository).shouldHaveNoInteractions();
-                then(sendDeviceCommandService).shouldHaveNoInteractions();
+                then(deviceShutdownSupport).shouldHaveNoInteractions();
             }
         }
 
@@ -83,19 +92,21 @@ class ShutdownIdleMachinesServiceTest {
         class Context_with_idle_machines {
 
             @Test
-            @DisplayName("해당 기기에 전원 종료 명령을 전송해야 한다")
-            void it_sends_power_off_command() {
+            @DisplayName("기기 상태를 조회하여 안전 종료를 위임해야 한다")
+            void it_delegates_safe_shutdown() {
                 // Given
                 var machine = createMachine(1L, "W-2F-L1", "device-1");
                 given(machineRepository.findAll()).willReturn(List.of(machine));
                 given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of());
+                given(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1")))
+                        .willReturn(Map.of("device-1", EMPTY_STATUS));
+                given(deviceShutdownSupport.shutdown(eq(machine), any())).willReturn(ShutdownResult.POWERED_OFF);
 
                 // When
                 shutdownIdleMachinesService.execute();
 
                 // Then
-                then(sendDeviceCommandService).should(times(1)).execute(eq("device-1"),
-                        any(SmartThingsCommandReqDto.class));
+                then(deviceShutdownSupport).should(times(1)).shutdown(eq(machine), any());
             }
         }
 
@@ -104,7 +115,7 @@ class ShutdownIdleMachinesServiceTest {
         class Context_with_reserved_machines {
 
             @Test
-            @DisplayName("해당 기기는 건너뛰어야 한다")
+            @DisplayName("해당 기기는 건너뛰고 상태 조회와 종료를 하지 않아야 한다")
             void it_skips_reserved_machine() {
                 // Given
                 var machine = createMachine(1L, "W-2F-L1", "device-1");
@@ -115,7 +126,31 @@ class ShutdownIdleMachinesServiceTest {
                 shutdownIdleMachinesService.execute();
 
                 // Then
-                then(sendDeviceCommandService).shouldHaveNoInteractions();
+                then(deviceStatusQuerySupport).shouldHaveNoInteractions();
+                then(deviceShutdownSupport).shouldHaveNoInteractions();
+            }
+        }
+
+        @Nested
+        @DisplayName("예약 없이 작동 중(무단 사용)인 기기일 때")
+        class Context_with_unauthorized_usage {
+
+            @Test
+            @DisplayName("안전 정지 결과를 받아 전원을 강제 차단하지 않아야 한다")
+            void it_safely_stops_without_power_off() {
+                // Given
+                var machine = createMachine(1L, "W-2F-L1", "device-1");
+                given(machineRepository.findAll()).willReturn(List.of(machine));
+                given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of());
+                given(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1")))
+                        .willReturn(Map.of("device-1", EMPTY_STATUS));
+                given(deviceShutdownSupport.shutdown(eq(machine), any())).willReturn(ShutdownResult.STOPPED);
+
+                // When
+                assertThatCode(() -> shutdownIdleMachinesService.execute()).doesNotThrowAnyException();
+
+                // Then
+                then(deviceShutdownSupport).should(times(1)).shutdown(eq(machine), any());
             }
         }
 
@@ -131,17 +166,17 @@ class ShutdownIdleMachinesServiceTest {
                 var machine2 = createMachine(2L, "W-2F-R1", "device-2");
                 given(machineRepository.findAll()).willReturn(List.of(machine1, machine2));
                 given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of());
-                willThrow(new SmartThingsPermissionException("권한 없음")).given(sendDeviceCommandService)
-                        .execute(eq("device-1"), any(SmartThingsCommandReqDto.class));
+                given(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1", "device-2")))
+                        .willReturn(Map.of("device-1", EMPTY_STATUS, "device-2", EMPTY_STATUS));
+                willThrow(new SmartThingsPermissionException("권한 없음")).given(deviceShutdownSupport)
+                        .shutdown(eq(machine1), any());
 
                 // When
                 shutdownIdleMachinesService.execute();
 
                 // Then
-                then(sendDeviceCommandService).should(times(1)).execute(eq("device-1"),
-                        any(SmartThingsCommandReqDto.class));
-                then(sendDeviceCommandService).should(never()).execute(eq("device-2"),
-                        any(SmartThingsCommandReqDto.class));
+                then(deviceShutdownSupport).should(times(1)).shutdown(eq(machine1), any());
+                then(deviceShutdownSupport).should(never()).shutdown(eq(machine2), any());
             }
         }
 
@@ -157,15 +192,16 @@ class ShutdownIdleMachinesServiceTest {
                 var machine2 = createMachine(2L, "W-2F-R1", "device-2");
                 given(machineRepository.findAll()).willReturn(List.of(machine1, machine2));
                 given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of());
-                willThrow(new RuntimeException("일시적 오류")).given(sendDeviceCommandService).execute(eq("device-1"),
-                        any(SmartThingsCommandReqDto.class));
+                given(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1", "device-2")))
+                        .willReturn(Map.of("device-1", EMPTY_STATUS, "device-2", EMPTY_STATUS));
+                willThrow(new RuntimeException("일시적 오류")).given(deviceShutdownSupport).shutdown(eq(machine1), any());
+                given(deviceShutdownSupport.shutdown(eq(machine2), any())).willReturn(ShutdownResult.POWERED_OFF);
 
                 // When
                 assertThatCode(() -> shutdownIdleMachinesService.execute()).doesNotThrowAnyException();
 
                 // Then
-                then(sendDeviceCommandService).should(times(1)).execute(eq("device-2"),
-                        any(SmartThingsCommandReqDto.class));
+                then(deviceShutdownSupport).should(times(1)).shutdown(eq(machine2), any());
             }
         }
     }

--- a/src/test/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupportTest.java
@@ -1,0 +1,142 @@
+package team.washer.server.v2.domain.smartthings.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.enums.Position;
+import team.washer.server.v2.domain.smartthings.dto.request.SmartThingsCommandReqDto;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.AttributeState;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.ComponentStatus;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.DryerOperatingState;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.RemoteControlStatus;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.WasherOperatingState;
+import team.washer.server.v2.domain.smartthings.service.SendDeviceCommandService;
+import team.washer.server.v2.domain.smartthings.support.DeviceShutdownSupport.ShutdownResult;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeviceShutdownSupport 안전 종료")
+class DeviceShutdownSupportTest {
+
+    @InjectMocks
+    private DeviceShutdownSupport deviceShutdownSupport;
+
+    @Mock
+    private SendDeviceCommandService sendDeviceCommandService;
+
+    private static AttributeState attr(String value) {
+        return new AttributeState(value, null, null);
+    }
+
+    private Machine machine(MachineType type) {
+        return Machine.builder().name("M-2F-L1").type(type).deviceId("device-1").floor(2).position(Position.LEFT)
+                .number(1).status(MachineStatus.NORMAL).availability(MachineAvailability.AVAILABLE).build();
+    }
+
+    private SmartThingsDeviceStatusResDto washerStatus(String machineState, boolean remoteEnabled) {
+        var washerOp = new WasherOperatingState(attr(machineState), null, null);
+        var rc = new RemoteControlStatus(attr(String.valueOf(remoteEnabled)));
+        return new SmartThingsDeviceStatusResDto(Map.of("main", new ComponentStatus(washerOp, null, null, rc)));
+    }
+
+    private SmartThingsDeviceStatusResDto dryerStatus(String machineState, boolean remoteEnabled) {
+        var dryerOp = new DryerOperatingState(attr(machineState), null, null);
+        var rc = new RemoteControlStatus(attr(String.valueOf(remoteEnabled)));
+        return new SmartThingsDeviceStatusResDto(Map.of("main", new ComponentStatus(null, dryerOp, null, rc)));
+    }
+
+    @Nested
+    @DisplayName("작동 중인 기기")
+    class OperatingMachine {
+
+        @Test
+        @DisplayName("세탁기가 run이고 원격 제어가 켜져 있으면 setMachineState stop으로 안전 정지하고 전원을 차단하지 않는다")
+        void shouldSafelyStopWasher_WhenRunningAndRemoteEnabled() {
+            var machine = machine(MachineType.WASHER);
+
+            var result = deviceShutdownSupport.shutdown(machine, washerStatus("run", true));
+
+            assertThat(result).isEqualTo(ShutdownResult.STOPPED);
+            var captor = ArgumentCaptor.forClass(SmartThingsCommandReqDto.class);
+            then(sendDeviceCommandService).should(times(1)).execute(eq("device-1"), captor.capture());
+            var command = captor.getValue().commands().get(0);
+            assertThat(command.capability()).isEqualTo("washerOperatingState");
+            assertThat(command.command()).isEqualTo("setMachineState");
+            assertThat(command.arguments()).containsExactly("stop");
+        }
+
+        @Test
+        @DisplayName("건조기가 pause이고 원격 제어가 켜져 있으면 dryerOperatingState로 안전 정지한다")
+        void shouldSafelyStopDryer_WhenPausedAndRemoteEnabled() {
+            var machine = machine(MachineType.DRYER);
+
+            var result = deviceShutdownSupport.shutdown(machine, dryerStatus("pause", true));
+
+            assertThat(result).isEqualTo(ShutdownResult.STOPPED);
+            var captor = ArgumentCaptor.forClass(SmartThingsCommandReqDto.class);
+            then(sendDeviceCommandService).should(times(1)).execute(eq("device-1"), captor.capture());
+            assertThat(captor.getValue().commands().get(0).capability()).isEqualTo("dryerOperatingState");
+        }
+
+        @Test
+        @DisplayName("작동 중이지만 원격 제어가 꺼져 있으면 어떤 명령도 보내지 않고 SKIPPED_REMOTE_DISABLED를 반환한다")
+        void shouldSkip_WhenRunningButRemoteDisabled() {
+            var machine = machine(MachineType.WASHER);
+
+            var result = deviceShutdownSupport.shutdown(machine, washerStatus("run", false));
+
+            assertThat(result).isEqualTo(ShutdownResult.SKIPPED_REMOTE_DISABLED);
+            then(sendDeviceCommandService).should(never()).execute(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("유휴/불명 기기")
+    class IdleMachine {
+
+        @Test
+        @DisplayName("정지(stop) 상태인 유휴 기기는 switch off로 전원을 정리한다")
+        void shouldPowerOff_WhenIdle() {
+            var machine = machine(MachineType.WASHER);
+
+            var result = deviceShutdownSupport.shutdown(machine, washerStatus("stop", false));
+
+            assertThat(result).isEqualTo(ShutdownResult.POWERED_OFF);
+            var captor = ArgumentCaptor.forClass(SmartThingsCommandReqDto.class);
+            then(sendDeviceCommandService).should(times(1)).execute(eq("device-1"), captor.capture());
+            var command = captor.getValue().commands().get(0);
+            assertThat(command.capability()).isEqualTo("switch");
+            assertThat(command.command()).isEqualTo("off");
+        }
+
+        @Test
+        @DisplayName("상태가 null이면 안전을 위해 종료하지 않고 SKIPPED_UNKNOWN을 반환한다")
+        void shouldSkip_WhenStatusNull() {
+            var machine = machine(MachineType.WASHER);
+
+            var result = deviceShutdownSupport.shutdown(machine, null);
+
+            assertThat(result).isEqualTo(ShutdownResult.SKIPPED_UNKNOWN);
+            then(sendDeviceCommandService).should(never()).execute(any(), any());
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupportTest.java
@@ -1,0 +1,139 @@
+package team.washer.server.v2.domain.smartthings.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.AttributeState;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.ComponentStatus;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.DryerOperatingState;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.WasherOperatingState;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("MachineStateDetectionSupport 완료 판정")
+class MachineStateDetectionSupportTest {
+
+    @InjectMocks
+    private MachineStateDetectionSupport machineStateDetectionSupport;
+
+    @Mock
+    private DeviceStatusQuerySupport deviceStatusQuerySupport;
+
+    private static String isoUtc(ZonedDateTime koreaTime) {
+        return koreaTime.withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime().toString() + "Z";
+    }
+
+    private static AttributeState attr(String value) {
+        return value == null ? null : new AttributeState(value, null, null);
+    }
+
+    private static SmartThingsDeviceStatusResDto washerStatus(String machineState,
+            String jobState,
+            String completionTime) {
+        var washerOpState = new WasherOperatingState(attr(machineState), attr(jobState), attr(completionTime));
+        return new SmartThingsDeviceStatusResDto(Map.of("main", new ComponentStatus(washerOpState, null, null, null)));
+    }
+
+    private static SmartThingsDeviceStatusResDto dryerStatus(String machineState,
+            String jobState,
+            String completionTime) {
+        var dryerOpState = new DryerOperatingState(attr(machineState), attr(jobState), attr(completionTime));
+        return new SmartThingsDeviceStatusResDto(Map.of("main", new ComponentStatus(null, dryerOpState, null, null)));
+    }
+
+    @Nested
+    @DisplayName("세탁기 완료 판정")
+    class WasherCompletion {
+
+        @Test
+        @DisplayName("jobState=finish, machineState=stop, 완료 시각이 지났으면 완료로 판정한다")
+        void shouldComplete_WhenFinishedStoppedAndTimePassed() {
+            var past = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(1);
+            var status = washerStatus("stop", "finish", isoUtc(past));
+
+            var result = machineStateDetectionSupport.isCompleted(status);
+
+            assertThat(result).isPresent();
+        }
+
+        @Test
+        @DisplayName("jobState=finish 이지만 machineState=run 이면 조기 보고로 보고 미완료로 판정한다")
+        void shouldNotComplete_WhenFinishedButStillRunning() {
+            var past = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(1);
+            var status = washerStatus("run", "finish", isoUtc(past));
+
+            var result = machineStateDetectionSupport.isCompleted(status);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("jobState=finish, machineState=stop 이지만 완료 시각이 미래(잔여시간 남음)면 미완료로 판정한다")
+        void shouldNotComplete_WhenFinishedButCompletionTimeInFuture() {
+            var future = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(3);
+            var status = washerStatus("stop", "finish", isoUtc(future));
+
+            var result = machineStateDetectionSupport.isCompleted(status);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("jobState가 finish 가 아니면 미완료로 판정한다")
+        void shouldNotComplete_WhenJobStateNotFinished() {
+            var status = washerStatus("run", "spin", null);
+
+            var result = machineStateDetectionSupport.isCompleted(status);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("completionTime 이 없어도 jobState=finish, machineState=stop 이면 완료로 판정한다")
+        void shouldComplete_WhenCompletionTimeNull() {
+            var status = washerStatus("stop", "finish", null);
+
+            var result = machineStateDetectionSupport.isCompleted(status);
+
+            assertThat(result).isPresent();
+        }
+    }
+
+    @Nested
+    @DisplayName("건조기 완료 판정")
+    class DryerCompletion {
+
+        @Test
+        @DisplayName("jobState=finished, machineState=stop, 완료 시각이 지났으면 완료로 판정한다")
+        void shouldComplete_WhenFinishedStoppedAndTimePassed() {
+            var past = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(1);
+            var status = dryerStatus("stop", "finished", isoUtc(past));
+
+            var result = machineStateDetectionSupport.isCompleted(status);
+
+            assertThat(result).isPresent();
+        }
+
+        @Test
+        @DisplayName("jobState=cooling 잔여 단계이고 machineState=run 이면 미완료로 판정한다")
+        void shouldNotComplete_WhenCoolingAndRunning() {
+            var future = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(2);
+            var status = dryerStatus("run", "cooling", isoUtc(future));
+
+            var result = machineStateDetectionSupport.isCompleted(status);
+
+            assertThat(result).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## 개요

SmartThings 기기 상태를 잘못 해석하여 발생하던 두 가지 현상을 수정하였습니다. 세탁/건조가 실제 종료 2~4분 전에 완료로 표시되던 문제와, 예약 없이 작동 중인 기기가 갑자기 전원 차단되던 문제를 함께 해결하였습니다.

## 본문

### 1. 세탁/건조 조기 완료 표시 수정 (`MachineStateDetectionSupport`)

기존 완료 판정은 SmartThings `jobState`(`finish`/`finished`) 문자열 하나에만 의존하였습니다. 삼성 기기는 냉각(`cooling`)·구김방지(`wrinklePrevent`) 등 잔여 단계가 남아 있어도 `jobState`를 먼저 완료로 보고하는 경우가 있어, 실제 종료 2~4분 전에 완료로 오인되었습니다.

- 완료 판정을 `jobState` + `machineState=stop`(물리적 정지) + `completionTime` 경과(잔여시간 0)의 `AND` 조건으로 강화하였습니다.
- 세탁기/건조기를 타입별로 독립 판정하도록 분리하였습니다.
- `SmartThingsDeviceStatusResDto`에 `getWasherCompletionTime`/`getDryerCompletionTime` 게터를 추가하였습니다.

### 2. 무단 사용 기기 안전 종료 및 표시 반영 (`DeviceShutdownSupport`, `ShutdownIdleMachinesServiceImpl`, `QueryAllMachinesStatusServiceImpl`)

`ShutdownIdleMachinesServiceImpl`이 활성 예약 없는 모든 기기에 실제 작동 상태 확인 없이 `switch off`(전원 차단)를 전송하여, 예약 없이 사용 중인 기기를 강제 종료시키던 문제가 있었습니다.

- 안전 종료 공통 컴포넌트 `DeviceShutdownSupport`를 도입하였습니다. 작동 중(`run`/`pause`)인 기기는 전원 차단 대신 `setMachineState(stop)`으로 사이클을 정상 종료하고, 유휴 기기만 전원을 정리합니다.
- 원격 제어(Smart Control) 비활성 기기에는 명령이 적용되지 않으므로, `remoteControlStatus`를 파싱하여 사전 확인 후 종료하도록 하였습니다.
- `ShutdownIdleMachinesServiceImpl`이 종료 전 기기 상태를 병렬 조회하여 `DeviceShutdownSupport`에 위임하도록 변경하였습니다. 작동 중 기기는 어떤 경우에도 `switch off`하지 않습니다.
- `QueryAllMachinesStatusServiceImpl.computeAvailability`가 예약이 없어도 실제 `machineState=run`이면 `IN_USE`로 표시하여 중복 예약을 차단하도록 하였습니다.

### 테스트

- `MachineStateDetectionSupportTest`, `DeviceShutdownSupportTest`를 신규 추가하였습니다.
- `ShutdownIdleMachinesServiceTest`를 새 구조에 맞게 재작성하였습니다.
- 관련 기존 테스트를 수정하였으며 전체 테스트가 통과하였습니다.

### 배포 전 확인 필요

실제 기기에 제어 명령을 전송하는 변경이므로, 배포 전 다음을 실측 확인해야 합니다.

- 기숙사 기기들의 원격 제어(Smart Control) 활성화 여부 (비활성 시 `setMachineState(stop)`이 무시되고 로그에 `SKIPPED_REMOTE_DISABLED`로 기록됩니다)
- `setMachineState(stop)`이 실제로 안전 배수 후 정지로 동작하는지 기기 1대 선행 검증
