### PR TITLE
[reservation] 비정상 중단 오판 수정 및 디바운스 적용

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/reservation/entity/Reservation.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/entity/Reservation.java
@@ -68,6 +68,10 @@ public class Reservation extends BaseEntity {
     @Column(name = "paused_at")
     private LocalDateTime pausedAt;
 
+    @Column(name = "interruption_count", nullable = false)
+    @Builder.Default
+    private int interruptionCount = 0;
+
     /**
      * 기기 일시정지 시각을 기록합니다.
      */
@@ -80,6 +84,21 @@ public class Reservation extends BaseEntity {
      */
     public void clearPausedAt() {
         this.pausedAt = null;
+    }
+
+    /**
+     * 비정상 중단 감지 횟수를 1 증가시킵니다. 사이클 단계 전환 중 순간적으로 보고되는 정지를 진짜 중단과 구분하기 위한 디바운스
+     * 카운터입니다.
+     */
+    public void incrementInterruptionCount() {
+        this.interruptionCount++;
+    }
+
+    /**
+     * 비정상 중단 감지 추적을 초기화합니다. 기기가 정상 동작(진행 중·일시정지)으로 확인되면 호출합니다.
+     */
+    public void clearInterruptionCount() {
+        this.interruptionCount = 0;
     }
 
     /**

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CancelOverdueReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CancelOverdueReservationServiceImpl.java
@@ -56,7 +56,7 @@ public class CancelOverdueReservationServiceImpl implements CancelOverdueReserva
             try {
                 var machine = reservation.getMachine();
                 var status = deviceStatusQuerySupport.queryDeviceStatus(machine.getDeviceId());
-                var isRunning = machineStateDetectionSupport.isRunning(status);
+                var isRunning = machineStateDetectionSupport.isRunning(status, machine.isWasher());
 
                 if (isRunning) {
                     var expectedCompletionTime = DateTimeUtil.parseAndConvertToKoreaTime(status.getCompletionTime());

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ProcessReservationLifecycleServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ProcessReservationLifecycleServiceImpl.java
@@ -43,7 +43,7 @@ public class ProcessReservationLifecycleServiceImpl implements ProcessReservatio
             try {
                 var machine = reservation.getMachine();
                 var status = deviceStatusQuerySupport.queryDeviceStatus(machine.getDeviceId());
-                var isRunning = machineStateDetectionSupport.isRunning(status);
+                var isRunning = machineStateDetectionSupport.isRunning(status, machine.isWasher());
 
                 if (isRunning) {
                     var expectedCompletionTime = DateTimeUtil.parseAndConvertToKoreaTime(status.getCompletionTime());
@@ -68,8 +68,9 @@ public class ProcessReservationLifecycleServiceImpl implements ProcessReservatio
         for (var reservation : runningReservations) {
             try {
                 var machine = reservation.getMachine();
+                var isWasher = machine.isWasher();
                 var status = deviceStatusQuerySupport.queryDeviceStatus(machine.getDeviceId());
-                var completionTime = machineStateDetectionSupport.isCompleted(status);
+                var completionTime = machineStateDetectionSupport.isCompleted(status, isWasher);
 
                 if (completionTime.isPresent()) {
                     reservation.complete();
@@ -80,18 +81,33 @@ public class ProcessReservationLifecycleServiceImpl implements ProcessReservatio
                     reservationNotificationSupport.sendCompletion(reservation.getUser(), machine);
 
                     log.info("Reservation {} completed (RUNNING → COMPLETED)", reservation.getId());
-                } else if (machineStateDetectionSupport.isInterrupted(status)) {
-                    reservation.cancel();
-                    machine.markAsAvailable();
-                    reservationRepository.save(reservation);
-                    machineRepository.save(machine);
+                } else if (machineStateDetectionSupport.isInterrupted(status, isWasher)) {
+                    // 사이클 단계 전환 중 순간적으로 보고되는 정지를 진짜 중단으로 오판하지 않도록, 연속으로 중단이
+                    // 감지될 때만 취소를 확정한다.
+                    reservation.incrementInterruptionCount();
+                    if (reservation.getInterruptionCount() >= ReservationConstants.INTERRUPTION_CONFIRM_THRESHOLD) {
+                        reservation.cancel();
+                        reservation.clearInterruptionCount();
+                        machine.markAsAvailable();
+                        reservationRepository.save(reservation);
+                        machineRepository.save(machine);
 
-                    reservationNotificationSupport.sendInterruption(reservation.getUser(), machine);
+                        reservationNotificationSupport.sendInterruption(reservation.getUser(), machine);
 
-                    log.warn(
-                            "Reservation {} cancelled due to machine interruption, no penalty applied (RUNNING → CANCELLED)",
-                            reservation.getId());
-                } else if (machineStateDetectionSupport.isPaused(status)) {
+                        log.warn(
+                                "Reservation {} cancelled due to confirmed machine interruption, no penalty applied (RUNNING → CANCELLED)",
+                                reservation.getId());
+                    } else {
+                        reservationRepository.save(reservation);
+                        log.warn("Reservation {} interruption suspected count={} threshold={} deferring cancellation",
+                                reservation.getId(),
+                                reservation.getInterruptionCount(),
+                                ReservationConstants.INTERRUPTION_CONFIRM_THRESHOLD);
+                    }
+                } else if (machineStateDetectionSupport.isPaused(status, isWasher)) {
+                    if (reservation.getInterruptionCount() > 0) {
+                        reservation.clearInterruptionCount();
+                    }
                     if (reservation.getPausedAt() == null) {
                         reservation.markAsPaused();
                         reservationRepository.save(reservation);
@@ -112,6 +128,9 @@ public class ProcessReservationLifecycleServiceImpl implements ProcessReservatio
                                 ReservationConstants.PAUSE_TIMEOUT_MINUTES);
                     }
                 } else {
+                    if (reservation.getInterruptionCount() > 0) {
+                        reservation.clearInterruptionCount();
+                    }
                     if (reservation.getPausedAt() != null) {
                         reservation.clearPausedAt();
                         log.info("Reservation {} resumed from pause, clearing pause tracking", reservation.getId());

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ProcessReservationLifecycleServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ProcessReservationLifecycleServiceImpl.java
@@ -107,6 +107,7 @@ public class ProcessReservationLifecycleServiceImpl implements ProcessReservatio
                 } else if (machineStateDetectionSupport.isPaused(status, isWasher)) {
                     if (reservation.getInterruptionCount() > 0) {
                         reservation.clearInterruptionCount();
+                        reservationRepository.save(reservation);
                     }
                     if (reservation.getPausedAt() == null) {
                         reservation.markAsPaused();
@@ -130,6 +131,7 @@ public class ProcessReservationLifecycleServiceImpl implements ProcessReservatio
                 } else {
                     if (reservation.getInterruptionCount() > 0) {
                         reservation.clearInterruptionCount();
+                        reservationRepository.save(reservation);
                     }
                     if (reservation.getPausedAt() != null) {
                         reservation.clearPausedAt();

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
@@ -5,18 +5,19 @@ import java.time.ZoneId;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.global.util.DateTimeUtil;
 
 /**
  * SmartThings 기기 상태 감지를 담당하는 지원 컴포넌트.
+ *
+ * <p>
+ * 모든 판정은 기기 타입(세탁기/건조기)에 해당하는 capability만 검사한다. 하나의 deviceId가 세탁기·건조기
+ * capability를 동시에 노출하는 경우, 사용하지 않는 쪽의 유휴 상태를 비정상 중단으로 오판하지 않기 위함이다.
  */
 @Component
-@RequiredArgsConstructor
 @Slf4j
 public class MachineStateDetectionSupport {
 
@@ -26,17 +27,18 @@ public class MachineStateDetectionSupport {
      */
     private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
-    private final DeviceStatusQuerySupport deviceStatusQuerySupport;
-
     /**
-     * 기기가 작동 중인지 감지한다.
+     * 기기가 작동 중인지 감지한다. 세탁기는 washerOperatingState, 건조기는 dryerOperatingState의
+     * machineState가 run인지 확인한다.
      */
-    public boolean isRunning(SmartThingsDeviceStatusResDto status) {
-        var washerOperatingState = status.getWasherOperatingState();
-        var dryerOperatingState = status.getDryerOperatingState();
-        var isRunning = "run".equalsIgnoreCase(washerOperatingState) || "run".equalsIgnoreCase(dryerOperatingState);
+    public boolean isRunning(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        if (status == null) {
+            return false;
+        }
+        var machineState = isWasher ? status.getWasherOperatingState() : status.getDryerOperatingState();
+        var isRunning = "run".equalsIgnoreCase(machineState);
         if (isRunning) {
-            log.debug("device is running");
+            log.debug("device is running isWasher={}", isWasher);
         }
         return isRunning;
     }
@@ -48,23 +50,20 @@ public class MachineStateDetectionSupport {
      * SmartThings 기기는 메인 사이클이 끝나면 냉각(cooling)·구김방지(wrinklePrevent) 등 잔여 단계가 남아 있어도
      * jobState를 finish/finished로 먼저 보고하는 경우가 있다. jobState만으로 판정하면 실제 종료 2~4분 전에 완료로
      * 오인하므로, machineState=stop(물리적 정지)와 completionTime이 현재 시각을 지났는지(잔여시간 0)를 함께
-     * 확인한다. 세탁기/건조기는 기기 타입별로 독립 판정한다.
+     * 확인한다.
      */
-    public Optional<LocalDateTime> isCompleted(SmartThingsDeviceStatusResDto status) {
+    public Optional<LocalDateTime> isCompleted(SmartThingsDeviceStatusResDto status, boolean isWasher) {
         if (status == null) {
             return Optional.empty();
         }
         var now = LocalDateTime.now(KOREA_ZONE);
-
-        var washerCompletion = evaluateCompletion(status.getWasherJobState(),
-                "finish",
-                status.getWasherOperatingState(),
-                status.getWasherCompletionTime(),
-                now);
-        if (washerCompletion.isPresent()) {
-            return washerCompletion;
+        if (isWasher) {
+            return evaluateCompletion(status.getWasherJobState(),
+                    "finish",
+                    status.getWasherOperatingState(),
+                    status.getWasherCompletionTime(),
+                    now);
         }
-
         return evaluateCompletion(status
                 .getDryerJobState(), "finished", status.getDryerOperatingState(), status.getDryerCompletionTime(), now);
     }
@@ -100,99 +99,53 @@ public class MachineStateDetectionSupport {
 
     /**
      * 기기가 비정상 중단되었는지 감지한다.
+     *
+     * <p>
+     * 전원이 꺼진 경우(switch=off)는 명백한 중단으로 본다. 그 외에는 사이클 진행 단계(wash/rinse/spin/drying 등)
+     * 도중 machineState가 stop으로 보고된 경우에만 중단으로 판정한다. machineState=stop이면서 jobState가
+     * finish/finished(정상 완료)이거나 none/공백(사이클 종료 직후 리셋·유휴)인 경우는, 정상 완료를 비정상 중단으로 오판하지
+     * 않도록 중단으로 보지 않는다.
      */
-    public boolean isInterrupted(SmartThingsDeviceStatusResDto status) {
-        var switchStatus = status.getSwitchStatus();
-        if ("off".equalsIgnoreCase(switchStatus)) {
-            log.debug("기기 전원이 꺼져 있음 (switch=off)");
+    public boolean isInterrupted(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        if (status == null) {
+            return false;
+        }
+        if ("off".equalsIgnoreCase(status.getSwitchStatus())) {
+            log.debug("device power off detected switch=off");
             return true;
         }
 
-        var washerMachineState = status.getWasherOperatingState();
-        var washerJobState = status.getWasherJobState();
-        if ("stop".equalsIgnoreCase(washerMachineState) && !"finish".equalsIgnoreCase(washerJobState)) {
-            log.debug("기기 세탁기가 비정상 정지됨 (machineState=stop, jobState={})", washerJobState);
-            return true;
+        var machineState = isWasher ? status.getWasherOperatingState() : status.getDryerOperatingState();
+        if (!"stop".equalsIgnoreCase(machineState)) {
+            return false;
         }
 
-        var dryerMachineState = status.getDryerOperatingState();
-        var dryerJobState = status.getDryerJobState();
-        if ("stop".equalsIgnoreCase(dryerMachineState) && !"finished".equalsIgnoreCase(dryerJobState)) {
-            log.debug("기기 건조기가 비정상 정지됨 (machineState=stop, jobState={})", dryerJobState);
-            return true;
+        var jobState = isWasher ? status.getWasherJobState() : status.getDryerJobState();
+        var finishedJobState = isWasher ? "finish" : "finished";
+        if (finishedJobState.equalsIgnoreCase(jobState)) {
+            return false;
+        }
+        if (jobState == null || jobState.isBlank() || "none".equalsIgnoreCase(jobState)) {
+            log.debug("machine stopped with idle jobState, not treated as interruption jobState={}", jobState);
+            return false;
         }
 
-        return false;
+        log.debug("machine interrupted mid-cycle machineState=stop jobState={}", jobState);
+        return true;
     }
 
     /**
      * 기기가 일시정지 상태인지 감지한다.
      */
-    public boolean isPaused(SmartThingsDeviceStatusResDto status) {
-        var washerMachineState = status.getWasherOperatingState();
-        if ("pause".equalsIgnoreCase(washerMachineState)) {
-            log.debug("기기 세탁기가 일시정지 상태 (machineState=pause)");
-            return true;
-        }
-
-        var dryerMachineState = status.getDryerOperatingState();
-        if ("pause".equalsIgnoreCase(dryerMachineState)) {
-            log.debug("기기 건조기가 일시정지 상태 (machineState=pause)");
-            return true;
-        }
-
-        return false;
-    }
-
-    /**
-     * 기기가 작동 중인지 감지한다.
-     */
-    @Transactional(readOnly = true)
-    public boolean isRunning(String deviceId) {
-        try {
-            return isRunning(deviceStatusQuerySupport.queryDeviceStatus(deviceId));
-        } catch (Exception e) {
-            log.warn("failed to detect running state for device {}", deviceId, e);
+    public boolean isPaused(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        if (status == null) {
             return false;
         }
-    }
-
-    /**
-     * 기기 작업이 완료되었는지 감지한다.
-     */
-    @Transactional(readOnly = true)
-    public Optional<LocalDateTime> isCompleted(String deviceId) {
-        try {
-            return isCompleted(deviceStatusQuerySupport.queryDeviceStatus(deviceId));
-        } catch (Exception e) {
-            log.warn("Failed to detect completion state for device: {}", deviceId, e);
-            return Optional.empty();
+        var machineState = isWasher ? status.getWasherOperatingState() : status.getDryerOperatingState();
+        var isPaused = "pause".equalsIgnoreCase(machineState);
+        if (isPaused) {
+            log.debug("device is paused isWasher={}", isWasher);
         }
-    }
-
-    /**
-     * 기기가 비정상 중단되었는지 감지한다.
-     */
-    @Transactional(readOnly = true)
-    public boolean isInterrupted(String deviceId) {
-        try {
-            return isInterrupted(deviceStatusQuerySupport.queryDeviceStatus(deviceId));
-        } catch (Exception e) {
-            log.warn("기기 {} 중단 상태 감지 실패", deviceId, e);
-            return false;
-        }
-    }
-
-    /**
-     * 기기가 일시정지 상태인지 감지한다.
-     */
-    @Transactional(readOnly = true)
-    public boolean isPaused(String deviceId) {
-        try {
-            return isPaused(deviceStatusQuerySupport.queryDeviceStatus(deviceId));
-        } catch (Exception e) {
-            log.warn("기기 {} 일시정지 상태 감지 실패", deviceId, e);
-            return false;
-        }
+        return isPaused;
     }
 }

--- a/src/main/java/team/washer/server/v2/global/common/constants/ReservationConstants.java
+++ b/src/main/java/team/washer/server/v2/global/common/constants/ReservationConstants.java
@@ -6,4 +6,10 @@ public final class ReservationConstants {
 
     public static final int DEFAULT_RESERVATION_DURATION_MINUTES = 90;
     public static final int PAUSE_TIMEOUT_MINUTES = 10;
+
+    /**
+     * 비정상 중단을 확정하기 전까지 연속으로 중단이 감지되어야 하는 폴링 횟수. 사이클 단계 전환 중 순간적으로 보고되는 정지를 진짜 중단으로
+     * 오판하지 않도록 디바운스하는 데 사용한다. 라이프사이클 폴링 주기(30초) 기준 약 90초 연속 정지 시 확정된다.
+     */
+    public static final int INTERRUPTION_CONFIRM_THRESHOLD = 3;
 }

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/CancelOverdueReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/CancelOverdueReservationServiceTest.java
@@ -1,6 +1,7 @@
 package team.washer.server.v2.domain.reservation.service;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -109,7 +110,8 @@ class CancelOverdueReservationServiceTest {
             var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null, null);
             var deviceStatus = new SmartThingsDeviceStatusResDto(java.util.Map.of("main", componentStatus));
             when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class))).thenReturn(true);
+            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(true);
 
             // When
             cancelOverdueReservationService.execute();
@@ -139,7 +141,8 @@ class CancelOverdueReservationServiceTest {
             when(reservation.getMachine()).thenReturn(machine);
             when(machine.getDeviceId()).thenReturn("device-123");
             when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class))).thenReturn(false);
+            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
             when(reservation.getUser()).thenReturn(user);
             when(user.getId()).thenReturn(1L);
             when(penaltyRedisUtil.hasWarning(1L)).thenReturn(false);
@@ -170,7 +173,8 @@ class CancelOverdueReservationServiceTest {
             when(reservation.getMachine()).thenReturn(machine);
             when(machine.getDeviceId()).thenReturn("device-123");
             when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class))).thenReturn(false);
+            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
             when(reservation.getUser()).thenReturn(user);
             when(user.getId()).thenReturn(1L);
             when(penaltyRedisUtil.hasWarning(1L)).thenReturn(true);
@@ -198,7 +202,8 @@ class CancelOverdueReservationServiceTest {
             when(reservation.getMachine()).thenReturn(machine);
             when(machine.getDeviceId()).thenReturn("device-123");
             when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class))).thenReturn(false);
+            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
             when(reservation.getUser()).thenReturn(user);
             when(user.getId()).thenReturn(1L);
             when(user.getRoomNumber()).thenReturn("101");

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ProcessReservationLifecycleServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ProcessReservationLifecycleServiceTest.java
@@ -1,6 +1,7 @@
 package team.washer.server.v2.domain.reservation.service;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -30,6 +31,7 @@ import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceSt
 import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
 import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.global.common.constants.ReservationConstants;
 
 @ExtendWith(MockitoExtension.class)
 class ProcessReservationLifecycleServiceTest {
@@ -84,7 +86,8 @@ class ProcessReservationLifecycleServiceTest {
             when(reservation.getUser()).thenReturn(user);
             when(machine.getDeviceId()).thenReturn("device-123");
             when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class))).thenReturn(true);
+            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(true);
 
             // When
             processReservationLifecycleService.execute();
@@ -106,7 +109,8 @@ class ProcessReservationLifecycleServiceTest {
             when(reservation.getMachine()).thenReturn(machine);
             when(machine.getDeviceId()).thenReturn("device-123");
             when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class))).thenReturn(false);
+            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
 
             // When
             processReservationLifecycleService.execute();
@@ -134,7 +138,7 @@ class ProcessReservationLifecycleServiceTest {
             when(reservation.getUser()).thenReturn(user);
             when(machine.getDeviceId()).thenReturn("device-123");
             when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class)))
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(Optional.of(LocalDateTime.now()));
 
             // When
@@ -158,11 +162,12 @@ class ProcessReservationLifecycleServiceTest {
             when(reservation.getMachine()).thenReturn(machine);
             when(machine.getDeviceId()).thenReturn("device-123");
             when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class)))
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(Optional.empty());
-            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class)))
+            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(false);
-            when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class))).thenReturn(false);
+            when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
             when(reservation.getExpectedCompletionTime()).thenReturn(null);
 
             // When
@@ -177,8 +182,38 @@ class ProcessReservationLifecycleServiceTest {
         }
 
         @Test
-        @DisplayName("RUNNING 상태에서 기기가 비정상 종료되면 패널티 없이 CANCELLED로 전환하고 중단 알림을 전송한다")
-        void execute_ShouldCancelWithoutPenaltyAndNotify_WhenMachineInterrupted() {
+        @DisplayName("RUNNING 상태에서 중단이 감지되어도 확정 임계치 미만이면 카운트만 증가시키고 취소하지 않는다")
+        void execute_ShouldOnlyIncrementCount_WhenInterruptionBelowThreshold() {
+            // Given
+            var deviceStatus = buildDeviceStatus(null);
+            when(reservationRepository.findByStatusWithMachineAndUser(ReservationStatus.RESERVED))
+                    .thenReturn(List.of());
+            when(reservationRepository.findByStatusWithMachineAndUser(ReservationStatus.RUNNING))
+                    .thenReturn(List.of(reservation));
+            when(reservation.getMachine()).thenReturn(machine);
+            when(machine.getDeviceId()).thenReturn("device-123");
+            when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(Optional.empty());
+            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(true);
+            when(reservation.getInterruptionCount()).thenReturn(1);
+
+            // When
+            processReservationLifecycleService.execute();
+
+            // Then
+            verify(reservation, times(1)).incrementInterruptionCount();
+            verify(reservation, never()).cancel();
+            verify(reservation, never()).clearInterruptionCount();
+            verify(reservationRepository, times(1)).save(reservation);
+            verify(machineRepository, never()).save(machine);
+            verify(reservationNotificationSupport, never()).sendInterruption(any(), any());
+        }
+
+        @Test
+        @DisplayName("RUNNING 상태에서 중단이 확정 임계치까지 연속 감지되면 패널티 없이 CANCELLED로 전환하고 중단 알림을 전송한다")
+        void execute_ShouldCancelWithoutPenaltyAndNotify_WhenInterruptionConfirmed() {
             // Given
             var deviceStatus = buildDeviceStatus(null);
             when(reservationRepository.findByStatusWithMachineAndUser(ReservationStatus.RESERVED))
@@ -189,21 +224,24 @@ class ProcessReservationLifecycleServiceTest {
             when(reservation.getUser()).thenReturn(user);
             when(machine.getDeviceId()).thenReturn("device-123");
             when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class)))
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(Optional.empty());
-            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class))).thenReturn(true);
+            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(true);
+            when(reservation.getInterruptionCount()).thenReturn(ReservationConstants.INTERRUPTION_CONFIRM_THRESHOLD);
 
             // When
             processReservationLifecycleService.execute();
 
             // Then
+            verify(reservation, times(1)).incrementInterruptionCount();
             verify(reservation, times(1)).cancel();
+            verify(reservation, times(1)).clearInterruptionCount();
             verify(machine, times(1)).markAsAvailable();
             verify(reservationRepository, times(1)).save(reservation);
             verify(machineRepository, times(1)).save(machine);
             verify(reservationNotificationSupport, times(1)).sendInterruption(user, machine);
             verify(reservation, never()).complete();
-            verify(reservation, never()).updateExpectedCompletionTime(any());
             verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
         }
 
@@ -219,11 +257,12 @@ class ProcessReservationLifecycleServiceTest {
             when(reservation.getMachine()).thenReturn(machine);
             when(machine.getDeviceId()).thenReturn("device-123");
             when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class)))
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(Optional.empty());
-            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class)))
+            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(false);
-            when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class))).thenReturn(true);
+            when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(true);
             when(reservation.getPausedAt()).thenReturn(null);
 
             // When
@@ -249,11 +288,12 @@ class ProcessReservationLifecycleServiceTest {
             when(reservation.getUser()).thenReturn(user);
             when(machine.getDeviceId()).thenReturn("device-123");
             when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class)))
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(Optional.empty());
-            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class)))
+            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(false);
-            when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class))).thenReturn(true);
+            when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(true);
             when(reservation.getPausedAt()).thenReturn(LocalDateTime.now().minusMinutes(11));
 
             // When
@@ -282,11 +322,12 @@ class ProcessReservationLifecycleServiceTest {
             when(reservation.getMachine()).thenReturn(machine);
             when(machine.getDeviceId()).thenReturn("device-123");
             when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class)))
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(Optional.empty());
-            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class)))
+            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(false);
-            when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class))).thenReturn(false);
+            when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
             when(reservation.getPausedAt()).thenReturn(LocalDateTime.now().minusMinutes(3));
             when(reservation.getExpectedCompletionTime()).thenReturn(null);
 

--- a/src/test/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupportTest.java
@@ -9,26 +9,21 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.AttributeState;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.ComponentStatus;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.DryerOperatingState;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.SwitchCapability;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.WasherOperatingState;
 
-@ExtendWith(MockitoExtension.class)
-@DisplayName("MachineStateDetectionSupport 완료 판정")
+@DisplayName("MachineStateDetectionSupport 상태 판정")
 class MachineStateDetectionSupportTest {
 
-    @InjectMocks
-    private MachineStateDetectionSupport machineStateDetectionSupport;
+    private static final boolean WASHER = true;
+    private static final boolean DRYER = false;
 
-    @Mock
-    private DeviceStatusQuerySupport deviceStatusQuerySupport;
+    private final MachineStateDetectionSupport machineStateDetectionSupport = new MachineStateDetectionSupport();
 
     private static String isoUtc(ZonedDateTime koreaTime) {
         return koreaTime.withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime().toString() + "Z";
@@ -52,6 +47,15 @@ class MachineStateDetectionSupportTest {
         return new SmartThingsDeviceStatusResDto(Map.of("main", new ComponentStatus(null, dryerOpState, null, null)));
     }
 
+    private static SmartThingsDeviceStatusResDto washerStatusWithSwitch(String machineState,
+            String jobState,
+            String switchState) {
+        var washerOpState = new WasherOperatingState(attr(machineState), attr(jobState), null);
+        var switchCapability = new SwitchCapability(attr(switchState));
+        return new SmartThingsDeviceStatusResDto(
+                Map.of("main", new ComponentStatus(washerOpState, null, switchCapability, null)));
+    }
+
     @Nested
     @DisplayName("세탁기 완료 판정")
     class WasherCompletion {
@@ -62,7 +66,7 @@ class MachineStateDetectionSupportTest {
             var past = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(1);
             var status = washerStatus("stop", "finish", isoUtc(past));
 
-            var result = machineStateDetectionSupport.isCompleted(status);
+            var result = machineStateDetectionSupport.isCompleted(status, WASHER);
 
             assertThat(result).isPresent();
         }
@@ -73,7 +77,7 @@ class MachineStateDetectionSupportTest {
             var past = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(1);
             var status = washerStatus("run", "finish", isoUtc(past));
 
-            var result = machineStateDetectionSupport.isCompleted(status);
+            var result = machineStateDetectionSupport.isCompleted(status, WASHER);
 
             assertThat(result).isEmpty();
         }
@@ -84,7 +88,7 @@ class MachineStateDetectionSupportTest {
             var future = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(3);
             var status = washerStatus("stop", "finish", isoUtc(future));
 
-            var result = machineStateDetectionSupport.isCompleted(status);
+            var result = machineStateDetectionSupport.isCompleted(status, WASHER);
 
             assertThat(result).isEmpty();
         }
@@ -94,7 +98,7 @@ class MachineStateDetectionSupportTest {
         void shouldNotComplete_WhenJobStateNotFinished() {
             var status = washerStatus("run", "spin", null);
 
-            var result = machineStateDetectionSupport.isCompleted(status);
+            var result = machineStateDetectionSupport.isCompleted(status, WASHER);
 
             assertThat(result).isEmpty();
         }
@@ -104,7 +108,7 @@ class MachineStateDetectionSupportTest {
         void shouldComplete_WhenCompletionTimeNull() {
             var status = washerStatus("stop", "finish", null);
 
-            var result = machineStateDetectionSupport.isCompleted(status);
+            var result = machineStateDetectionSupport.isCompleted(status, WASHER);
 
             assertThat(result).isPresent();
         }
@@ -120,7 +124,7 @@ class MachineStateDetectionSupportTest {
             var past = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(1);
             var status = dryerStatus("stop", "finished", isoUtc(past));
 
-            var result = machineStateDetectionSupport.isCompleted(status);
+            var result = machineStateDetectionSupport.isCompleted(status, DRYER);
 
             assertThat(result).isPresent();
         }
@@ -131,9 +135,133 @@ class MachineStateDetectionSupportTest {
             var future = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(2);
             var status = dryerStatus("run", "cooling", isoUtc(future));
 
-            var result = machineStateDetectionSupport.isCompleted(status);
+            var result = machineStateDetectionSupport.isCompleted(status, DRYER);
 
             assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("비정상 중단 판정")
+    class Interruption {
+
+        @Test
+        @DisplayName("전원이 꺼져 있으면(switch=off) 중단으로 판정한다")
+        void shouldInterrupt_WhenPowerOff() {
+            var status = washerStatusWithSwitch("run", "wash", "off");
+
+            assertThat(machineStateDetectionSupport.isInterrupted(status, WASHER)).isTrue();
+        }
+
+        @Test
+        @DisplayName("세탁기가 진행 단계(spin) 도중 stop 되면 중단으로 판정한다")
+        void shouldInterrupt_WhenWasherStoppedMidCycle() {
+            var status = washerStatus("stop", "spin", null);
+
+            assertThat(machineStateDetectionSupport.isInterrupted(status, WASHER)).isTrue();
+        }
+
+        @Test
+        @DisplayName("세탁기가 stop, jobState=finish(정상 완료)면 중단으로 판정하지 않는다")
+        void shouldNotInterrupt_WhenWasherFinished() {
+            var status = washerStatus("stop", "finish", null);
+
+            assertThat(machineStateDetectionSupport.isInterrupted(status, WASHER)).isFalse();
+        }
+
+        @Test
+        @DisplayName("세탁기가 stop, jobState=none(종료 직후 리셋·유휴)이면 중단으로 판정하지 않는다")
+        void shouldNotInterrupt_WhenWasherStoppedAndJobReset() {
+            var status = washerStatus("stop", "none", null);
+
+            assertThat(machineStateDetectionSupport.isInterrupted(status, WASHER)).isFalse();
+        }
+
+        @Test
+        @DisplayName("세탁기가 stop, jobState=null이면 중단으로 판정하지 않는다")
+        void shouldNotInterrupt_WhenWasherStoppedAndJobNull() {
+            var status = washerStatus("stop", null, null);
+
+            assertThat(machineStateDetectionSupport.isInterrupted(status, WASHER)).isFalse();
+        }
+
+        @Test
+        @DisplayName("세탁기가 run 중이면 중단으로 판정하지 않는다")
+        void shouldNotInterrupt_WhenWasherRunning() {
+            var status = washerStatus("run", "wash", null);
+
+            assertThat(machineStateDetectionSupport.isInterrupted(status, WASHER)).isFalse();
+        }
+
+        @Test
+        @DisplayName("건조기가 진행 단계(drying) 도중 stop 되면 중단으로 판정한다")
+        void shouldInterrupt_WhenDryerStoppedMidCycle() {
+            var status = dryerStatus("stop", "drying", null);
+
+            assertThat(machineStateDetectionSupport.isInterrupted(status, DRYER)).isTrue();
+        }
+
+        @Test
+        @DisplayName("건조기가 stop, jobState=finished(정상 완료)면 중단으로 판정하지 않는다")
+        void shouldNotInterrupt_WhenDryerFinished() {
+            var status = dryerStatus("stop", "finished", null);
+
+            assertThat(machineStateDetectionSupport.isInterrupted(status, DRYER)).isFalse();
+        }
+
+        @Test
+        @DisplayName("세탁기 capability만 보므로 건조기가 작동 중인 세탁기 기기를 중단으로 오판하지 않는다")
+        void shouldNotInterrupt_WhenOtherTypeIdle() {
+            // 세탁기가 정상 작동(run) 중이지만 건조기 capability가 함께 노출되어 stop/none인 경우에도,
+            // 세탁기 타입 판정은 세탁기 capability만 확인해야 한다.
+            var washerOpState = new WasherOperatingState(attr("run"), attr("wash"), null);
+            var dryerOpState = new DryerOperatingState(attr("stop"), attr("none"), null);
+            var status = new SmartThingsDeviceStatusResDto(
+                    Map.of("main", new ComponentStatus(washerOpState, dryerOpState, null, null)));
+
+            assertThat(machineStateDetectionSupport.isInterrupted(status, WASHER)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("일시정지 판정")
+    class Paused {
+
+        @Test
+        @DisplayName("machineState=pause 이면 일시정지로 판정한다")
+        void shouldPause_WhenMachineStatePause() {
+            var status = washerStatus("pause", "wash", null);
+
+            assertThat(machineStateDetectionSupport.isPaused(status, WASHER)).isTrue();
+        }
+
+        @Test
+        @DisplayName("machineState=run 이면 일시정지가 아니다")
+        void shouldNotPause_WhenRunning() {
+            var status = dryerStatus("run", "drying", null);
+
+            assertThat(machineStateDetectionSupport.isPaused(status, DRYER)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("작동 판정")
+    class Running {
+
+        @Test
+        @DisplayName("machineState=run 이면 작동 중으로 판정한다")
+        void shouldRun_WhenMachineStateRun() {
+            var status = washerStatus("run", "wash", null);
+
+            assertThat(machineStateDetectionSupport.isRunning(status, WASHER)).isTrue();
+        }
+
+        @Test
+        @DisplayName("machineState=stop 이면 작동 중이 아니다")
+        void shouldNotRun_WhenStopped() {
+            var status = washerStatus("stop", "none", null);
+
+            assertThat(machineStateDetectionSupport.isRunning(status, WASHER)).isFalse();
         }
     }
 }


### PR DESCRIPTION
## 개요

기기가 정상 작동·완료 중임에도 "비정상 종료" 알림이 반복적으로 발생하고 예약이 취소되던 문제를 수정하였습니다. `MachineStateDetectionSupport`의 중단 판정 로직을 기기 타입별로 분리하고 판정 범위를 좁혔으며, 순간적인 정지를 진짜 중단과 구분하기 위한 디바운스를 도입하였습니다.

## 본문

### 원인

`MachineStateDetectionSupport.isInterrupted`가 `machineState=stop && jobState!=finish` 조건만으로 중단을 판정하여 정상 상태까지 비정상 중단으로 오판하였습니다.

- 세탁 정상 종료 시 SmartThings가 `jobState`를 `finish → none`으로 리셋하는데, 라이프사이클 폴링(30초)이 `none` 시점에 걸리면 완료(`isCompleted`)로도, 중단(`isInterrupted`)으로도 처리되어 정상 완료가 취소되었습니다.
- 사이클 단계 전환 중 순간적으로 보고되는 `stop`, 그리고 하나의 `deviceId`가 세탁기·건조기 capability를 동시에 노출할 때 사용하지 않는 쪽의 유휴 상태도 오판 원인이 되었습니다.

### 변경 사항

- **타입별 판정**: `isRunning`, `isCompleted`, `isInterrupted`, `isPaused`가 `machine.isWasher()`를 받아 해당 기기 capability만 검사하도록 변경하였습니다. 호출되지 않던 `deviceId` 기반 오버로드는 제거하였습니다.
- **중단 판정 범위 축소**: `switch=off`는 즉시 중단으로 보고, 그 외에는 `jobState`가 `none`·공백·완료 상태이면 중단으로 판정하지 않고 진행 단계(`wash`/`rinse`/`spin`/`drying` 등) 도중 `stop`일 때만 중단으로 의심하도록 변경하였습니다.
- **디바운스 도입**: `Reservation`에 `interruptionCount` 필드와 `incrementInterruptionCount`·`clearInterruptionCount`를 추가하고, `ReservationConstants.INTERRUPTION_CONFIRM_THRESHOLD`(3회, 약 90초) 연속 감지 시에만 취소를 확정하도록 하였습니다. 정상 진행·일시정지로 확인되면 카운터를 초기화합니다.

### 테스트

- `MachineStateDetectionSupportTest`에 비정상 중단 판정 단위 테스트를 추가하였습니다(종료 직후 리셋·타입 오판 회귀 방지 포함).
- `ProcessReservationLifecycleServiceTest`에 디바운스 미달·확정 동작 테스트를 추가하고 기존 테스트의 시그니처 변경을 반영하였습니다.

### 참고

- `ddl-auto: update` 설정으로 `reservations.interruption_count` 컬럼이 자동 추가됩니다.
