### PR TITLE
[notification] FCM 토큰 저장 및 전송 보강

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/notification/dto/request/FcmTokenReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/dto/request/FcmTokenReqDto.java
@@ -2,7 +2,9 @@ package team.washer.server.v2.domain.notification.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import team.washer.server.v2.global.common.constants.NotificationConstants;
 
 public record FcmTokenReqDto(
-        @NotBlank(message = "FCM 토큰은 필수입니다") @Schema(description = "FCM 토큰", example = "dGVzdC10b2tlbi1leGFtcGxl") String token) {
+        @NotBlank(message = "FCM 토큰은 필수입니다") @Size(max = NotificationConstants.FCM_TOKEN_MAX_LENGTH, message = "FCM 토큰은 4096자를 초과할 수 없습니다") @Schema(description = "FCM 토큰", example = "dGVzdC10b2tlbi1leGFtcGxl") String token) {
 }

--- a/src/main/java/team/washer/server/v2/domain/notification/service/impl/DeleteFcmTokenServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/service/impl/DeleteFcmTokenServiceImpl.java
@@ -2,6 +2,7 @@ package team.washer.server.v2.domain.notification.service.impl;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
@@ -19,7 +20,7 @@ public class DeleteFcmTokenServiceImpl implements DeleteFcmTokenService {
     private final UserRepository userRepository;
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void execute(final Long userId) {
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));

--- a/src/main/java/team/washer/server/v2/domain/notification/service/impl/DeleteFcmTokenServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/service/impl/DeleteFcmTokenServiceImpl.java
@@ -25,6 +25,6 @@ public class DeleteFcmTokenServiceImpl implements DeleteFcmTokenService {
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
         user.clearFcmToken();
-        log.info("FCM token deleted: userId={}", userId);
+        log.info("FCM token deleted userId={}", userId);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/notification/service/impl/RegisterFcmTokenServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/service/impl/RegisterFcmTokenServiceImpl.java
@@ -28,6 +28,6 @@ public class RegisterFcmTokenServiceImpl implements RegisterFcmTokenService {
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
         user.updateFcmToken(token);
-        log.info("FCM token registered/updated: userId={}", userId);
+        log.info("FCM token registered or updated userId={}", userId);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/notification/support/FcmNotificationSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/support/FcmNotificationSupport.java
@@ -43,9 +43,16 @@ public class FcmNotificationSupport {
 
         try {
             final var notification = Notification.builder().setTitle(title).setBody(body).build();
-            final var message = Message.builder().setToken(token).setNotification(notification).putData("title", title)
-                    .putData("body", body).setAndroidConfig(androidConfig(title, body))
-                    .setApnsConfig(apnsConfig(title, body)).setWebpushConfig(webpushConfig(title, body)).build();
+            final var messageBuilder = Message.builder().setToken(token).setNotification(notification)
+                    .setAndroidConfig(androidConfig(title, body)).setApnsConfig(apnsConfig(title, body))
+                    .setWebpushConfig(webpushConfig(title, body));
+            if (title != null) {
+                messageBuilder.putData("title", title);
+            }
+            if (body != null) {
+                messageBuilder.putData("body", body);
+            }
+            final var message = messageBuilder.build();
             final String messageId = firebaseMessaging.send(message);
             log.info("FCM notification sent successfully userId={} messageId={}", user.getId(), messageId);
         } catch (FirebaseMessagingException e) {

--- a/src/main/java/team/washer/server/v2/domain/notification/support/FcmNotificationSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/support/FcmNotificationSupport.java
@@ -30,7 +30,7 @@ public class FcmNotificationSupport {
     public void send(final User user, final String title, final String body) {
         final String token = user.getFcmToken();
         if (token == null || token.isBlank()) {
-            log.debug("FCM token not found, skipping notification: userId={}", user.getId());
+            log.debug("FCM token not found skipping notification userId={}", user.getId());
             return;
         }
 
@@ -38,12 +38,12 @@ public class FcmNotificationSupport {
             final var notification = Notification.builder().setTitle(title).setBody(body).build();
             final var message = Message.builder().setToken(token).setNotification(notification).build();
             final String messageId = firebaseMessaging.send(message);
-            log.info("FCM notification sent successfully: userId={}, messageId={}", user.getId(), messageId);
+            log.info("FCM notification sent successfully userId={} messageId={}", user.getId(), messageId);
         } catch (FirebaseMessagingException e) {
             final MessagingErrorCode errorCode = e.getMessagingErrorCode();
-            log.error("Failed to send FCM notification: userId={}, errorCode={}", user.getId(), errorCode, e);
+            log.error("Failed to send FCM notification userId={} errorCode={}", user.getId(), errorCode, e);
             if (errorCode == MessagingErrorCode.UNREGISTERED || errorCode == MessagingErrorCode.INVALID_ARGUMENT) {
-                log.warn("Removing invalid FCM token: userId={}, errorCode={}", user.getId(), errorCode);
+                log.warn("Removing invalid FCM token userId={} errorCode={}", user.getId(), errorCode);
                 deleteFcmTokenService.execute(user.getId());
             }
         }

--- a/src/main/java/team/washer/server/v2/domain/notification/support/FcmNotificationSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/support/FcmNotificationSupport.java
@@ -2,11 +2,18 @@ package team.washer.server.v2.domain.notification.support;
 
 import org.springframework.stereotype.Component;
 
+import com.google.firebase.messaging.AndroidConfig;
+import com.google.firebase.messaging.AndroidNotification;
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.ApsAlert;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.MessagingErrorCode;
 import com.google.firebase.messaging.Notification;
+import com.google.firebase.messaging.WebpushConfig;
+import com.google.firebase.messaging.WebpushNotification;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,7 +43,9 @@ public class FcmNotificationSupport {
 
         try {
             final var notification = Notification.builder().setTitle(title).setBody(body).build();
-            final var message = Message.builder().setToken(token).setNotification(notification).build();
+            final var message = Message.builder().setToken(token).setNotification(notification).putData("title", title)
+                    .putData("body", body).setAndroidConfig(androidConfig(title, body))
+                    .setApnsConfig(apnsConfig(title, body)).setWebpushConfig(webpushConfig(title, body)).build();
             final String messageId = firebaseMessaging.send(message);
             log.info("FCM notification sent successfully userId={} messageId={}", user.getId(), messageId);
         } catch (FirebaseMessagingException e) {
@@ -47,5 +56,20 @@ public class FcmNotificationSupport {
                 deleteFcmTokenService.execute(user.getId());
             }
         }
+    }
+
+    private AndroidConfig androidConfig(final String title, final String body) {
+        return AndroidConfig.builder().setPriority(AndroidConfig.Priority.HIGH)
+                .setNotification(AndroidNotification.builder().setTitle(title).setBody(body).build()).build();
+    }
+
+    private ApnsConfig apnsConfig(final String title, final String body) {
+        final var alert = ApsAlert.builder().setTitle(title).setBody(body).build();
+        return ApnsConfig.builder().setAps(Aps.builder().setAlert(alert).setSound("default").build()).build();
+    }
+
+    private WebpushConfig webpushConfig(final String title, final String body) {
+        return WebpushConfig.builder()
+                .setNotification(WebpushNotification.builder().setTitle(title).setBody(body).build()).build();
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupport.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -101,6 +103,26 @@ public class ReservationNotificationSupport {
         notificationRepository.save(notification);
         enforceNotificationLimit(user);
         log.info("Notification persisted userId={} type={}", user.getId(), notification.getType());
+        sendAfterCommit(user, notification, fcmTitle);
+    }
+
+    private void sendAfterCommit(final User user, final Notification notification, final String fcmTitle) {
+        if (TransactionSynchronizationManager.isActualTransactionActive()
+                && TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+
+                @Override
+                public void afterCommit() {
+                    sendFcm(user, notification, fcmTitle);
+                }
+            });
+            return;
+        }
+
+        sendFcm(user, notification, fcmTitle);
+    }
+
+    private void sendFcm(final User user, final Notification notification, final String fcmTitle) {
         try {
             fcmNotificationSupport.send(user, fcmTitle, notification.getMessage());
         } catch (RuntimeException e) {

--- a/src/main/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupport.java
@@ -100,8 +100,12 @@ public class ReservationNotificationSupport {
     private void persistAndSend(final User user, final Notification notification, final String fcmTitle) {
         notificationRepository.save(notification);
         enforceNotificationLimit(user);
-        log.info("Notification sent userId={} type={}", user.getId(), notification.getType());
-        fcmNotificationSupport.send(user, fcmTitle, notification.getMessage());
+        log.info("Notification persisted userId={} type={}", user.getId(), notification.getType());
+        try {
+            fcmNotificationSupport.send(user, fcmTitle, notification.getMessage());
+        } catch (RuntimeException e) {
+            log.error("FCM notification send failed userId={} type={}", user.getId(), notification.getType(), e);
+        }
     }
 
     private void enforceNotificationLimit(final User user) {

--- a/src/main/java/team/washer/server/v2/domain/user/entity/User.java
+++ b/src/main/java/team/washer/server/v2/domain/user/entity/User.java
@@ -17,6 +17,7 @@ import team.washer.server.v2.domain.malfunction.entity.MalfunctionReport;
 import team.washer.server.v2.domain.notification.entity.Notification;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.user.enums.UserRole;
+import team.washer.server.v2.global.common.constants.NotificationConstants;
 import team.washer.server.v2.global.common.constants.TimeRestrictionConstants;
 import team.washer.server.v2.global.common.entity.BaseEntity;
 
@@ -72,7 +73,8 @@ public class User extends BaseEntity {
     @Column(name = "last_cancellation_at")
     private LocalDateTime lastCancellationAt;
 
-    @Column(name = "fcm_token", length = 255)
+    @Size(max = NotificationConstants.FCM_TOKEN_MAX_LENGTH, message = "FCM 토큰은 4096자를 초과할 수 없습니다")
+    @Column(name = "fcm_token", length = NotificationConstants.FCM_TOKEN_MAX_LENGTH)
     private String fcmToken;
 
     // 연관관계

--- a/src/main/java/team/washer/server/v2/global/common/constants/NotificationConstants.java
+++ b/src/main/java/team/washer/server/v2/global/common/constants/NotificationConstants.java
@@ -1,0 +1,9 @@
+package team.washer.server.v2.global.common.constants;
+
+public final class NotificationConstants {
+
+    public static final int FCM_TOKEN_MAX_LENGTH = 4096;
+
+    private NotificationConstants() {
+    }
+}

--- a/src/main/java/team/washer/server/v2/global/config/FcmConfig.java
+++ b/src/main/java/team/washer/server/v2/global/config/FcmConfig.java
@@ -33,7 +33,7 @@ public class FcmConfig {
     public FirebaseMessaging firebaseMessaging() throws IOException {
         if (fcmProperties.serviceAccountJson() == null || fcmProperties.serviceAccountJson().isBlank()) {
             throw new IllegalStateException(
-                    "FCM service account JSON is not configured. Set FIREBASE_SERVICE_ACCOUNT_JSON environment variable.");
+                    "FCM service account JSON is not configured. Set THIRD_PARTY_FCM_SERVICE_ACCOUNT_JSON environment variable.");
         }
 
         if (FirebaseApp.getApps().isEmpty()) {

--- a/src/test/java/team/washer/server/v2/domain/notification/dto/request/FcmTokenReqDtoTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/dto/request/FcmTokenReqDtoTest.java
@@ -1,0 +1,40 @@
+package team.washer.server.v2.domain.notification.dto.request;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import jakarta.validation.Validation;
+import team.washer.server.v2.global.common.constants.NotificationConstants;
+
+@DisplayName("FcmTokenReqDto의")
+class FcmTokenReqDtoTest {
+
+    @Test
+    @DisplayName("FCM 토큰은 4096자까지 허용한다")
+    void token_allows_max_length() {
+        try (var validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            var validator = validatorFactory.getValidator();
+            var request = new FcmTokenReqDto("a".repeat(NotificationConstants.FCM_TOKEN_MAX_LENGTH));
+
+            var violations = validator.validate(request);
+
+            assertThat(violations).isEmpty();
+        }
+    }
+
+    @Test
+    @DisplayName("FCM 토큰이 4096자를 초과하면 검증에 실패한다")
+    void token_rejects_over_max_length() {
+        try (var validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            var validator = validatorFactory.getValidator();
+            var request = new FcmTokenReqDto("a".repeat(NotificationConstants.FCM_TOKEN_MAX_LENGTH + 1));
+
+            var violations = validator.validate(request);
+
+            assertThat(violations).extracting(violation -> violation.getMessage())
+                    .contains("FCM 토큰은 4096자를 초과할 수 없습니다");
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/notification/service/RegisterFcmTokenServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/service/RegisterFcmTokenServiceTest.java
@@ -18,6 +18,7 @@ import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.notification.service.impl.RegisterFcmTokenServiceImpl;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.common.constants.NotificationConstants;
 import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 
 @ExtendWith(MockitoExtension.class)
@@ -86,6 +87,29 @@ class RegisterFcmTokenServiceTest {
 
                 // Then
                 assertThat(user.getFcmToken()).isEqualTo(newToken);
+                then(userRepository).should(times(1)).findById(USER_ID);
+            }
+        }
+
+        @Nested
+        @DisplayName("긴 FCM 토큰을 등록할 때")
+        class Context_with_long_token {
+
+            @Test
+            @DisplayName("토큰 전체가 잘리지 않고 저장되어야 한다")
+            void it_registers_full_token() {
+                // Given
+                when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+                String token = "a".repeat(NotificationConstants.FCM_TOKEN_MAX_LENGTH);
+                User user = createUser();
+
+                given(userRepository.findById(USER_ID)).willReturn(Optional.of(user));
+
+                // When
+                registerFcmTokenService.execute(token);
+
+                // Then
+                assertThat(user.getFcmToken()).hasSize(NotificationConstants.FCM_TOKEN_MAX_LENGTH).isEqualTo(token);
                 then(userRepository).should(times(1)).findById(USER_ID);
             }
         }

--- a/src/test/java/team/washer/server/v2/domain/notification/support/FcmNotificationSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/support/FcmNotificationSupportTest.java
@@ -1,0 +1,67 @@
+package team.washer.server.v2.domain.notification.support;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+
+import team.washer.server.v2.domain.notification.service.DeleteFcmTokenService;
+import team.washer.server.v2.domain.user.entity.User;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FcmNotificationSupport 클래스는")
+class FcmNotificationSupportTest {
+
+    @InjectMocks
+    private FcmNotificationSupport fcmNotificationSupport;
+
+    @Mock
+    private FirebaseMessaging firebaseMessaging;
+
+    @Mock
+    private DeleteFcmTokenService deleteFcmTokenService;
+
+    private User createUserWithToken() {
+        final var user = User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3).build();
+        user.updateFcmToken("fcm-token");
+        return user;
+    }
+
+    @Nested
+    @DisplayName("send 메서드는")
+    class Describe_send {
+
+        @Test
+        @DisplayName("제목이 null이어도 예외 없이 전송해야 한다")
+        void it_omits_null_title_data() throws Exception {
+            // Given
+            User user = createUserWithToken();
+            given(firebaseMessaging.send(any(Message.class))).willReturn("message-id");
+
+            // When & Then
+            assertThatCode(() -> fcmNotificationSupport.send(user, null, "본문")).doesNotThrowAnyException();
+            then(firebaseMessaging).should(times(1)).send(any(Message.class));
+        }
+
+        @Test
+        @DisplayName("본문이 null이어도 예외 없이 전송해야 한다")
+        void it_omits_null_body_data() throws Exception {
+            // Given
+            User user = createUserWithToken();
+            given(firebaseMessaging.send(any(Message.class))).willReturn("message-id");
+
+            // When & Then
+            assertThatCode(() -> fcmNotificationSupport.send(user, "제목", null)).doesNotThrowAnyException();
+            then(firebaseMessaging).should(times(1)).send(any(Message.class));
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupportTest.java
@@ -3,6 +3,7 @@ package team.washer.server.v2.domain.notification.support;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.machine.enums.MachineType;
@@ -18,7 +20,7 @@ import team.washer.server.v2.domain.notification.repository.NotificationReposito
 import team.washer.server.v2.domain.user.entity.User;
 
 @ExtendWith(MockitoExtension.class)
-@DisplayName("ReservationNotificationSupport 클래스의")
+@DisplayName("ReservationNotificationSupport 클래스는")
 class ReservationNotificationSupportTest {
 
     @InjectMocks
@@ -30,6 +32,14 @@ class ReservationNotificationSupportTest {
     @Mock
     private FcmNotificationSupport fcmNotificationSupport;
 
+    @AfterEach
+    void clearTransactionSynchronization() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+        TransactionSynchronizationManager.setActualTransactionActive(false);
+    }
+
     private User createUser() {
         return User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3).build();
     }
@@ -39,11 +49,11 @@ class ReservationNotificationSupportTest {
     }
 
     @Nested
-    @DisplayName("알림 저장 후 30개 제한 로직은")
+    @DisplayName("알림 저장 개수 제한 로직은")
     class Describe_notification_limit {
 
         @Nested
-        @DisplayName("알림 개수가 30개 이하일 때")
+        @DisplayName("알림 개수가 30개 이하이면")
         class Context_with_count_under_limit {
 
             @Test
@@ -66,7 +76,7 @@ class ReservationNotificationSupportTest {
         }
 
         @Nested
-        @DisplayName("알림 개수가 정확히 30개일 때")
+        @DisplayName("알림 개수가 정확히 30개이면")
         class Context_with_count_at_limit {
 
             @Test
@@ -89,7 +99,7 @@ class ReservationNotificationSupportTest {
         }
 
         @Nested
-        @DisplayName("알림 개수가 30개를 초과할 때")
+        @DisplayName("알림 개수가 30개를 초과하면")
         class Context_with_count_over_limit {
 
             @Test
@@ -109,6 +119,36 @@ class ReservationNotificationSupportTest {
                 // Then
                 then(notificationRepository).should(times(1)).deleteOldestByUserExceedingLimit(user, 30);
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("FCM 전송 시점은")
+    class Describe_fcm_send_timing {
+
+        @Test
+        @DisplayName("트랜잭션 커밋 전에는 전송하지 않고 커밋 이후에 전송해야 한다")
+        void it_sends_after_commit() {
+            // Given
+            User user = createUser();
+            Machine machine = createMachine();
+            given(notificationRepository.save(any(Notification.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+            given(notificationRepository.countByUser(user)).willReturn(1L);
+            TransactionSynchronizationManager.setActualTransactionActive(true);
+            TransactionSynchronizationManager.initSynchronization();
+
+            // When
+            reservationNotificationSupport.sendCompletion(user, machine);
+
+            // Then
+            then(fcmNotificationSupport).should(never()).send(any(), anyString(), anyString());
+            final var synchronizations = TransactionSynchronizationManager.getSynchronizations();
+            assertThat(synchronizations).hasSize(1);
+
+            synchronizations.getFirst().afterCommit();
+
+            then(fcmNotificationSupport).should(times(1)).send(eq(user), anyString(), anyString());
         }
     }
 

--- a/src/test/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupportTest.java
@@ -1,5 +1,6 @@
 package team.washer.server.v2.domain.notification.support;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import org.junit.jupiter.api.DisplayName;
@@ -108,6 +109,29 @@ class ReservationNotificationSupportTest {
                 // Then
                 then(notificationRepository).should(times(1)).deleteOldestByUserExceedingLimit(user, 30);
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("FCM 전송이 실패할 때는")
+    class Describe_fcm_failure {
+
+        @Test
+        @DisplayName("알림을 저장하고 예외를 전파하지 않아야 한다")
+        void it_persists_notification_without_propagating_exception() {
+            // Given
+            User user = createUser();
+            Machine machine = createMachine();
+            given(notificationRepository.save(any(Notification.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+            given(notificationRepository.countByUser(user)).willReturn(1L);
+            willThrow(new RuntimeException("fcm down")).given(fcmNotificationSupport)
+                    .send(any(), anyString(), anyString());
+
+            // When & Then
+            assertThatCode(() -> reservationNotificationSupport.sendCompletion(user, machine))
+                    .doesNotThrowAnyException();
+            then(notificationRepository).should(times(1)).save(any(Notification.class));
         }
     }
 }

--- a/src/test/java/team/washer/server/v2/domain/user/entity/UserTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/entity/UserTest.java
@@ -8,8 +8,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.Size;
 import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.user.enums.UserRole;
+import team.washer.server.v2.global.common.constants.NotificationConstants;
 
 @DisplayName("User 엔티티의")
 class UserTest {
@@ -18,6 +21,22 @@ class UserTest {
     private User createUser(final Integer grade, final UserRole role) {
         return User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(grade).floor(3).penaltyCount(0)
                 .role(role).build();
+    }
+
+    @Nested
+    @DisplayName("FCM 토큰 필드는")
+    class Describe_fcmToken {
+
+        @Test
+        @DisplayName("긴 등록 토큰을 저장할 수 있도록 4096자까지 허용한다")
+        void it_allows_long_registration_token() throws NoSuchFieldException {
+            final var field = User.class.getDeclaredField("fcmToken");
+            final var column = field.getAnnotation(Column.class);
+            final var size = field.getAnnotation(Size.class);
+
+            assertThat(column.length()).isEqualTo(NotificationConstants.FCM_TOKEN_MAX_LENGTH);
+            assertThat(size.max()).isEqualTo(NotificationConstants.FCM_TOKEN_MAX_LENGTH);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 개요

  `FCM` 전송 실패가 예약 완료와 알림 저장 흐름을 깨지 않도록 예외를 격리했습니다.
  긴 `FCM` 토큰 저장과 실제 푸쉬 수신 가능성을 보강하기 위해 토큰 컬럼 길이와 메시지 payload 구성을 개선했습니다.

  ## 본문

  - `ReservationNotificationSupport`에서 알림 저장 후 `FCM` 전송 중 `RuntimeException`이 발생해도 예약 처리로 예외가 전파되지 않도록 수정했습니다.
  - `users.fcm_token` 컬럼 길이를 `255`에서 `4096`으로 확장하고, `FcmTokenReqDto`에도 동일한 최대 길이 검증을 추가했습니다.
  - `FCM` 메시지에 `notification` payload와 함께 `data` payload를 포함하도록 수정했습니다.
  - `AndroidConfig`에 `HIGH` priority를 설정하고, `ApnsConfig`, `WebpushConfig`를 추가해 플랫폼별 푸쉬 수신 설정을 보강했습니다.
  - `FcmConfig`의 설정 누락 메시지를 실제 환경변수인 `THIRD_PARTY_FCM_SERVICE_ACCOUNT_JSON` 기준으로 수정했습니다.
  - `FcmNotificationSupport`, `RegisterFcmTokenServiceImpl`, `DeleteFcmTokenServiceImpl`의 로그를 `key=value` 형식으로 정리했습니다.
  - `FCM` 전송 실패, 긴 토큰 등록, DTO 길이 검증, 엔티티 컬럼 매핑에 대한 회귀 테스트를 추가했습니다.