### PR TITLE
[smartthings] 완료 푸시 누락 조건 보완

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.notification.support.ReservationNotificationSupport;
+import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
@@ -95,6 +96,13 @@ public class ReservationLifecycleProcessor {
         var completionTime = machineStateDetectionSupport.isCompleted(status, isWasher);
 
         if (completionTime.isPresent()) {
+            if (isStaleCompletion(reservation, completionTime.get())) {
+                log.debug("Stale completion ignored reservationId={} startTime={} completionTime={}",
+                        reservation.getId(),
+                        reservation.getStartTime(),
+                        completionTime.get());
+                return;
+            }
             reservation.complete();
             machine.markAsAvailable();
             reservationRepository.save(reservation);
@@ -167,5 +175,10 @@ public class ReservationLifecycleProcessor {
                 reservationRepository.save(reservation);
             }
         }
+    }
+
+    private boolean isStaleCompletion(Reservation reservation, LocalDateTime completionTime) {
+        var startTime = reservation.getStartTime();
+        return startTime != null && completionTime.isBefore(startTime);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
@@ -48,9 +48,9 @@ public class MachineStateDetectionSupport {
      *
      * <p>
      * SmartThings 기기는 메인 사이클이 끝나면 냉각(cooling)·구김방지(wrinklePrevent) 등 잔여 단계가 남아 있어도
-     * jobState를 finish/finished로 먼저 보고하는 경우가 있다. jobState만으로 판정하면 실제 종료 2~4분 전에 완료로
-     * 오인하므로, machineState=stop(물리적 정지)와 completionTime이 현재 시각을 지났는지(잔여시간 0)를 함께
-     * 확인한다.
+     * jobState를 finish/finished로 먼저 보고하는 경우가 있다. 반대로 완료 직후 jobState가 none/null로 빠르게
+     * 리셋될 수 있으므로, machineState=stop(물리적 정지)와 completionTime이 현재 시각을 지났는지(잔여시간 0)를
+     * 함께 확인한다.
      */
     public Optional<LocalDateTime> isCompleted(SmartThingsDeviceStatusResDto status, boolean isWasher) {
         if (status == null) {
@@ -69,19 +69,19 @@ public class MachineStateDetectionSupport {
     }
 
     /**
-     * jobState·machineState·completionTime을 종합하여 단일 기기 타입의 완료 여부를 판정한다. 세 조건을 모두
-     * 만족할 때만 완료로 보고, 완료 시각(없으면 현재 시각)을 반환한다.
+     * jobState·machineState·completionTime을 종합하여 단일 기기 타입의 완료 여부를 판정한다.
      */
     private Optional<LocalDateTime> evaluateCompletion(String jobState,
             String finishedJobState,
             String machineState,
             String completionTimeStr,
             LocalDateTime now) {
-        if (!finishedJobState.equalsIgnoreCase(jobState)) {
-            return Optional.empty();
-        }
         if (!"stop".equalsIgnoreCase(machineState)) {
-            log.debug("job finished but machine not stopped yet machineState={} jobState={}", machineState, jobState);
+            if (finishedJobState.equalsIgnoreCase(jobState)) {
+                log.debug("job finished but machine not stopped yet machineState={} jobState={}",
+                        machineState,
+                        jobState);
+            }
             return Optional.empty();
         }
         var completionTime = (completionTimeStr != null && !completionTimeStr.isBlank())
@@ -93,8 +93,23 @@ public class MachineStateDetectionSupport {
                     jobState);
             return Optional.empty();
         }
+
+        if (!finishedJobState.equalsIgnoreCase(jobState)) {
+            if (isResetJobState(jobState) && completionTime != null) {
+                log.debug("device job is completed after job reset jobState={} completionTime={}",
+                        jobState,
+                        completionTime);
+                return Optional.of(completionTime);
+            }
+            return Optional.empty();
+        }
+
         log.debug("device job is completed jobState={} completionTime={}", jobState, completionTime);
         return Optional.of(completionTime != null ? completionTime : now);
+    }
+
+    private boolean isResetJobState(String jobState) {
+        return jobState == null || jobState.isBlank() || "none".equalsIgnoreCase(jobState);
     }
 
     /**

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
@@ -158,6 +158,28 @@ class ReservationLifecycleProcessorTest {
         }
 
         @Test
+        @DisplayName("완료 시각이 현재 예약 시작 시각보다 이전이면 이전 상태로 보고 완료 처리하지 않는다")
+        void shouldNotCompleteReservation_WhenCompletionTimeBeforeReservationStartTime() {
+            // Given
+            var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
+            var staleCompletionTime = LocalDateTime.now().minusMinutes(5);
+            givenRunningReservation();
+            when(reservation.getStartTime()).thenReturn(LocalDateTime.now());
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(Optional.of(staleCompletionTime));
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, never()).complete();
+            verify(machine, never()).markAsAvailable();
+            verify(reservationRepository, never()).save(reservation);
+            verify(machineRepository, never()).save(machine);
+            verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
+        }
+
+        @Test
         @DisplayName("RUNNING 상태이고 기기 작업이 완료되지 않으면 예상 완료 시각을 갱신한다")
         void shouldUpdateExpectedCompletionTime_WhenRunningAndMachineNotCompleted() {
             // Given

--- a/src/test/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupportTest.java
@@ -112,6 +112,27 @@ class MachineStateDetectionSupportTest {
 
             assertThat(result).isPresent();
         }
+
+        @Test
+        @DisplayName("완료 직후 jobState가 none으로 리셋되어도 완료 시각이 지났으면 완료로 판정한다")
+        void shouldComplete_WhenJobStateResetAndCompletionTimePassed() {
+            var past = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(1);
+            var status = washerStatus("stop", "none", isoUtc(past));
+
+            var result = machineStateDetectionSupport.isCompleted(status, WASHER);
+
+            assertThat(result).isPresent();
+        }
+
+        @Test
+        @DisplayName("jobState가 none으로 리셋됐지만 완료 시각이 없으면 완료로 판정하지 않는다")
+        void shouldNotComplete_WhenJobStateResetAndCompletionTimeNull() {
+            var status = washerStatus("stop", "none", null);
+
+            var result = machineStateDetectionSupport.isCompleted(status, WASHER);
+
+            assertThat(result).isEmpty();
+        }
     }
 
     @Nested
@@ -138,6 +159,17 @@ class MachineStateDetectionSupportTest {
             var result = machineStateDetectionSupport.isCompleted(status, DRYER);
 
             assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("건조 완료 직후 jobState가 none으로 리셋되어도 완료 시각이 지났으면 완료로 판정한다")
+        void shouldComplete_WhenDryerJobStateResetAndCompletionTimePassed() {
+            var past = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(1);
+            var status = dryerStatus("stop", "none", isoUtc(past));
+
+            var result = machineStateDetectionSupport.isCompleted(status, DRYER);
+
+            assertThat(result).isPresent();
         }
     }
 


### PR DESCRIPTION
## 개요

`SmartThings` 완료 직후 `jobState`가 `none`으로 리셋되는 경우에도 완료 상태를 정상 판정하도록 수정했습니다.
완료 판정 누락으로 예약이 `RUNNING`에 남아 완료 푸시 알림이 발송되지 않을 수 있는 문제를 보완했습니다.

## 본문

- `MachineStateDetectionSupport`의 완료 판정에서 `machineState=stop`이고 `completionTime`이 현재 시각을 지난 경우, `jobState`가 `none`, `null`, 공백으로 리셋되어도 완료로 처리하도록 수정했습니다.
- `finish/finished`가 보고됐지만 `machineState`가 아직 `stop`이 아닌 경우에는 기존처럼 조기 완료로 판정하지 않도록 유지했습니다.
- `completionTime`이 없는 `jobState` 리셋 상태는 완료로 판정하지 않아 단순 유휴 상태를 완료로 오판하지 않도록 했습니다.
- `MachineStateDetectionSupportTest`에 세탁기와 건조기의 `jobState` 리셋 완료 케이스를 추가했습니다.

검증:
- `./gradlew.bat test --tests "team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupportTest" -q`
- `./gradlew.bat test --tests "team.washer.server.v2.domain.reservation.service.ReservationLifecycleProcessorTest" --tests "team.washer.server.v2.domain.reservation.service.ProcessReservationLifecycleServiceTest" -q`
- `./gradlew.bat spotlessCheck -q`
