### PR TITLE
[admin] 호실 세탁 강제 금지 기능 추가

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/admin/controller/AdminWashingBanController.java
+++ b/src/main/java/team/washer/server/v2/domain/admin/controller/AdminWashingBanController.java
@@ -1,0 +1,47 @@
+package team.washer.server.v2.domain.admin.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import team.themoment.sdk.response.CommonApiResponse;
+import team.washer.server.v2.domain.admin.dto.request.CreateWashingBanReqDto;
+import team.washer.server.v2.domain.admin.dto.response.WashingBanResDto;
+import team.washer.server.v2.domain.admin.service.CreateWashingBanService;
+import team.washer.server.v2.domain.admin.service.DeleteWashingBanService;
+import team.washer.server.v2.domain.admin.service.QueryAllWashingBansService;
+
+@RestController
+@RequestMapping("/api/v2/admin/washing-bans")
+@RequiredArgsConstructor
+@Tag(name = "Admin Washing Ban", description = "관리자 세탁 강제 금지 API")
+public class AdminWashingBanController {
+
+    private final CreateWashingBanService createWashingBanService;
+    private final DeleteWashingBanService deleteWashingBanService;
+    private final QueryAllWashingBansService queryAllWashingBansService;
+
+    @PostMapping
+    @Operation(summary = "호실 세탁 금지 등록", description = "특정 호실의 세탁기/건조기 신규 예약을 무기한 금지합니다.")
+    public CommonApiResponse createWashingBan(@RequestBody @Valid final CreateWashingBanReqDto reqDto) {
+        createWashingBanService.execute(reqDto);
+        return CommonApiResponse.success("호실 세탁 금지가 등록되었습니다.");
+    }
+
+    @DeleteMapping("/{roomNumber}")
+    @Operation(summary = "호실 세탁 금지 해제", description = "특정 호실의 세탁 금지를 해제합니다.")
+    public CommonApiResponse deleteWashingBan(@PathVariable final String roomNumber) {
+        deleteWashingBanService.execute(roomNumber);
+        return CommonApiResponse.success("호실 세탁 금지가 해제되었습니다.");
+    }
+
+    @GetMapping
+    @Operation(summary = "금지 호실 목록 조회", description = "현재 세탁이 금지된 전체 호실 목록을 조회합니다.")
+    public List<WashingBanResDto> queryAllWashingBans() {
+        return queryAllWashingBansService.execute();
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/admin/dto/request/CreateWashingBanReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/admin/dto/request/CreateWashingBanReqDto.java
@@ -1,0 +1,10 @@
+package team.washer.server.v2.domain.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(description = "호실 세탁 금지 등록 요청 DTO")
+public record CreateWashingBanReqDto(
+        @NotBlank(message = "호실은 필수입니다") @Pattern(regexp = "^\\d{3,4}$", message = "호실은 3-4자리 숫자여야 합니다") @Schema(description = "금지할 호실 번호", example = "301") String roomNumber) {
+}

--- a/src/main/java/team/washer/server/v2/domain/admin/dto/response/WashingBanResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/admin/dto/response/WashingBanResDto.java
@@ -1,0 +1,11 @@
+package team.washer.server.v2.domain.admin.dto.response;
+
+import java.time.LocalDateTime;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "호실 세탁 금지 응답 DTO")
+public record WashingBanResDto(@Schema(description = "금지 ID") Long id,
+        @Schema(description = "호실 번호", example = "301") String roomNumber,
+        @Schema(description = "금지 등록 시각") LocalDateTime bannedAt) {
+}

--- a/src/main/java/team/washer/server/v2/domain/admin/entity/WashingBan.java
+++ b/src/main/java/team/washer/server/v2/domain/admin/entity/WashingBan.java
@@ -1,0 +1,21 @@
+package team.washer.server.v2.domain.admin.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.*;
+import team.washer.server.v2.global.common.entity.BaseEntity;
+
+@Entity
+@Table(name = "washing_bans", uniqueConstraints = @UniqueConstraint(name = "uk_washing_ban_room_number", columnNames = "room_number"))
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class WashingBan extends BaseEntity {
+
+    @NotBlank
+    @Pattern(regexp = "^\\d{3,4}$")
+    @Column(name = "room_number", nullable = false, length = 4)
+    private String roomNumber;
+}

--- a/src/main/java/team/washer/server/v2/domain/admin/repository/WashingBanRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/admin/repository/WashingBanRepository.java
@@ -1,0 +1,12 @@
+package team.washer.server.v2.domain.admin.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team.washer.server.v2.domain.admin.entity.WashingBan;
+
+public interface WashingBanRepository extends JpaRepository<WashingBan, Long> {
+    boolean existsByRoomNumber(String roomNumber);
+    Optional<WashingBan> findByRoomNumber(String roomNumber);
+}

--- a/src/main/java/team/washer/server/v2/domain/admin/service/CreateWashingBanService.java
+++ b/src/main/java/team/washer/server/v2/domain/admin/service/CreateWashingBanService.java
@@ -1,0 +1,7 @@
+package team.washer.server.v2.domain.admin.service;
+
+import team.washer.server.v2.domain.admin.dto.request.CreateWashingBanReqDto;
+
+public interface CreateWashingBanService {
+    void execute(CreateWashingBanReqDto reqDto);
+}

--- a/src/main/java/team/washer/server/v2/domain/admin/service/DeleteWashingBanService.java
+++ b/src/main/java/team/washer/server/v2/domain/admin/service/DeleteWashingBanService.java
@@ -1,0 +1,5 @@
+package team.washer.server.v2.domain.admin.service;
+
+public interface DeleteWashingBanService {
+    void execute(String roomNumber);
+}

--- a/src/main/java/team/washer/server/v2/domain/admin/service/QueryAllWashingBansService.java
+++ b/src/main/java/team/washer/server/v2/domain/admin/service/QueryAllWashingBansService.java
@@ -1,0 +1,9 @@
+package team.washer.server.v2.domain.admin.service;
+
+import java.util.List;
+
+import team.washer.server.v2.domain.admin.dto.response.WashingBanResDto;
+
+public interface QueryAllWashingBansService {
+    List<WashingBanResDto> execute();
+}

--- a/src/main/java/team/washer/server/v2/domain/admin/service/impl/CreateWashingBanServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/admin/service/impl/CreateWashingBanServiceImpl.java
@@ -1,0 +1,33 @@
+package team.washer.server.v2.domain.admin.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.admin.dto.request.CreateWashingBanReqDto;
+import team.washer.server.v2.domain.admin.entity.WashingBan;
+import team.washer.server.v2.domain.admin.repository.WashingBanRepository;
+import team.washer.server.v2.domain.admin.service.CreateWashingBanService;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CreateWashingBanServiceImpl implements CreateWashingBanService {
+
+    private final WashingBanRepository washingBanRepository;
+
+    @Override
+    @Transactional
+    public void execute(final CreateWashingBanReqDto reqDto) {
+        if (washingBanRepository.existsByRoomNumber(reqDto.roomNumber())) {
+            throw new ExpectedException("이미 금지된 호실입니다.", HttpStatus.CONFLICT);
+        }
+
+        final var ban = WashingBan.builder().roomNumber(reqDto.roomNumber()).build();
+        washingBanRepository.save(ban);
+        log.info("Created washing ban roomNumber={}", reqDto.roomNumber());
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/admin/service/impl/DeleteWashingBanServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/admin/service/impl/DeleteWashingBanServiceImpl.java
@@ -1,0 +1,29 @@
+package team.washer.server.v2.domain.admin.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.admin.repository.WashingBanRepository;
+import team.washer.server.v2.domain.admin.service.DeleteWashingBanService;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeleteWashingBanServiceImpl implements DeleteWashingBanService {
+
+    private final WashingBanRepository washingBanRepository;
+
+    @Override
+    @Transactional
+    public void execute(final String roomNumber) {
+        final var ban = washingBanRepository.findByRoomNumber(roomNumber)
+                .orElseThrow(() -> new ExpectedException("금지된 호실이 아닙니다.", HttpStatus.NOT_FOUND));
+
+        washingBanRepository.delete(ban);
+        log.info("Deleted washing ban roomNumber={}", roomNumber);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/admin/service/impl/QueryAllWashingBansServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/admin/service/impl/QueryAllWashingBansServiceImpl.java
@@ -1,0 +1,25 @@
+package team.washer.server.v2.domain.admin.service.impl;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.admin.dto.response.WashingBanResDto;
+import team.washer.server.v2.domain.admin.repository.WashingBanRepository;
+import team.washer.server.v2.domain.admin.service.QueryAllWashingBansService;
+
+@Service
+@RequiredArgsConstructor
+public class QueryAllWashingBansServiceImpl implements QueryAllWashingBansService {
+
+    private final WashingBanRepository washingBanRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<WashingBanResDto> execute() {
+        return washingBanRepository.findAll().stream()
+                .map(ban -> new WashingBanResDto(ban.getId(), ban.getRoomNumber(), ban.getCreatedAt())).toList();
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/dto/response/ReservationAvailabilityResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/dto/response/ReservationAvailabilityResDto.java
@@ -6,5 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "예약 가능 상태 DTO")
 public record ReservationAvailabilityResDto(@Schema(description = "예약 가능 여부", example = "false") boolean canReserve,
-        @Schema(description = "패널티 만료 시간 (패널티 없을 경우 null)", example = "2026-03-12T21:30:00") LocalDateTime penaltyExpiresAt) {
+        @Schema(description = "패널티 만료 시간 (패널티 없을 경우 null)", example = "2026-03-12T21:30:00") LocalDateTime penaltyExpiresAt,
+        @Schema(description = "호실 세탁 강제 금지 여부", example = "false") boolean isBanned) {
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.admin.repository.WashingBanRepository;
 import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.machine.enums.MachineAvailability;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
@@ -33,6 +34,7 @@ public class CreateReservationServiceImpl implements CreateReservationService {
     private final ReservationRepository reservationRepository;
     private final UserRepository userRepository;
     private final MachineRepository machineRepository;
+    private final WashingBanRepository washingBanRepository;
     private final PenaltyRedisUtil penaltyRedisUtil;
     private final ReservationEnvironment reservationEnvironment;
     private final CurrentUserProvider currentUserProvider;
@@ -45,6 +47,11 @@ public class CreateReservationServiceImpl implements CreateReservationService {
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
         user.validateFloorRestriction();
+
+        // 호실 세탁 강제 금지 검증
+        if (washingBanRepository.existsByRoomNumber(user.getRoomNumber())) {
+            throw new ExpectedException("해당 호실은 현재 세탁이 금지된 상태입니다.", HttpStatus.FORBIDDEN);
+        }
 
         // 48시간 차단 검증 (호실 단위)
         if (penaltyRedisUtil.isBlocked(user.getRoomNumber())) {

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
@@ -48,13 +48,18 @@ public class CreateReservationServiceImpl implements CreateReservationService {
 
         user.validateFloorRestriction();
 
+        final String roomNumber = user.getRoomNumber();
+        if (roomNumber == null) {
+            throw new ExpectedException("호실 정보가 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
+        }
+
         // 호실 세탁 강제 금지 검증
-        if (washingBanRepository.existsByRoomNumber(user.getRoomNumber())) {
+        if (washingBanRepository.existsByRoomNumber(roomNumber)) {
             throw new ExpectedException("해당 호실은 현재 세탁이 금지된 상태입니다.", HttpStatus.FORBIDDEN);
         }
 
         // 48시간 차단 검증 (호실 단위)
-        if (penaltyRedisUtil.isBlocked(user.getRoomNumber())) {
+        if (penaltyRedisUtil.isBlocked(roomNumber)) {
             throw new ExpectedException("48시간 내 취소 횟수를 초과하여 예약이 제한됩니다", HttpStatus.BAD_REQUEST);
         }
 
@@ -96,7 +101,7 @@ public class CreateReservationServiceImpl implements CreateReservationService {
 
         // 동일 호실의 동일 유형 기기 중복 예약 검증
         final boolean hasDuplicateTypeReservation = reservationRepository
-                .existsActiveReservationByRoomAndMachineType(user.getRoomNumber(), machine.getType());
+                .existsActiveReservationByRoomAndMachineType(roomNumber, machine.getType());
         if (hasDuplicateTypeReservation) {
             throw new ExpectedException(String.format("해당 호실에 이미 %s 예약이 존재합니다. 동일 유형의 기기는 동시에 두 개 이상 예약할 수 없습니다.",
                     machine.getType().getDescription()), HttpStatus.BAD_REQUEST);

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryReservationAvailabilityServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryReservationAvailabilityServiceImpl.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.admin.repository.WashingBanRepository;
 import team.washer.server.v2.domain.machine.enums.MachineType;
 import team.washer.server.v2.domain.reservation.dto.response.ReservationAvailabilityResDto;
 import team.washer.server.v2.domain.reservation.service.QueryReservationAvailabilityService;
@@ -15,6 +16,7 @@ import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 @RequiredArgsConstructor
 public class QueryReservationAvailabilityServiceImpl implements QueryReservationAvailabilityService {
 
+    private final WashingBanRepository washingBanRepository;
     private final PenaltyRedisUtil penaltyRedisUtil;
     private final UserRepository userRepository;
     private final CurrentUserProvider currentUserProvider;
@@ -24,6 +26,9 @@ public class QueryReservationAvailabilityServiceImpl implements QueryReservation
     public ReservationAvailabilityResDto execute() {
         final var userId = currentUserProvider.getCurrentUserId();
         final var roomNumber = userRepository.findById(userId).map(u -> u.getRoomNumber()).orElse(null);
+
+        // 호실 세탁 강제 금지 여부
+        final boolean isBanned = roomNumber != null && washingBanRepository.existsByRoomNumber(roomNumber);
 
         // 48시간 블록(호실 단위)이면 모든 예약 불가
         final boolean blocked = roomNumber != null && penaltyRedisUtil.isBlocked(roomNumber);
@@ -37,10 +42,10 @@ public class QueryReservationAvailabilityServiceImpl implements QueryReservation
             }
         }
 
-        if (blocked || allTypesInCooldown) {
-            return new ReservationAvailabilityResDto(false, penaltyRedisUtil.getPenaltyExpiryTime(userId));
+        if (isBanned || blocked || allTypesInCooldown) {
+            return new ReservationAvailabilityResDto(false, penaltyRedisUtil.getPenaltyExpiryTime(userId), isBanned);
         }
 
-        return new ReservationAvailabilityResDto(true, null);
+        return new ReservationAvailabilityResDto(true, null, false);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryReservationAvailabilityServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryReservationAvailabilityServiceImpl.java
@@ -42,7 +42,7 @@ public class QueryReservationAvailabilityServiceImpl implements QueryReservation
             }
         }
 
-        if (isBanned || blocked || allTypesInCooldown) {
+        if (roomNumber == null || isBanned || blocked || allTypesInCooldown) {
             return new ReservationAvailabilityResDto(false, penaltyRedisUtil.getPenaltyExpiryTime(userId), isBanned);
         }
 

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
@@ -145,6 +145,7 @@ class CreateReservationServiceTest {
             final var reqDto = new CreateReservationReqDto(1L);
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            when(user.getRoomNumber()).thenReturn(ROOM_NUMBER);
             when(reservationEnvironment.disableTimeRestriction()).thenReturn(true);
             when(machineRepository.findByIdForUpdate(reqDto.machineId())).thenReturn(Optional.of(machine));
             when(machine.getType()).thenReturn(MachineType.WASHER);
@@ -234,6 +235,23 @@ class CreateReservationServiceTest {
             // When & Then
             assertThatThrownBy(() -> createReservationService.execute(reqDto)).isInstanceOf(ExpectedException.class)
                     .hasMessageContaining("1인 1예약");
+        }
+
+        @Test
+        @DisplayName("금지된 호실의 사용자가 예약을 시도하면 FORBIDDEN 예외를 발생시킨다")
+        void execute_ShouldThrowForbidden_WhenRoomIsBanned() {
+            // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+            final var reqDto = new CreateReservationReqDto(1L);
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            when(user.getRoomNumber()).thenReturn(ROOM_NUMBER);
+            when(washingBanRepository.existsByRoomNumber(ROOM_NUMBER)).thenReturn(true);
+
+            // When & Then
+            assertThatThrownBy(() -> createReservationService.execute(reqDto)).isInstanceOf(ExpectedException.class)
+                    .hasMessageContaining("세탁이 금지된").satisfies(
+                            e -> assertThat(((ExpectedException) e).getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN));
         }
 
         @Test

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.admin.repository.WashingBanRepository;
 import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.machine.enums.MachineAvailability;
 import team.washer.server.v2.domain.machine.enums.MachineType;
@@ -45,6 +46,8 @@ class CreateReservationServiceTest {
     private UserRepository userRepository;
     @Mock
     private MachineRepository machineRepository;
+    @Mock
+    private WashingBanRepository washingBanRepository;
     @Mock
     private PenaltyRedisUtil penaltyRedisUtil;
     @Mock

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/QueryReservationAvailabilityServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/QueryReservationAvailabilityServiceTest.java
@@ -14,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import team.washer.server.v2.domain.admin.repository.WashingBanRepository;
 import team.washer.server.v2.domain.machine.enums.MachineType;
 import team.washer.server.v2.domain.reservation.service.impl.QueryReservationAvailabilityServiceImpl;
 import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
@@ -27,6 +28,9 @@ class QueryReservationAvailabilityServiceTest {
 
     @InjectMocks
     private QueryReservationAvailabilityServiceImpl queryReservationAvailabilityService;
+
+    @Mock
+    private WashingBanRepository washingBanRepository;
 
     @Mock
     private PenaltyRedisUtil penaltyRedisUtil;

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/QueryReservationAvailabilityServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/QueryReservationAvailabilityServiceTest.java
@@ -127,6 +127,30 @@ class QueryReservationAvailabilityServiceTest {
         }
 
         @Nested
+        @DisplayName("세탁 강제 금지된 호실의 사용자가 조회할 때")
+        class Context_with_banned_room {
+
+            @Test
+            @DisplayName("isBanned가 true이고 예약 불가 상태를 반환해야 한다")
+            void it_returns_banned_and_unavailable() {
+                // Given
+                var userId = 1L;
+                var user = createUser("301");
+                given(currentUserProvider.getCurrentUserId()).willReturn(userId);
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(washingBanRepository.existsByRoomNumber("301")).willReturn(true);
+                given(penaltyRedisUtil.isBlocked("301")).willReturn(false);
+
+                // When
+                var result = queryReservationAvailabilityService.execute();
+
+                // Then
+                assertThat(result.canReserve()).isFalse();
+                assertThat(result.isBanned()).isTrue();
+            }
+        }
+
+        @Nested
         @DisplayName("48시간 블록 중인 호실의 사용자가 조회할 때")
         class Context_with_blocked_room {
 


### PR DESCRIPTION
## 개요

관리자가 특정 호실의 세탁기/건조기 신규 예약을 무기한 차단할 수 있는 세탁 강제 금지 기능을 추가하였습니다. `WashingBan` 엔티티와 관리자 API 3개를 신규 구현하였으며, 기존 예약 생성 및 가용성 조회 흐름에 금지 검증을 연동하였습니다.

## 본문

### 주요 변경 사항

**`WashingBan` 도메인 신규 추가 (`domain/admin/`)**

- `WashingBan` 엔티티: `roomNumber` 필드에 unique 제약을 적용하여 동일 호실 중복 금지를 DB 레벨에서 보장하였습니다.
- `WashingBanRepository`: `existsByRoomNumber`, `findByRoomNumber` 메서드를 제공합니다.
- 서비스 3종 추가:
  - `CreateWashingBanService` — 중복 호실 금지 시도 시 `409 CONFLICT` 반환
  - `DeleteWashingBanService` — 금지되지 않은 호실 해제 시도 시 `404 NOT_FOUND` 반환
  - `QueryAllWashingBansService` — 현재 금지된 전체 호실 목록 반환

**`AdminWashingBanController` 신규 추가**

| 메서드 | 경로 | 설명 |
|--------|------|------|
| `POST` | `/api/v2/admin/washing-bans` | 호실 세탁 금지 등록 |
| `DELETE` | `/api/v2/admin/washing-bans/{roomNumber}` | 호실 세탁 금지 해제 |
| `GET` | `/api/v2/admin/washing-bans` | 금지 호실 목록 조회 |

기존 `DomainAuthorizationConfig`의 `/api/v2/admin/**` 규칙에 의해 `DORMITORY_COUNCIL` 및 `ADMIN` 권한만 접근 가능합니다.

**예약 도메인 연동**

- `CreateReservationServiceImpl`: `validateFloorRestriction()` 직후 `WashingBanRepository.existsByRoomNumber()`로 금지 호실 검증을 수행하며, 금지된 경우 `403 FORBIDDEN`을 반환합니다. 기존 활성 예약(RESERVED/RUNNING)은 유지됩니다.
- `ReservationAvailabilityResDto`: `isBanned` 필드를 추가하였습니다.
- `QueryReservationAvailabilityServiceImpl`: `isBanned`가 `true`이면 `canReserve: false`로 응답하여 프론트엔드가 예약 버튼을 사전에 비활성화할 수 있도록 하였습니다.

**테스트**

- `CreateReservationServiceTest`, `QueryReservationAvailabilityServiceTest`에 `@Mock WashingBanRepository`를 추가하여 기존 255개 테스트가 모두 통과합니다.
