### PR TITLE
[reservation] 만료 예약 취소 트랜잭션 범위 분리

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
@@ -101,7 +101,7 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
             LocalDateTime threshold,
             LocalDateTime recentCutoff) {
 
-        return jpaQueryFactory.selectFrom(reservation)
+        return jpaQueryFactory.selectFrom(reservation).leftJoin(reservation.machine, machine).fetchJoin()
                 .where(reservation.status.eq(status),
                         reservation.createdAt.goe(recentCutoff),
                         reservation.reservedAt.lt(threshold))

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CancelOverdueReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CancelOverdueReservationServiceImpl.java
@@ -1,128 +1,60 @@
 package team.washer.server.v2.domain.reservation.service.impl;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.List;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import team.washer.server.v2.domain.machine.entity.Machine;
-import team.washer.server.v2.domain.machine.repository.MachineRepository;
-import team.washer.server.v2.domain.notification.support.ReservationNotificationSupport;
-import team.washer.server.v2.domain.reservation.entity.Reservation;
-import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
-import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.reservation.service.CancelOverdueReservationService;
-import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
 import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
-import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
-import team.washer.server.v2.domain.user.entity.User;
-import team.washer.server.v2.global.common.constants.PenaltyConstants;
-import team.washer.server.v2.global.util.DateTimeUtil;
 
+/**
+ * 만료된 예약 취소 스케줄링 진입점.
+ *
+ * <p>
+ * 처리 대상 조회와 개별 예약의 DB 갱신은 {@link OverdueReservationProcessor}가 독립 트랜잭션으로 수행하고,
+ * 이 클래스는 트랜잭션 밖에서 SmartThings 외부 API를 호출한 뒤 그 결과를 넘겨주는 조율만 담당한다. 외부 API 호출이 DB
+ * 커넥션을 점유하지 않도록 하기 위함이다.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class CancelOverdueReservationServiceImpl implements CancelOverdueReservationService {
 
-    private final ReservationRepository reservationRepository;
-    private final MachineRepository machineRepository;
-    private final PenaltyRedisUtil penaltyRedisUtil;
-    private final ReservationNotificationSupport reservationNotificationSupport;
-    private final MachineStateDetectionSupport machineStateDetectionSupport;
+    private final OverdueReservationProcessor overdueReservationProcessor;
     private final DeviceStatusQuerySupport deviceStatusQuerySupport;
 
     @Override
-    @Transactional
     public void execute() {
-        // reservedAt 기준 3분 초과 (타임아웃 상수 사용)
-        LocalDateTime threshold = LocalDateTime.now().minusMinutes(ReservationStatus.RESERVED.getTimeoutMinutes());
-        LocalDateTime recentCutoff = LocalDateTime.now().minusHours(24);
-
-        List<Reservation> expiredReservations = reservationRepository
-                .findExpiredReservations(ReservationStatus.RESERVED, threshold, recentCutoff);
-
-        if (expiredReservations.isEmpty()) {
+        var targets = overdueReservationProcessor.findExpiredTargets();
+        if (targets.isEmpty()) {
             return;
         }
 
         var autoStarted = new ArrayList<Long>();
         var cancelled = new ArrayList<Long>();
 
-        for (Reservation reservation : expiredReservations) {
+        for (var target : targets) {
             try {
-                var machine = reservation.getMachine();
-                var status = deviceStatusQuerySupport.queryDeviceStatus(machine.getDeviceId());
-                var isRunning = machineStateDetectionSupport.isRunning(status, machine.isWasher());
-
-                if (isRunning) {
-                    var expectedCompletionTime = DateTimeUtil.parseAndConvertToKoreaTime(status.getCompletionTime());
-                    reservation.start(expectedCompletionTime);
-                    machine.markAsInUse();
-                    reservationRepository.save(reservation);
-                    machineRepository.save(machine);
-                    reservationNotificationSupport.sendStarted(reservation.getUser(), machine, expectedCompletionTime);
-                    autoStarted.add(reservation.getId());
-                } else {
-                    reservation.cancel();
-                    machine.markAsAvailable();
-                    reservationRepository.save(reservation);
-                    machineRepository.save(machine);
-
-                    User user = reservation.getUser();
-                    applyTimeoutPenalty(user, machine);
-                    cancelled.add(reservation.getId());
+                var status = deviceStatusQuerySupport.queryDeviceStatus(target.deviceId());
+                var result = overdueReservationProcessor.processOverdue(target.reservationId(), status);
+                switch (result) {
+                    case AUTO_STARTED -> autoStarted.add(target.reservationId());
+                    case CANCELLED -> cancelled.add(target.reservationId());
+                    case SKIPPED -> {
+                    }
                 }
             } catch (Exception e) {
-                log.error("reservation timeout error processing RESERVED reservation={}", reservation.getId(), e);
+                log.error("reservation timeout error processing RESERVED reservation={}", target.reservationId(), e);
             }
         }
 
         log.info("reservation timeout RESERVED processed={} auto_started={} {} cancelled={} {}",
-                expiredReservations.size(),
+                targets.size(),
                 autoStarted.size(),
                 autoStarted,
                 cancelled.size(),
                 cancelled);
-    }
-
-    /**
-     * 타임아웃 취소 시 패널티를 적용합니다.
-     * <p>
-     * 1. 항상 5분 쿨다운 적용<br>
-     * 2. 취소 횟수 기록 (48h 슬라이딩 윈도우)<br>
-     * 3. 첫 번째 경고 여부에 따라 알림 분기<br>
-     * 4. 48시간 내 {maxCount}회 초과 시 48h 블록 적용
-     * </p>
-     */
-    private void applyTimeoutPenalty(User user, Machine machine) {
-        final long userId = user.getId();
-
-        penaltyRedisUtil.applyCooldown(userId, machine.getType());
-        penaltyRedisUtil.recordCancellation(userId);
-        user.updateLastCancellationTime();
-
-        if (!penaltyRedisUtil.hasWarning(userId)) {
-            penaltyRedisUtil.applyWarning(userId);
-            reservationNotificationSupport.sendTimeoutWarning(user, machine);
-            log.info("timeout first warning applied userId={}", userId);
-        } else {
-            reservationNotificationSupport.sendAutoCancellation(user, machine);
-            log.info("timeout penalty applied userId={}", userId);
-        }
-
-        if (penaltyRedisUtil.getCancellationCount(userId) > PenaltyConstants.MAX_CANCELLATIONS_IN_48H) {
-            final boolean wasBlocked = penaltyRedisUtil.isBlocked(user.getRoomNumber());
-            penaltyRedisUtil.applyBlock(user.getRoomNumber());
-            if (!wasBlocked) {
-                reservationNotificationSupport.sendCancellationBlock(user, machine);
-            }
-            log.warn("48h block applied roomNumber={} exceeded max cancellations {}",
-                    user.getRoomNumber(),
-                    PenaltyConstants.MAX_CANCELLATIONS_IN_48H);
-        }
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/OverdueReservationProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/OverdueReservationProcessor.java
@@ -1,0 +1,138 @@
+package team.washer.server.v2.domain.reservation.service.impl;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.notification.support.ReservationNotificationSupport;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.global.common.constants.PenaltyConstants;
+import team.washer.server.v2.global.util.DateTimeUtil;
+
+/**
+ * 만료된 예약 처리의 트랜잭션 경계를 담당하는 컴포넌트.
+ *
+ * <p>
+ * SmartThings 외부 API 호출은 호출 측({@code CancelOverdueReservationServiceImpl})이
+ * 트랜잭션 밖에서 수행하고, 이 컴포넌트는 조회된 상태를 바탕으로 개별 예약의 DB 갱신만 짧은 독립 트랜잭션
+ * ({@link Propagation#REQUIRES_NEW})으로 처리한다. 외부 API 호출이 DB 커넥션을 점유하지 않도록 하여 커넥션
+ * 풀 고갈을 방지한다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OverdueReservationProcessor {
+
+    private final ReservationRepository reservationRepository;
+    private final MachineRepository machineRepository;
+    private final PenaltyRedisUtil penaltyRedisUtil;
+    private final ReservationNotificationSupport reservationNotificationSupport;
+    private final MachineStateDetectionSupport machineStateDetectionSupport;
+
+    /**
+     * 외부 API 호출 대상이 되는 만료 예약의 식별자와 기기 ID 쌍.
+     */
+    public record OverdueTarget(Long reservationId, String deviceId) {
+    }
+
+    /**
+     * 개별 만료 예약 처리 결과. 호출 측의 요약 로그 집계에 사용한다.
+     */
+    public enum OverdueResult {
+        AUTO_STARTED, CANCELLED, SKIPPED
+    }
+
+    /**
+     * 타임아웃된 RESERVED 예약을 조회하여 처리 대상(예약 ID, 기기 ID)을 반환한다. 짧은 읽기 전용 트랜잭션으로 수행된다.
+     */
+    @Transactional(readOnly = true)
+    public List<OverdueTarget> findExpiredTargets() {
+        // reservedAt 기준 타임아웃 상수 초과
+        var threshold = LocalDateTime.now().minusMinutes(ReservationStatus.RESERVED.getTimeoutMinutes());
+        var recentCutoff = LocalDateTime.now().minusHours(24);
+
+        return reservationRepository.findExpiredReservations(ReservationStatus.RESERVED, threshold, recentCutoff)
+                .stream()
+                .map(reservation -> new OverdueTarget(reservation.getId(), reservation.getMachine().getDeviceId()))
+                .toList();
+    }
+
+    /**
+     * 만료된 예약을 기기 상태에 따라 자동 시작하거나 취소(패널티 부여)한다. 외부 API 호출 이후의 DB 갱신만 독립 트랜잭션으로 처리한다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public OverdueResult processOverdue(Long reservationId, SmartThingsDeviceStatusResDto status) {
+        var reservation = reservationRepository.findById(reservationId).orElse(null);
+        if (reservation == null || !reservation.isReserved()) {
+            return OverdueResult.SKIPPED;
+        }
+        var machine = reservation.getMachine();
+
+        if (machineStateDetectionSupport.isRunning(status, machine.isWasher())) {
+            var expectedCompletionTime = DateTimeUtil.parseAndConvertToKoreaTime(status.getCompletionTime());
+            reservation.start(expectedCompletionTime);
+            machine.markAsInUse();
+            reservationRepository.save(reservation);
+            machineRepository.save(machine);
+            reservationNotificationSupport.sendStarted(reservation.getUser(), machine, expectedCompletionTime);
+            return OverdueResult.AUTO_STARTED;
+        }
+
+        reservation.cancel();
+        machine.markAsAvailable();
+        reservationRepository.save(reservation);
+        machineRepository.save(machine);
+
+        applyTimeoutPenalty(reservation.getUser(), machine);
+        return OverdueResult.CANCELLED;
+    }
+
+    /**
+     * 타임아웃 취소 시 패널티를 적용합니다.
+     * <p>
+     * 1. 항상 5분 쿨다운 적용<br>
+     * 2. 취소 횟수 기록 (48h 슬라이딩 윈도우)<br>
+     * 3. 첫 번째 경고 여부에 따라 알림 분기<br>
+     * 4. 48시간 내 {maxCount}회 초과 시 48h 블록 적용
+     * </p>
+     */
+    private void applyTimeoutPenalty(User user, Machine machine) {
+        final long userId = user.getId();
+
+        penaltyRedisUtil.applyCooldown(userId, machine.getType());
+        penaltyRedisUtil.recordCancellation(userId);
+        user.updateLastCancellationTime();
+
+        if (!penaltyRedisUtil.hasWarning(userId)) {
+            penaltyRedisUtil.applyWarning(userId);
+            reservationNotificationSupport.sendTimeoutWarning(user, machine);
+            log.info("timeout first warning applied userId={}", userId);
+        } else {
+            reservationNotificationSupport.sendAutoCancellation(user, machine);
+            log.info("timeout penalty applied userId={}", userId);
+        }
+
+        if (penaltyRedisUtil.getCancellationCount(userId) > PenaltyConstants.MAX_CANCELLATIONS_IN_48H) {
+            final boolean wasBlocked = penaltyRedisUtil.isBlocked(user.getRoomNumber());
+            penaltyRedisUtil.applyBlock(user.getRoomNumber());
+            if (!wasBlocked) {
+                reservationNotificationSupport.sendCancellationBlock(user, machine);
+            }
+            log.warn("48h block applied roomNumber={} exceeded max cancellations {}",
+                    user.getRoomNumber(),
+                    PenaltyConstants.MAX_CANCELLATIONS_IN_48H);
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/CancelOverdueReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/CancelOverdueReservationServiceTest.java
@@ -1,220 +1,92 @@
 package team.washer.server.v2.domain.reservation.service;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDateTime;
-import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import team.washer.server.v2.domain.machine.entity.Machine;
-import team.washer.server.v2.domain.machine.repository.MachineRepository;
-import team.washer.server.v2.domain.notification.support.ReservationNotificationSupport;
-import team.washer.server.v2.domain.reservation.entity.Reservation;
-import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
-import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.reservation.service.impl.CancelOverdueReservationServiceImpl;
-import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
+import team.washer.server.v2.domain.reservation.service.impl.OverdueReservationProcessor;
+import team.washer.server.v2.domain.reservation.service.impl.OverdueReservationProcessor.OverdueResult;
+import team.washer.server.v2.domain.reservation.service.impl.OverdueReservationProcessor.OverdueTarget;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
-import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
-import team.washer.server.v2.domain.user.entity.User;
 
 @ExtendWith(MockitoExtension.class)
+@DisplayName("CancelOverdueReservationService 조율")
 class CancelOverdueReservationServiceTest {
 
     @InjectMocks
     private CancelOverdueReservationServiceImpl cancelOverdueReservationService;
 
     @Mock
-    private ReservationRepository reservationRepository;
-
-    @Mock
-    private MachineRepository machineRepository;
-
-    @Mock
-    private PenaltyRedisUtil penaltyRedisUtil;
-
-    @Mock
-    private ReservationNotificationSupport reservationNotificationSupport;
-
-    @Mock
-    private MachineStateDetectionSupport machineStateDetectionSupport;
+    private OverdueReservationProcessor overdueReservationProcessor;
 
     @Mock
     private DeviceStatusQuerySupport deviceStatusQuerySupport;
 
-    @Mock
-    private Reservation reservation;
-
-    @Mock
-    private Machine machine;
-
-    @Mock
-    private User user;
-
-    @Nested
-    @DisplayName("만료된 예약이 없으면")
-    class NoExpiredReservations {
-
-        @Test
-        @DisplayName("아무 동작도 하지 않는다")
-        void execute_ShouldDoNothing_WhenNoExpiredReservations() {
-            // Given
-            when(reservationRepository.findExpiredReservations(eq(ReservationStatus.RESERVED),
-                    any(LocalDateTime.class),
-                    any(LocalDateTime.class))).thenReturn(Collections.emptyList());
-
-            // When
-            cancelOverdueReservationService.execute();
-
-            // Then
-            verify(reservation, never()).cancel();
-            verify(reservationRepository, never()).save(any());
-            verify(penaltyRedisUtil, never()).applyCooldown(any(), any());
-        }
+    private SmartThingsDeviceStatusResDto buildDeviceStatus(String completionTime) {
+        var completionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState(completionTime, null, null);
+        var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(null, null, completionTimeAttr);
+        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null, null);
+        return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
     }
 
-    @Nested
-    @DisplayName("만료된 RESERVED 예약이 있고 기기가 작동 중이면")
-    class MachineRunning {
+    @Test
+    @DisplayName("만료된 예약이 없으면 기기 상태를 조회하지 않고 종료한다")
+    void execute_ShouldDoNothing_WhenNoExpiredTargets() {
+        // Given
+        when(overdueReservationProcessor.findExpiredTargets()).thenReturn(List.of());
 
-        @Test
-        @DisplayName("자동으로 RUNNING 상태로 시작하고 시작 알림을 전송한다")
-        void execute_ShouldAutoStartAndNotify_WhenMachineRunning() {
-            // Given
-            when(reservationRepository.findExpiredReservations(eq(ReservationStatus.RESERVED),
-                    any(LocalDateTime.class),
-                    any(LocalDateTime.class))).thenReturn(List.of(reservation));
-            when(reservation.getMachine()).thenReturn(machine);
-            when(reservation.getUser()).thenReturn(user);
-            when(machine.getDeviceId()).thenReturn("device-123");
+        // When
+        cancelOverdueReservationService.execute();
 
-            var completionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState("2026-01-26T15:30:00Z",
-                    "2026-01-26T14:30:00Z",
-                    null);
-            var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(null, null, completionTimeAttr);
-            var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null, null);
-            var deviceStatus = new SmartThingsDeviceStatusResDto(java.util.Map.of("main", componentStatus));
-            when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(true);
-
-            // When
-            cancelOverdueReservationService.execute();
-
-            // Then
-            verify(reservation, times(1)).start(any(LocalDateTime.class));
-            verify(reservationRepository, times(1)).save(reservation);
-            verify(reservationNotificationSupport, times(1))
-                    .sendStarted(eq(user), eq(machine), any(LocalDateTime.class));
-            verify(reservation, never()).cancel();
-            verify(penaltyRedisUtil, never()).applyCooldown(any(), any());
-        }
+        // Then
+        verify(deviceStatusQuerySupport, never()).queryDeviceStatus(any());
+        verify(overdueReservationProcessor, never()).processOverdue(anyLong(),
+                any(SmartThingsDeviceStatusResDto.class));
     }
 
-    @Nested
-    @DisplayName("만료된 RESERVED 예약이 있고 기기가 작동 중이지 않으면")
-    class MachineNotRunning {
+    @Test
+    @DisplayName("대상별로 트랜잭션 밖에서 기기 상태를 조회한 뒤 프로세서에 위임한다")
+    void execute_ShouldQueryStatusOutsideTransactionThenDelegate() {
+        // Given
+        var status = buildDeviceStatus("2026-01-26T15:30:00Z");
+        when(overdueReservationProcessor.findExpiredTargets()).thenReturn(List.of(new OverdueTarget(1L, "device-1")));
+        when(deviceStatusQuerySupport.queryDeviceStatus("device-1")).thenReturn(status);
+        when(overdueReservationProcessor.processOverdue(1L, status)).thenReturn(OverdueResult.CANCELLED);
 
-        @Test
-        @DisplayName("예약을 취소하고 타임아웃 패널티를 부여한다 (첫 경고)")
-        void execute_ShouldCancelAndApplyTimeoutPenalty_WhenFirstWarning() {
-            // Given
-            var deviceStatus = new SmartThingsDeviceStatusResDto(java.util.Map.of());
-            when(reservationRepository.findExpiredReservations(eq(ReservationStatus.RESERVED),
-                    any(LocalDateTime.class),
-                    any(LocalDateTime.class))).thenReturn(List.of(reservation));
-            when(reservation.getMachine()).thenReturn(machine);
-            when(machine.getDeviceId()).thenReturn("device-123");
-            when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(false);
-            when(reservation.getUser()).thenReturn(user);
-            when(user.getId()).thenReturn(1L);
-            when(penaltyRedisUtil.hasWarning(1L)).thenReturn(false);
-            when(penaltyRedisUtil.getCancellationCount(1L)).thenReturn(1L);
+        // When
+        cancelOverdueReservationService.execute();
 
-            // When
-            cancelOverdueReservationService.execute();
+        // Then
+        verify(overdueReservationProcessor, times(1)).processOverdue(1L, status);
+    }
 
-            // Then
-            verify(reservation, times(1)).cancel();
-            verify(reservationRepository, times(1)).save(reservation);
-            verify(penaltyRedisUtil, times(1)).applyCooldown(eq(1L), any());
-            verify(penaltyRedisUtil, times(1)).recordCancellation(1L);
-            verify(penaltyRedisUtil, times(1)).applyWarning(1L);
-            verify(reservationNotificationSupport, times(1)).sendTimeoutWarning(user, machine);
-            verify(reservationNotificationSupport, never()).sendAutoCancellation(any(), any());
-            verify(reservation, never()).start(any());
-        }
+    @Test
+    @DisplayName("기기 상태 조회가 실패하면 해당 예약은 건너뛰고 처리를 계속한다")
+    void execute_ShouldSkipReservation_WhenStatusQueryFails() {
+        // Given
+        when(overdueReservationProcessor.findExpiredTargets()).thenReturn(List.of(new OverdueTarget(1L, "device-1")));
+        when(deviceStatusQuerySupport.queryDeviceStatus("device-1")).thenThrow(new RuntimeException("api error"));
 
-        @Test
-        @DisplayName("이미 경고가 있으면 자동 취소 알림을 전송한다")
-        void execute_ShouldSendAutoCancellation_WhenWarningAlreadyExists() {
-            // Given
-            var deviceStatus = new SmartThingsDeviceStatusResDto(java.util.Map.of());
-            when(reservationRepository.findExpiredReservations(eq(ReservationStatus.RESERVED),
-                    any(LocalDateTime.class),
-                    any(LocalDateTime.class))).thenReturn(List.of(reservation));
-            when(reservation.getMachine()).thenReturn(machine);
-            when(machine.getDeviceId()).thenReturn("device-123");
-            when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(false);
-            when(reservation.getUser()).thenReturn(user);
-            when(user.getId()).thenReturn(1L);
-            when(penaltyRedisUtil.hasWarning(1L)).thenReturn(true);
-            when(penaltyRedisUtil.getCancellationCount(1L)).thenReturn(2L);
+        // When
+        cancelOverdueReservationService.execute();
 
-            // When
-            cancelOverdueReservationService.execute();
-
-            // Then
-            verify(penaltyRedisUtil, times(1)).applyCooldown(eq(1L), any());
-            verify(penaltyRedisUtil, times(1)).recordCancellation(1L);
-            verify(penaltyRedisUtil, never()).applyWarning(any());
-            verify(reservationNotificationSupport, times(1)).sendAutoCancellation(user, machine);
-            verify(reservationNotificationSupport, never()).sendTimeoutWarning(any(), any());
-        }
-
-        @Test
-        @DisplayName("48시간 내 취소 횟수가 4회를 초과하면 48시간 예약 차단을 적용한다")
-        void execute_ShouldApplyBlock_WhenCancellationCountExceedsLimit() {
-            // Given
-            var deviceStatus = new SmartThingsDeviceStatusResDto(java.util.Map.of());
-            when(reservationRepository.findExpiredReservations(eq(ReservationStatus.RESERVED),
-                    any(LocalDateTime.class),
-                    any(LocalDateTime.class))).thenReturn(List.of(reservation));
-            when(reservation.getMachine()).thenReturn(machine);
-            when(machine.getDeviceId()).thenReturn("device-123");
-            when(deviceStatusQuerySupport.queryDeviceStatus("device-123")).thenReturn(deviceStatus);
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(false);
-            when(reservation.getUser()).thenReturn(user);
-            when(user.getId()).thenReturn(1L);
-            when(user.getRoomNumber()).thenReturn("101");
-            when(penaltyRedisUtil.hasWarning(1L)).thenReturn(true);
-            when(penaltyRedisUtil.getCancellationCount(1L)).thenReturn(5L);
-
-            // When
-            cancelOverdueReservationService.execute();
-
-            // Then
-            verify(penaltyRedisUtil, times(1)).applyBlock("101");
-        }
+        // Then
+        verify(overdueReservationProcessor, never()).processOverdue(anyLong(),
+                any(SmartThingsDeviceStatusResDto.class));
     }
 }

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/OverdueReservationProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/OverdueReservationProcessorTest.java
@@ -1,0 +1,210 @@
+package team.washer.server.v2.domain.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.notification.support.ReservationNotificationSupport;
+import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.reservation.service.impl.OverdueReservationProcessor;
+import team.washer.server.v2.domain.reservation.service.impl.OverdueReservationProcessor.OverdueResult;
+import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
+import team.washer.server.v2.domain.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("OverdueReservationProcessor 개별 만료 예약 처리")
+class OverdueReservationProcessorTest {
+
+    private static final Long RESERVATION_ID = 1L;
+
+    @InjectMocks
+    private OverdueReservationProcessor overdueReservationProcessor;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private MachineRepository machineRepository;
+
+    @Mock
+    private PenaltyRedisUtil penaltyRedisUtil;
+
+    @Mock
+    private ReservationNotificationSupport reservationNotificationSupport;
+
+    @Mock
+    private MachineStateDetectionSupport machineStateDetectionSupport;
+
+    @Mock
+    private Reservation reservation;
+
+    @Mock
+    private Machine machine;
+
+    @Mock
+    private User user;
+
+    private SmartThingsDeviceStatusResDto buildDeviceStatus(String completionTime) {
+        var completionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState(completionTime, null, null);
+        var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(null, null, completionTimeAttr);
+        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null, null);
+        return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
+    }
+
+    private void givenReservedReservation() {
+        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
+        when(reservation.isReserved()).thenReturn(true);
+        when(reservation.getMachine()).thenReturn(machine);
+    }
+
+    @Nested
+    @DisplayName("기기가 작동 중이면")
+    class MachineRunning {
+
+        @Test
+        @DisplayName("자동으로 RUNNING 상태로 시작하고 시작 알림을 전송하며 AUTO_STARTED를 반환한다")
+        void shouldAutoStartAndNotify_WhenMachineRunning() {
+            // Given
+            var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
+            givenReservedReservation();
+            when(reservation.getUser()).thenReturn(user);
+            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(true);
+
+            // When
+            var result = overdueReservationProcessor.processOverdue(RESERVATION_ID, deviceStatus);
+
+            // Then
+            assertThat(result).isEqualTo(OverdueResult.AUTO_STARTED);
+            verify(reservation, times(1)).start(any(LocalDateTime.class));
+            verify(reservationRepository, times(1)).save(reservation);
+            verify(reservationNotificationSupport, times(1))
+                    .sendStarted(eq(user), eq(machine), any(LocalDateTime.class));
+            verify(reservation, never()).cancel();
+            verify(penaltyRedisUtil, never()).applyCooldown(any(), any());
+        }
+    }
+
+    @Nested
+    @DisplayName("기기가 작동 중이지 않으면")
+    class MachineNotRunning {
+
+        @Test
+        @DisplayName("예약을 취소하고 타임아웃 패널티를 부여한다 (첫 경고) 후 CANCELLED를 반환한다")
+        void shouldCancelAndApplyTimeoutPenalty_WhenFirstWarning() {
+            // Given
+            var deviceStatus = buildDeviceStatus(null);
+            givenReservedReservation();
+            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
+            when(reservation.getUser()).thenReturn(user);
+            when(user.getId()).thenReturn(1L);
+            when(penaltyRedisUtil.hasWarning(1L)).thenReturn(false);
+            when(penaltyRedisUtil.getCancellationCount(1L)).thenReturn(1L);
+
+            // When
+            var result = overdueReservationProcessor.processOverdue(RESERVATION_ID, deviceStatus);
+
+            // Then
+            assertThat(result).isEqualTo(OverdueResult.CANCELLED);
+            verify(reservation, times(1)).cancel();
+            verify(reservationRepository, times(1)).save(reservation);
+            verify(penaltyRedisUtil, times(1)).applyCooldown(eq(1L), any());
+            verify(penaltyRedisUtil, times(1)).recordCancellation(1L);
+            verify(penaltyRedisUtil, times(1)).applyWarning(1L);
+            verify(reservationNotificationSupport, times(1)).sendTimeoutWarning(user, machine);
+            verify(reservationNotificationSupport, never()).sendAutoCancellation(any(), any());
+            verify(reservation, never()).start(any());
+        }
+
+        @Test
+        @DisplayName("이미 경고가 있으면 자동 취소 알림을 전송한다")
+        void shouldSendAutoCancellation_WhenWarningAlreadyExists() {
+            // Given
+            var deviceStatus = buildDeviceStatus(null);
+            givenReservedReservation();
+            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
+            when(reservation.getUser()).thenReturn(user);
+            when(user.getId()).thenReturn(1L);
+            when(penaltyRedisUtil.hasWarning(1L)).thenReturn(true);
+            when(penaltyRedisUtil.getCancellationCount(1L)).thenReturn(2L);
+
+            // When
+            overdueReservationProcessor.processOverdue(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(penaltyRedisUtil, times(1)).applyCooldown(eq(1L), any());
+            verify(penaltyRedisUtil, times(1)).recordCancellation(1L);
+            verify(penaltyRedisUtil, never()).applyWarning(any());
+            verify(reservationNotificationSupport, times(1)).sendAutoCancellation(user, machine);
+            verify(reservationNotificationSupport, never()).sendTimeoutWarning(any(), any());
+        }
+
+        @Test
+        @DisplayName("48시간 내 취소 횟수가 한도를 초과하면 48시간 예약 차단을 적용한다")
+        void shouldApplyBlock_WhenCancellationCountExceedsLimit() {
+            // Given
+            var deviceStatus = buildDeviceStatus(null);
+            givenReservedReservation();
+            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
+            when(reservation.getUser()).thenReturn(user);
+            when(user.getId()).thenReturn(1L);
+            when(user.getRoomNumber()).thenReturn("101");
+            when(penaltyRedisUtil.hasWarning(1L)).thenReturn(true);
+            when(penaltyRedisUtil.getCancellationCount(1L)).thenReturn(5L);
+
+            // When
+            overdueReservationProcessor.processOverdue(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(penaltyRedisUtil, times(1)).applyBlock("101");
+        }
+    }
+
+    @Nested
+    @DisplayName("재조회 시점에 RESERVED 상태가 아니면")
+    class NoLongerReserved {
+
+        @Test
+        @DisplayName("아무 처리도 하지 않고 SKIPPED를 반환한다")
+        void shouldSkip_WhenNoLongerReserved() {
+            // Given
+            var deviceStatus = buildDeviceStatus(null);
+            when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
+            when(reservation.isReserved()).thenReturn(false);
+
+            // When
+            var result = overdueReservationProcessor.processOverdue(RESERVATION_ID, deviceStatus);
+
+            // Then
+            assertThat(result).isEqualTo(OverdueResult.SKIPPED);
+            verify(reservation, never()).start(any());
+            verify(reservation, never()).cancel();
+            verify(reservationRepository, never()).save(any());
+        }
+    }
+}


### PR DESCRIPTION
## 개요

`CancelOverdueReservationServiceImpl.execute()`의 트랜잭션 범위를 SmartThings 외부 API 호출 이후로 좁혀, 트랜잭션 내 외부 API 호출로 인한 DB 커넥션 풀 고갈 위험을 제거하였습니다. 앞서 `ProcessReservationLifecycleServiceImpl`에 적용한 패턴과 동일하게 정리하였습니다.

## 본문

### 배경

`execute()` 전체에 `@Transactional`이 적용되어 있어, 만료 예약을 순회하며 `deviceStatusQuerySupport.queryDeviceStatus(...)`로 외부 HTTP API를 호출하는 동안 DB 커넥션이 계속 점유되었습니다. 외부 호출이 지연되면 커넥션 풀이 고갈되어 애플리케이션 전체 장애로 이어질 수 있습니다.

### 변경 사항

- **트랜잭션 경계 컴포넌트 분리**: `OverdueReservationProcessor`를 신설하여 self-invocation 프록시 문제를 피하면서 트랜잭션 경계를 명확히 하였습니다.
  - `findExpiredTargets()`: 짧은 `readOnly` 트랜잭션으로 만료 예약의 `(예약 ID, 기기 ID)`만 조회합니다.
  - `processOverdue(reservationId, status)`: `@Transactional(propagation = REQUIRES_NEW)`로 개별 예약의 DB 갱신(자동 시작 또는 취소·패널티)만 처리하고, 결과를 `OverdueResult`(`AUTO_STARTED`/`CANCELLED`/`SKIPPED`)로 반환합니다.
  - 재조회 시점에 상태가 바뀐 경우를 대비해 `isReserved()` 가드를 추가하였습니다.
- **`CancelOverdueReservationServiceImpl`**: `@Transactional`을 제거하고, 트랜잭션 밖에서 외부 API를 호출한 뒤 프로세서에 위임하는 조율 역할만 담당하도록 변경하였습니다. 요약 로그(`processed`/`auto_started`/`cancelled`)는 그대로 유지하였습니다.
- **타임아웃 패널티 로직**(`applyTimeoutPenalty`)은 동작 변경 없이 프로세서로 이전하였습니다.

### 테스트

- 로직 검증을 `OverdueReservationProcessorTest`로 이전하였습니다(자동 시작, 첫 경고 취소, 기존 경고 자동 취소, 48시간 차단, 상태 변경 시 스킵).
- `CancelOverdueReservationServiceTest`는 조율 검증(대상 없음·위임·조회 실패 스킵)으로 재작성하였습니다.
- 전체 테스트가 통과합니다.