### PR TITLE
[reservation] 패널티 상태 응답에 호실 차단 여부 필드 추가

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/reservation/dto/response/PenaltyStatusResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/dto/response/PenaltyStatusResDto.java
@@ -6,7 +6,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "패널티 상태 DTO")
 public record PenaltyStatusResDto(@Schema(description = "사용자 ID", example = "1") Long userId,
-        @Schema(description = "패널티 적용 여부", example = "true") boolean isPenalized,
-        @Schema(description = "패널티 만료 시간", example = "2026-01-27T21:30:00") LocalDateTime penaltyExpiresAt,
-        @Schema(description = "남은 시간 (분)", example = "5") Long remainingMinutes) {
+        @Schema(description = "패널티 적용 여부 (쿨다운 또는 호실 차단 중 하나라도 활성이면 true)", example = "true") boolean isPenalized,
+        @Schema(description = "패널티 만료 시간 (쿨다운·차단 중 가장 늦은 시각)", example = "2026-01-27T21:30:00") LocalDateTime penaltyExpiresAt,
+        @Schema(description = "남은 시간 (분)", example = "5") Long remainingMinutes,
+        @Schema(description = "48시간 호실 차단 여부 (연장 가능 여부 판단용)", example = "false") boolean isRoomBlocked,
+        @Schema(description = "호실 차단 만료 시간", example = "2026-01-29T12:00:00") LocalDateTime blockExpiresAt) {
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryPenaltyStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryPenaltyStatusServiceImpl.java
@@ -30,6 +30,14 @@ public class QueryPenaltyStatusServiceImpl implements QueryPenaltyStatusService 
             remainingMinutes = Duration.between(LocalDateTime.now(), penaltyExpiresAt).toMinutes();
         }
 
-        return new PenaltyStatusResDto(userId, isPenalized, penaltyExpiresAt, remainingMinutes);
+        final LocalDateTime blockExpiresAt = penaltyRedisUtil.getBlockExpiryTime(userId);
+        final boolean isRoomBlocked = blockExpiresAt != null && LocalDateTime.now().isBefore(blockExpiresAt);
+
+        return new PenaltyStatusResDto(userId,
+                isPenalized,
+                penaltyExpiresAt,
+                remainingMinutes,
+                isRoomBlocked,
+                blockExpiresAt);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryPenaltyStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryPenaltyStatusServiceImpl.java
@@ -22,16 +22,17 @@ public class QueryPenaltyStatusServiceImpl implements QueryPenaltyStatusService 
     @Override
     @Transactional(readOnly = true)
     public PenaltyStatusResDto execute(final Long userId) {
+        final LocalDateTime now = LocalDateTime.now();
         final LocalDateTime penaltyExpiresAt = penaltyRedisUtil.getPenaltyExpiryTime(userId);
-        final boolean isPenalized = penaltyExpiresAt != null && LocalDateTime.now().isBefore(penaltyExpiresAt);
+        final boolean isPenalized = penaltyExpiresAt != null && now.isBefore(penaltyExpiresAt);
 
         Long remainingMinutes = null;
         if (isPenalized) {
-            remainingMinutes = Duration.between(LocalDateTime.now(), penaltyExpiresAt).toMinutes();
+            remainingMinutes = Duration.between(now, penaltyExpiresAt).toMinutes();
         }
 
         final LocalDateTime blockExpiresAt = penaltyRedisUtil.getBlockExpiryTime(userId);
-        final boolean isRoomBlocked = blockExpiresAt != null && LocalDateTime.now().isBefore(blockExpiresAt);
+        final boolean isRoomBlocked = blockExpiresAt != null && now.isBefore(blockExpiresAt);
 
         return new PenaltyStatusResDto(userId,
                 isPenalized,

--- a/src/main/java/team/washer/server/v2/domain/reservation/util/PenaltyRedisUtil.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/util/PenaltyRedisUtil.java
@@ -188,6 +188,20 @@ public class PenaltyRedisUtil {
     // ===== 48시간 예약 차단 (호실 단위) =====
 
     /**
+     * 사용자 ID 기준으로 48시간 호실 차단의 만료 시각을 반환합니다.
+     * <p>
+     * 차단이 없거나 호실 정보가 없으면 {@code null}을 반환합니다.
+     * </p>
+     */
+    public LocalDateTime getBlockExpiryTime(final Long userId) {
+        final User user = userRepository.findById(userId).orElse(null);
+        if (user == null || user.getRoomNumber() == null) {
+            return null;
+        }
+        return expiryFromTtl(blockRemainingTtlSeconds(user.getRoomNumber()));
+    }
+
+    /**
      * 호실 단위 예약 차단 기간을 지정한 일수만큼 연장합니다.
      *
      * @param roomNumber

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/QueryPenaltyStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/QueryPenaltyStatusServiceTest.java
@@ -31,16 +31,17 @@ class QueryPenaltyStatusServiceTest {
     class Describe_execute {
 
         @Nested
-        @DisplayName("패널티가 적용 중인 사용자를 조회할 때")
-        class Context_with_penalized_user {
+        @DisplayName("쿨다운만 있는 사용자를 조회할 때")
+        class Context_with_cooldown_only_user {
 
             @Test
-            @DisplayName("패널티 상태와 남은 분을 반환해야 한다")
-            void it_returns_penalty_status_with_remaining_minutes() {
+            @DisplayName("isPenalized=true, isRoomBlocked=false를 반환해야 한다")
+            void it_returns_penalized_but_not_room_blocked() {
                 // Given
                 var userId = 1L;
-                var expiresAt = LocalDateTime.now().plusMinutes(30);
+                var expiresAt = LocalDateTime.now().plusMinutes(5);
                 given(penaltyRedisUtil.getPenaltyExpiryTime(userId)).willReturn(expiresAt);
+                given(penaltyRedisUtil.getBlockExpiryTime(userId)).willReturn(null);
 
                 // When
                 var result = queryPenaltyStatusService.execute(userId);
@@ -50,8 +51,32 @@ class QueryPenaltyStatusServiceTest {
                 assertThat(result.userId()).isEqualTo(userId);
                 assertThat(result.isPenalized()).isTrue();
                 assertThat(result.penaltyExpiresAt()).isEqualTo(expiresAt);
-                assertThat(result.remainingMinutes()).isNotNull();
                 assertThat(result.remainingMinutes()).isGreaterThan(0L);
+                assertThat(result.isRoomBlocked()).isFalse();
+                assertThat(result.blockExpiresAt()).isNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("호실 차단 중인 사용자를 조회할 때")
+        class Context_with_room_blocked_user {
+
+            @Test
+            @DisplayName("isPenalized=true, isRoomBlocked=true를 반환해야 한다")
+            void it_returns_penalized_and_room_blocked() {
+                // Given
+                var userId = 1L;
+                var blockExpiresAt = LocalDateTime.now().plusHours(40);
+                given(penaltyRedisUtil.getPenaltyExpiryTime(userId)).willReturn(blockExpiresAt);
+                given(penaltyRedisUtil.getBlockExpiryTime(userId)).willReturn(blockExpiresAt);
+
+                // When
+                var result = queryPenaltyStatusService.execute(userId);
+
+                // Then
+                assertThat(result.isPenalized()).isTrue();
+                assertThat(result.isRoomBlocked()).isTrue();
+                assertThat(result.blockExpiresAt()).isEqualTo(blockExpiresAt);
             }
         }
 
@@ -65,6 +90,7 @@ class QueryPenaltyStatusServiceTest {
                 // Given
                 var userId = 1L;
                 given(penaltyRedisUtil.getPenaltyExpiryTime(userId)).willReturn(null);
+                given(penaltyRedisUtil.getBlockExpiryTime(userId)).willReturn(null);
 
                 // When
                 var result = queryPenaltyStatusService.execute(userId);
@@ -75,6 +101,8 @@ class QueryPenaltyStatusServiceTest {
                 assertThat(result.isPenalized()).isFalse();
                 assertThat(result.penaltyExpiresAt()).isNull();
                 assertThat(result.remainingMinutes()).isNull();
+                assertThat(result.isRoomBlocked()).isFalse();
+                assertThat(result.blockExpiresAt()).isNull();
             }
         }
 
@@ -89,6 +117,7 @@ class QueryPenaltyStatusServiceTest {
                 var userId = 1L;
                 var expiredAt = LocalDateTime.now().minusMinutes(1);
                 given(penaltyRedisUtil.getPenaltyExpiryTime(userId)).willReturn(expiredAt);
+                given(penaltyRedisUtil.getBlockExpiryTime(userId)).willReturn(null);
 
                 // When
                 var result = queryPenaltyStatusService.execute(userId);
@@ -96,6 +125,7 @@ class QueryPenaltyStatusServiceTest {
                 // Then
                 assertThat(result.isPenalized()).isFalse();
                 assertThat(result.remainingMinutes()).isNull();
+                assertThat(result.isRoomBlocked()).isFalse();
             }
         }
     }


### PR DESCRIPTION
## 개요

패널티 상태 조회 응답(`PenaltyStatusResDto`)에 48시간 호실 차단 여부(`isRoomBlocked`)와 차단 만료 시각(`blockExpiresAt`) 필드를 추가하였습니다. 클라이언트가 연장 가능 여부를 판단하기 위해 호실 차단 상태를 직접 확인할 수 있도록 하였습니다.

## 본문

**변경 사항**

- `PenaltyStatusResDto`에 `isRoomBlocked`(호실 차단 여부), `blockExpiresAt`(차단 만료 시각) 필드를 추가하였습니다.
- `PenaltyRedisUtil`에 `getBlockExpiryTime(userId)` 메서드를 추가하였습니다. 사용자 ID로 호실 번호를 조회한 뒤 Redis TTL 기반으로 차단 만료 시각을 반환합니다. 차단 내역이 없거나 호실 정보가 없으면 `null`을 반환합니다.
- `QueryPenaltyStatusServiceImpl`에서 `getBlockExpiryTime`을 호출하여 응답 DTO에 호실 차단 상태를 포함하도록 수정하였습니다.
- `QueryPenaltyStatusServiceTest`에 쿨다운만 있는 케이스(`isRoomBlocked=false`)와 호실 차단 중인 케이스(`isRoomBlocked=true`) 시나리오를 추가하였습니다.
