### PR TITLE
[appversion] 앱 버전 정책 관리 API 추가

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/appversion/controller/AdminAppVersionController.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/controller/AdminAppVersionController.java
@@ -1,0 +1,43 @@
+package team.washer.server.v2.domain.appversion.controller;
+
+import java.util.List;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.appversion.dto.request.UpsertAppVersionPolicyReqDto;
+import team.washer.server.v2.domain.appversion.dto.response.AppVersionPolicyResDto;
+import team.washer.server.v2.domain.appversion.enums.AppPlatform;
+import team.washer.server.v2.domain.appversion.service.QueryAppVersionPoliciesService;
+import team.washer.server.v2.domain.appversion.service.UpsertAppVersionPolicyService;
+
+@RestController
+@RequestMapping("/api/v2/admin/app-versions")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "Admin App Version", description = "앱 버전 정책 관리 API")
+public class AdminAppVersionController {
+
+    private final QueryAppVersionPoliciesService queryAppVersionPoliciesService;
+    private final UpsertAppVersionPolicyService upsertAppVersionPolicyService;
+
+    @GetMapping
+    @Operation(summary = "앱 버전 정책 목록 조회", description = "플랫폼별 앱 버전 정책 목록을 조회합니다.")
+    public List<AppVersionPolicyResDto> queryAppVersionPolicies() {
+        return queryAppVersionPoliciesService.execute();
+    }
+
+    @PutMapping("/{platform}")
+    @Operation(summary = "앱 버전 정책 등록/수정", description = "플랫폼별 최신 버전, 최소 지원 버전, 스토어 URL, 업데이트 메시지를 등록하거나 수정합니다.")
+    public AppVersionPolicyResDto upsertAppVersionPolicy(
+            @Parameter(description = "앱 플랫폼") @PathVariable @NotNull final AppPlatform platform,
+            @RequestBody @Valid final UpsertAppVersionPolicyReqDto reqDto) {
+        return upsertAppVersionPolicyService.execute(platform, reqDto);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/controller/AppVersionController.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/controller/AppVersionController.java
@@ -1,0 +1,31 @@
+package team.washer.server.v2.domain.appversion.controller;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.appversion.dto.request.AppVersionStatusReqDto;
+import team.washer.server.v2.domain.appversion.dto.response.AppVersionStatusResDto;
+import team.washer.server.v2.domain.appversion.service.QueryAppVersionStatusService;
+
+@RestController
+@RequestMapping("/api/v2/app-versions")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "App Version", description = "앱 버전 API")
+public class AppVersionController {
+
+    private final QueryAppVersionStatusService queryAppVersionStatusService;
+
+    @GetMapping("/status")
+    @Operation(summary = "앱 버전 상태 조회", description = "현재 앱 버전의 업데이트 필요 여부를 조회합니다. 앱 시작 시 인증 없이 사용할 수 있습니다.")
+    public AppVersionStatusResDto queryAppVersionStatus(@Valid @ModelAttribute final AppVersionStatusReqDto reqDto) {
+        return queryAppVersionStatusService.execute(reqDto);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/dto/request/AppVersionStatusReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/dto/request/AppVersionStatusReqDto.java
@@ -1,0 +1,14 @@
+package team.washer.server.v2.domain.appversion.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+import team.washer.server.v2.domain.appversion.enums.AppPlatform;
+
+@Schema(description = "앱 버전 상태 조회 요청 DTO")
+public record AppVersionStatusReqDto(
+        @Schema(description = "앱 플랫폼", example = "ANDROID") @NotNull(message = "플랫폼은 필수입니다.") AppPlatform platform,
+        @Schema(description = "현재 앱 버전 코드", example = "12") @NotNull(message = "버전 코드는 필수입니다.") @PositiveOrZero(message = "버전 코드는 0 이상이어야 합니다.") Integer versionCode,
+        @Schema(description = "현재 앱 버전 이름", example = "1.2.3") @Size(max = 50, message = "버전 이름은 50자를 초과할 수 없습니다.") String versionName) {
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/dto/request/UpsertAppVersionPolicyReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/dto/request/UpsertAppVersionPolicyReqDto.java
@@ -1,0 +1,17 @@
+package team.washer.server.v2.domain.appversion.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "앱 버전 정책 등록/수정 요청 DTO")
+public record UpsertAppVersionPolicyReqDto(
+        @Schema(description = "최신 앱 버전 이름", example = "1.4.0") @NotBlank(message = "최신 버전 이름은 필수입니다.") @Size(max = 50, message = "최신 버전 이름은 50자를 초과할 수 없습니다.") String latestVersionName,
+        @Schema(description = "최신 앱 버전 코드", example = "18") @NotNull(message = "최신 버전 코드는 필수입니다.") @PositiveOrZero(message = "최신 버전 코드는 0 이상이어야 합니다.") Integer latestVersionCode,
+        @Schema(description = "최소 지원 앱 버전 이름", example = "1.3.0") @NotBlank(message = "최소 지원 버전 이름은 필수입니다.") @Size(max = 50, message = "최소 지원 버전 이름은 50자를 초과할 수 없습니다.") String minSupportedVersionName,
+        @Schema(description = "최소 지원 앱 버전 코드", example = "15") @NotNull(message = "최소 지원 버전 코드는 필수입니다.") @PositiveOrZero(message = "최소 지원 버전 코드는 0 이상이어야 합니다.") Integer minSupportedVersionCode,
+        @Schema(description = "스토어 URL", example = "https://play.google.com/store/apps/details?id=team.washer") @NotBlank(message = "스토어 URL은 필수입니다.") @Size(max = 500, message = "스토어 URL은 500자를 초과할 수 없습니다.") String storeUrl,
+        @Schema(description = "업데이트 안내 메시지", example = "앱 업데이트가 필요합니다.") @NotBlank(message = "업데이트 안내 메시지는 필수입니다.") @Size(max = 255, message = "업데이트 안내 메시지는 255자를 초과할 수 없습니다.") String updateMessage) {
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/dto/response/AppVersionPolicyResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/dto/response/AppVersionPolicyResDto.java
@@ -1,0 +1,14 @@
+package team.washer.server.v2.domain.appversion.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import team.washer.server.v2.domain.appversion.enums.AppPlatform;
+
+@Schema(description = "앱 버전 정책 응답 DTO")
+public record AppVersionPolicyResDto(@Schema(description = "앱 플랫폼", example = "ANDROID") AppPlatform platform,
+        @Schema(description = "최신 앱 버전 이름", example = "1.4.0") String latestVersionName,
+        @Schema(description = "최신 앱 버전 코드", example = "18") Integer latestVersionCode,
+        @Schema(description = "최소 지원 앱 버전 이름", example = "1.3.0") String minSupportedVersionName,
+        @Schema(description = "최소 지원 앱 버전 코드", example = "15") Integer minSupportedVersionCode,
+        @Schema(description = "스토어 URL", example = "https://play.google.com/store/apps/details?id=team.washer") String storeUrl,
+        @Schema(description = "업데이트 안내 메시지", example = "앱 업데이트가 필요합니다.") String updateMessage) {
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/dto/response/AppVersionStatusResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/dto/response/AppVersionStatusResDto.java
@@ -1,0 +1,20 @@
+package team.washer.server.v2.domain.appversion.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import team.washer.server.v2.domain.appversion.enums.AppPlatform;
+import team.washer.server.v2.domain.appversion.enums.AppUpdateStatus;
+
+@Schema(description = "앱 버전 상태 응답 DTO")
+public record AppVersionStatusResDto(@Schema(description = "앱 플랫폼", example = "ANDROID") AppPlatform platform,
+        @Schema(description = "현재 앱 버전 이름", example = "1.2.3") String currentVersionName,
+        @Schema(description = "현재 앱 버전 코드", example = "12") Integer currentVersionCode,
+        @Schema(description = "최신 앱 버전 이름", example = "1.4.0") String latestVersionName,
+        @Schema(description = "최신 앱 버전 코드", example = "18") Integer latestVersionCode,
+        @Schema(description = "최소 지원 앱 버전 이름", example = "1.3.0") String minSupportedVersionName,
+        @Schema(description = "최소 지원 앱 버전 코드", example = "15") Integer minSupportedVersionCode,
+        @Schema(description = "강제 업데이트 필요 여부", example = "true") boolean updateRequired,
+        @Schema(description = "업데이트 가능 여부", example = "true") boolean updateAvailable,
+        @Schema(description = "업데이트 상태", example = "UPDATE_REQUIRED") AppUpdateStatus updateStatus,
+        @Schema(description = "스토어 URL", example = "https://play.google.com/store/apps/details?id=team.washer") String storeUrl,
+        @Schema(description = "업데이트 안내 메시지", example = "앱 업데이트가 필요합니다.") String updateMessage) {
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/entity/AppVersionPolicy.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/entity/AppVersionPolicy.java
@@ -1,0 +1,86 @@
+package team.washer.server.v2.domain.appversion.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.*;
+import team.washer.server.v2.domain.appversion.enums.AppPlatform;
+import team.washer.server.v2.domain.appversion.enums.AppUpdateStatus;
+import team.washer.server.v2.global.common.entity.BaseEntity;
+
+@Entity
+@Table(name = "app_version_policies", uniqueConstraints = @UniqueConstraint(name = "uk_app_version_policy_platform", columnNames = "platform"))
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class AppVersionPolicy extends BaseEntity {
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "platform", nullable = false, length = 20)
+    private AppPlatform platform;
+
+    @NotBlank
+    @Size(max = 50)
+    @Column(name = "latest_version_name", nullable = false, length = 50)
+    private String latestVersionName;
+
+    @NotNull
+    @PositiveOrZero
+    @Column(name = "latest_version_code", nullable = false)
+    private Integer latestVersionCode;
+
+    @NotBlank
+    @Size(max = 50)
+    @Column(name = "min_supported_version_name", nullable = false, length = 50)
+    private String minSupportedVersionName;
+
+    @NotNull
+    @PositiveOrZero
+    @Column(name = "min_supported_version_code", nullable = false)
+    private Integer minSupportedVersionCode;
+
+    @NotBlank
+    @Size(max = 500)
+    @Column(name = "store_url", nullable = false, length = 500)
+    private String storeUrl;
+
+    @NotBlank
+    @Size(max = 255)
+    @Column(name = "update_message", nullable = false, length = 255)
+    private String updateMessage;
+
+    /**
+     * 앱 버전 정책을 최신 운영 기준으로 갱신합니다.
+     */
+    public void updatePolicy(final String latestVersionName,
+            final Integer latestVersionCode,
+            final String minSupportedVersionName,
+            final Integer minSupportedVersionCode,
+            final String storeUrl,
+            final String updateMessage) {
+        this.latestVersionName = latestVersionName;
+        this.latestVersionCode = latestVersionCode;
+        this.minSupportedVersionName = minSupportedVersionName;
+        this.minSupportedVersionCode = minSupportedVersionCode;
+        this.storeUrl = storeUrl;
+        this.updateMessage = updateMessage;
+    }
+
+    /**
+     * 현재 앱 버전의 업데이트 상태를 계산합니다.
+     *
+     * @param versionCode
+     *            현재 앱 버전 코드
+     * @return 업데이트 상태
+     */
+    public AppUpdateStatus resolveUpdateStatus(final int versionCode) {
+        if (versionCode < minSupportedVersionCode) {
+            return AppUpdateStatus.UPDATE_REQUIRED;
+        }
+        if (versionCode < latestVersionCode) {
+            return AppUpdateStatus.UPDATE_AVAILABLE;
+        }
+        return AppUpdateStatus.SUPPORTED;
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/enums/AppPlatform.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/enums/AppPlatform.java
@@ -1,0 +1,5 @@
+package team.washer.server.v2.domain.appversion.enums;
+
+public enum AppPlatform {
+    ANDROID, IOS
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/enums/AppUpdateStatus.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/enums/AppUpdateStatus.java
@@ -1,0 +1,5 @@
+package team.washer.server.v2.domain.appversion.enums;
+
+public enum AppUpdateStatus {
+    SUPPORTED, UPDATE_AVAILABLE, UPDATE_REQUIRED
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/repository/AppVersionPolicyRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/repository/AppVersionPolicyRepository.java
@@ -1,0 +1,12 @@
+package team.washer.server.v2.domain.appversion.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import team.washer.server.v2.domain.appversion.entity.AppVersionPolicy;
+import team.washer.server.v2.domain.appversion.enums.AppPlatform;
+
+public interface AppVersionPolicyRepository extends JpaRepository<AppVersionPolicy, Long> {
+    Optional<AppVersionPolicy> findByPlatform(AppPlatform platform);
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/service/QueryAppVersionPoliciesService.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/service/QueryAppVersionPoliciesService.java
@@ -1,0 +1,9 @@
+package team.washer.server.v2.domain.appversion.service;
+
+import java.util.List;
+
+import team.washer.server.v2.domain.appversion.dto.response.AppVersionPolicyResDto;
+
+public interface QueryAppVersionPoliciesService {
+    List<AppVersionPolicyResDto> execute();
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/service/QueryAppVersionStatusService.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/service/QueryAppVersionStatusService.java
@@ -1,0 +1,8 @@
+package team.washer.server.v2.domain.appversion.service;
+
+import team.washer.server.v2.domain.appversion.dto.request.AppVersionStatusReqDto;
+import team.washer.server.v2.domain.appversion.dto.response.AppVersionStatusResDto;
+
+public interface QueryAppVersionStatusService {
+    AppVersionStatusResDto execute(AppVersionStatusReqDto reqDto);
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/service/UpsertAppVersionPolicyService.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/service/UpsertAppVersionPolicyService.java
@@ -1,0 +1,9 @@
+package team.washer.server.v2.domain.appversion.service;
+
+import team.washer.server.v2.domain.appversion.dto.request.UpsertAppVersionPolicyReqDto;
+import team.washer.server.v2.domain.appversion.dto.response.AppVersionPolicyResDto;
+import team.washer.server.v2.domain.appversion.enums.AppPlatform;
+
+public interface UpsertAppVersionPolicyService {
+    AppVersionPolicyResDto execute(AppPlatform platform, UpsertAppVersionPolicyReqDto reqDto);
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/service/impl/QueryAppVersionPoliciesServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/service/impl/QueryAppVersionPoliciesServiceImpl.java
@@ -1,0 +1,37 @@
+package team.washer.server.v2.domain.appversion.service.impl;
+
+import java.util.List;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.appversion.dto.response.AppVersionPolicyResDto;
+import team.washer.server.v2.domain.appversion.entity.AppVersionPolicy;
+import team.washer.server.v2.domain.appversion.repository.AppVersionPolicyRepository;
+import team.washer.server.v2.domain.appversion.service.QueryAppVersionPoliciesService;
+
+@Service
+@RequiredArgsConstructor
+public class QueryAppVersionPoliciesServiceImpl implements QueryAppVersionPoliciesService {
+
+    private final AppVersionPolicyRepository appVersionPolicyRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AppVersionPolicyResDto> execute() {
+        return appVersionPolicyRepository.findAll(Sort.by(Sort.Direction.ASC, "platform")).stream()
+                .map(this::mapToResDto).toList();
+    }
+
+    private AppVersionPolicyResDto mapToResDto(final AppVersionPolicy policy) {
+        return new AppVersionPolicyResDto(policy.getPlatform(),
+                policy.getLatestVersionName(),
+                policy.getLatestVersionCode(),
+                policy.getMinSupportedVersionName(),
+                policy.getMinSupportedVersionCode(),
+                policy.getStoreUrl(),
+                policy.getUpdateMessage());
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/service/impl/QueryAppVersionStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/service/impl/QueryAppVersionStatusServiceImpl.java
@@ -1,0 +1,48 @@
+package team.washer.server.v2.domain.appversion.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.appversion.dto.request.AppVersionStatusReqDto;
+import team.washer.server.v2.domain.appversion.dto.response.AppVersionStatusResDto;
+import team.washer.server.v2.domain.appversion.entity.AppVersionPolicy;
+import team.washer.server.v2.domain.appversion.enums.AppUpdateStatus;
+import team.washer.server.v2.domain.appversion.repository.AppVersionPolicyRepository;
+import team.washer.server.v2.domain.appversion.service.QueryAppVersionStatusService;
+
+@Service
+@RequiredArgsConstructor
+public class QueryAppVersionStatusServiceImpl implements QueryAppVersionStatusService {
+
+    private final AppVersionPolicyRepository appVersionPolicyRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public AppVersionStatusResDto execute(final AppVersionStatusReqDto reqDto) {
+        final var policy = appVersionPolicyRepository.findByPlatform(reqDto.platform())
+                .orElseThrow(() -> new ExpectedException("앱 버전 정책을 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+        final var updateStatus = policy.resolveUpdateStatus(reqDto.versionCode());
+
+        return mapToStatusResDto(policy, reqDto, updateStatus);
+    }
+
+    private AppVersionStatusResDto mapToStatusResDto(final AppVersionPolicy policy,
+            final AppVersionStatusReqDto reqDto,
+            final AppUpdateStatus updateStatus) {
+        return new AppVersionStatusResDto(policy.getPlatform(),
+                reqDto.versionName(),
+                reqDto.versionCode(),
+                policy.getLatestVersionName(),
+                policy.getLatestVersionCode(),
+                policy.getMinSupportedVersionName(),
+                policy.getMinSupportedVersionCode(),
+                updateStatus == AppUpdateStatus.UPDATE_REQUIRED,
+                updateStatus != AppUpdateStatus.SUPPORTED,
+                updateStatus,
+                policy.getStoreUrl(),
+                policy.getUpdateMessage());
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/service/impl/UpsertAppVersionPolicyServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/service/impl/UpsertAppVersionPolicyServiceImpl.java
@@ -1,0 +1,66 @@
+package team.washer.server.v2.domain.appversion.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.appversion.dto.request.UpsertAppVersionPolicyReqDto;
+import team.washer.server.v2.domain.appversion.dto.response.AppVersionPolicyResDto;
+import team.washer.server.v2.domain.appversion.entity.AppVersionPolicy;
+import team.washer.server.v2.domain.appversion.enums.AppPlatform;
+import team.washer.server.v2.domain.appversion.repository.AppVersionPolicyRepository;
+import team.washer.server.v2.domain.appversion.service.UpsertAppVersionPolicyService;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UpsertAppVersionPolicyServiceImpl implements UpsertAppVersionPolicyService {
+
+    private final AppVersionPolicyRepository appVersionPolicyRepository;
+
+    @Override
+    @Transactional
+    public AppVersionPolicyResDto execute(final AppPlatform platform, final UpsertAppVersionPolicyReqDto reqDto) {
+        validateVersionCodeRange(reqDto);
+
+        final var policy = appVersionPolicyRepository.findByPlatform(platform)
+                .orElseGet(() -> AppVersionPolicy.builder().platform(platform)
+                        .latestVersionName(reqDto.latestVersionName()).latestVersionCode(reqDto.latestVersionCode())
+                        .minSupportedVersionName(reqDto.minSupportedVersionName())
+                        .minSupportedVersionCode(reqDto.minSupportedVersionCode()).storeUrl(reqDto.storeUrl())
+                        .updateMessage(reqDto.updateMessage()).build());
+
+        policy.updatePolicy(reqDto.latestVersionName(),
+                reqDto.latestVersionCode(),
+                reqDto.minSupportedVersionName(),
+                reqDto.minSupportedVersionCode(),
+                reqDto.storeUrl(),
+                reqDto.updateMessage());
+        final var savedPolicy = appVersionPolicyRepository.save(policy);
+        log.info("App version policy upserted platform={} latestVersionCode={} minSupportedVersionCode={}",
+                platform,
+                reqDto.latestVersionCode(),
+                reqDto.minSupportedVersionCode());
+
+        return mapToResDto(savedPolicy);
+    }
+
+    private void validateVersionCodeRange(final UpsertAppVersionPolicyReqDto reqDto) {
+        if (reqDto.minSupportedVersionCode() > reqDto.latestVersionCode()) {
+            throw new ExpectedException("최소 지원 버전 코드는 최신 버전 코드보다 클 수 없습니다", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private AppVersionPolicyResDto mapToResDto(final AppVersionPolicy policy) {
+        return new AppVersionPolicyResDto(policy.getPlatform(),
+                policy.getLatestVersionName(),
+                policy.getLatestVersionCode(),
+                policy.getMinSupportedVersionName(),
+                policy.getMinSupportedVersionCode(),
+                policy.getStoreUrl(),
+                policy.getUpdateMessage());
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/service/impl/UpsertAppVersionPolicyServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/service/impl/UpsertAppVersionPolicyServiceImpl.java
@@ -27,11 +27,7 @@ public class UpsertAppVersionPolicyServiceImpl implements UpsertAppVersionPolicy
         validateVersionCodeRange(reqDto);
 
         final var policy = appVersionPolicyRepository.findByPlatform(platform)
-                .orElseGet(() -> AppVersionPolicy.builder().platform(platform)
-                        .latestVersionName(reqDto.latestVersionName()).latestVersionCode(reqDto.latestVersionCode())
-                        .minSupportedVersionName(reqDto.minSupportedVersionName())
-                        .minSupportedVersionCode(reqDto.minSupportedVersionCode()).storeUrl(reqDto.storeUrl())
-                        .updateMessage(reqDto.updateMessage()).build());
+                .orElseGet(() -> AppVersionPolicy.builder().platform(platform).build());
 
         policy.updatePolicy(reqDto.latestVersionName(),
                 reqDto.latestVersionCode(),

--- a/src/main/java/team/washer/server/v2/global/security/config/DomainAuthorizationConfig.java
+++ b/src/main/java/team/washer/server/v2/global/security/config/DomainAuthorizationConfig.java
@@ -32,7 +32,8 @@ public class DomainAuthorizationConfig {
                 // Swagger UI
                 .requestMatchers(swaggerUiResources, swaggerUiPath, apiDocsPath, apiDocsPath + "/**").permitAll()
                 // 헬스 체크
-                .requestMatchers("/api/v2/health", "/api/v2/admin/smartthings/**").permitAll()
+                .requestMatchers("/api/v2/health", "/api/v2/admin/smartthings/**", "/api/v2/app-versions/status")
+                .permitAll()
                 // 인증 엔드포인트
                 .requestMatchers("/api/v2/auth/login", "/api/v2/auth/refresh", "/api/v2/auth/token/status").permitAll()
                 // 관리자 엔드포인트

--- a/src/test/java/team/washer/server/v2/domain/appversion/service/QueryAppVersionStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/appversion/service/QueryAppVersionStatusServiceTest.java
@@ -1,0 +1,111 @@
+package team.washer.server.v2.domain.appversion.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.appversion.dto.request.AppVersionStatusReqDto;
+import team.washer.server.v2.domain.appversion.entity.AppVersionPolicy;
+import team.washer.server.v2.domain.appversion.enums.AppPlatform;
+import team.washer.server.v2.domain.appversion.enums.AppUpdateStatus;
+import team.washer.server.v2.domain.appversion.repository.AppVersionPolicyRepository;
+import team.washer.server.v2.domain.appversion.service.impl.QueryAppVersionStatusServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("QueryAppVersionStatusServiceImpl 클래스는")
+class QueryAppVersionStatusServiceTest {
+
+    @InjectMocks
+    private QueryAppVersionStatusServiceImpl queryAppVersionStatusService;
+
+    @Mock
+    private AppVersionPolicyRepository appVersionPolicyRepository;
+
+    private AppVersionPolicy createPolicy() {
+        return AppVersionPolicy.builder().platform(AppPlatform.ANDROID).latestVersionName("1.4.0").latestVersionCode(18)
+                .minSupportedVersionName("1.3.0").minSupportedVersionCode(15)
+                .storeUrl("https://play.google.com/store/apps/details?id=team.washer").updateMessage("앱 업데이트가 필요합니다.")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Test
+        @DisplayName("최소 지원 버전보다 낮으면 강제 업데이트 상태를 반환해야 한다")
+        void it_returns_required_update_status() {
+            // Given
+            final var reqDto = new AppVersionStatusReqDto(AppPlatform.ANDROID, 14, "1.2.0");
+            given(appVersionPolicyRepository.findByPlatform(AppPlatform.ANDROID))
+                    .willReturn(Optional.of(createPolicy()));
+
+            // When
+            final var result = queryAppVersionStatusService.execute(reqDto);
+
+            // Then
+            assertThat(result.updateStatus()).isEqualTo(AppUpdateStatus.UPDATE_REQUIRED);
+            assertThat(result.updateRequired()).isTrue();
+            assertThat(result.updateAvailable()).isTrue();
+            assertThat(result.currentVersionName()).isEqualTo("1.2.0");
+            assertThat(result.currentVersionCode()).isEqualTo(14);
+        }
+
+        @Test
+        @DisplayName("최신 버전보다 낮고 최소 지원 버전 이상이면 선택 업데이트 상태를 반환해야 한다")
+        void it_returns_available_update_status() {
+            // Given
+            final var reqDto = new AppVersionStatusReqDto(AppPlatform.ANDROID, 16, "1.3.1");
+            given(appVersionPolicyRepository.findByPlatform(AppPlatform.ANDROID))
+                    .willReturn(Optional.of(createPolicy()));
+
+            // When
+            final var result = queryAppVersionStatusService.execute(reqDto);
+
+            // Then
+            assertThat(result.updateStatus()).isEqualTo(AppUpdateStatus.UPDATE_AVAILABLE);
+            assertThat(result.updateRequired()).isFalse();
+            assertThat(result.updateAvailable()).isTrue();
+        }
+
+        @Test
+        @DisplayName("최신 버전 이상이면 지원 상태를 반환해야 한다")
+        void it_returns_supported_status() {
+            // Given
+            final var reqDto = new AppVersionStatusReqDto(AppPlatform.ANDROID, 18, "1.4.0");
+            given(appVersionPolicyRepository.findByPlatform(AppPlatform.ANDROID))
+                    .willReturn(Optional.of(createPolicy()));
+
+            // When
+            final var result = queryAppVersionStatusService.execute(reqDto);
+
+            // Then
+            assertThat(result.updateStatus()).isEqualTo(AppUpdateStatus.SUPPORTED);
+            assertThat(result.updateRequired()).isFalse();
+            assertThat(result.updateAvailable()).isFalse();
+        }
+
+        @Test
+        @DisplayName("플랫폼 정책이 없으면 ExpectedException을 던져야 한다")
+        void it_throws_expected_exception_when_policy_not_found() {
+            // Given
+            final var reqDto = new AppVersionStatusReqDto(AppPlatform.IOS, 1, "1.0.0");
+            given(appVersionPolicyRepository.findByPlatform(AppPlatform.IOS)).willReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> queryAppVersionStatusService.execute(reqDto)).isInstanceOf(ExpectedException.class)
+                    .hasMessage("앱 버전 정책을 찾을 수 없습니다").hasFieldOrPropertyWithValue("statusCode", HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/appversion/service/UpsertAppVersionPolicyServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/appversion/service/UpsertAppVersionPolicyServiceTest.java
@@ -1,0 +1,110 @@
+package team.washer.server.v2.domain.appversion.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.appversion.dto.request.UpsertAppVersionPolicyReqDto;
+import team.washer.server.v2.domain.appversion.entity.AppVersionPolicy;
+import team.washer.server.v2.domain.appversion.enums.AppPlatform;
+import team.washer.server.v2.domain.appversion.repository.AppVersionPolicyRepository;
+import team.washer.server.v2.domain.appversion.service.impl.UpsertAppVersionPolicyServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpsertAppVersionPolicyServiceImpl 클래스는")
+class UpsertAppVersionPolicyServiceTest {
+
+    @InjectMocks
+    private UpsertAppVersionPolicyServiceImpl upsertAppVersionPolicyService;
+
+    @Mock
+    private AppVersionPolicyRepository appVersionPolicyRepository;
+
+    private UpsertAppVersionPolicyReqDto createReqDto() {
+        return new UpsertAppVersionPolicyReqDto("1.4.0",
+                18,
+                "1.3.0",
+                15,
+                "https://play.google.com/store/apps/details?id=team.washer",
+                "앱 업데이트가 필요합니다.");
+    }
+
+    private AppVersionPolicy createPolicy() {
+        return AppVersionPolicy.builder().platform(AppPlatform.ANDROID).latestVersionName("1.3.0").latestVersionCode(15)
+                .minSupportedVersionName("1.2.0").minSupportedVersionCode(12)
+                .storeUrl("https://play.google.com/store/apps/details?id=team.washer").updateMessage("이전 메시지").build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Test
+        @DisplayName("기존 정책이 없으면 새 정책을 저장해야 한다")
+        void it_creates_policy_when_not_exists() {
+            // Given
+            final var reqDto = createReqDto();
+            given(appVersionPolicyRepository.findByPlatform(AppPlatform.ANDROID)).willReturn(Optional.empty());
+            given(appVersionPolicyRepository.save(any(AppVersionPolicy.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            final var result = upsertAppVersionPolicyService.execute(AppPlatform.ANDROID, reqDto);
+
+            // Then
+            assertThat(result.platform()).isEqualTo(AppPlatform.ANDROID);
+            assertThat(result.latestVersionCode()).isEqualTo(18);
+            assertThat(result.minSupportedVersionCode()).isEqualTo(15);
+            then(appVersionPolicyRepository).should(times(1)).save(any(AppVersionPolicy.class));
+        }
+
+        @Test
+        @DisplayName("기존 정책이 있으면 정책 값을 갱신해야 한다")
+        void it_updates_policy_when_exists() {
+            // Given
+            final var reqDto = createReqDto();
+            final var policy = createPolicy();
+            given(appVersionPolicyRepository.findByPlatform(AppPlatform.ANDROID)).willReturn(Optional.of(policy));
+            given(appVersionPolicyRepository.save(policy)).willReturn(policy);
+
+            // When
+            final var result = upsertAppVersionPolicyService.execute(AppPlatform.ANDROID, reqDto);
+
+            // Then
+            assertThat(result.latestVersionName()).isEqualTo("1.4.0");
+            assertThat(result.latestVersionCode()).isEqualTo(18);
+            assertThat(result.minSupportedVersionName()).isEqualTo("1.3.0");
+            assertThat(result.minSupportedVersionCode()).isEqualTo(15);
+            assertThat(result.updateMessage()).isEqualTo("앱 업데이트가 필요합니다.");
+        }
+
+        @Test
+        @DisplayName("최소 지원 버전 코드가 최신 버전 코드보다 크면 ExpectedException을 던져야 한다")
+        void it_throws_expected_exception_when_min_version_code_is_greater_than_latest() {
+            // Given
+            final var reqDto = new UpsertAppVersionPolicyReqDto("1.4.0",
+                    18,
+                    "1.5.0",
+                    19,
+                    "https://play.google.com/store/apps/details?id=team.washer",
+                    "앱 업데이트가 필요합니다.");
+
+            // When & Then
+            assertThatThrownBy(() -> upsertAppVersionPolicyService.execute(AppPlatform.ANDROID, reqDto))
+                    .isInstanceOf(ExpectedException.class).hasMessage("최소 지원 버전 코드는 최신 버전 코드보다 클 수 없습니다")
+                    .hasFieldOrPropertyWithValue("statusCode", HttpStatus.BAD_REQUEST);
+            then(appVersionPolicyRepository).should(never()).save(any(AppVersionPolicy.class));
+        }
+    }
+}


### PR DESCRIPTION
## 개요

  앱 시작 시 현재 앱 버전의 업데이트 필요 여부를 조회할 수 있는 앱 버전 정책 API를 추가했습니다.
  관리자가 플랫폼별 버전 정책을 등록/수정하면 클라이언트는 `updateStatus` 기준으로 강제 업데이트, 선택 업데이트, 정상 사용 상태를 처리할 수 있습니다.

  ## 본문

  - `AppVersionPolicy` 엔티티와 `AppPlatform`, `AppUpdateStatus` enum을 추가했습니다.
  - `GET /api/v2/app-versions/status` 공개 API를 추가해 로그인 전에도 앱 버전 상태를 조회할 수 있도록 했습니다.
  - `PUT /api/v2/admin/app-versions/{platform}` API로 플랫폼별 최신 버전, 최소 지원 버전, 스토어 URL, 업데이트 메시지를 등록/수정할 수 있도록 했습니다.
  - `GET /api/v2/admin/app-versions` API로 등록된 앱 버전 정책 목록을 조회할 수 있도록 했습니다.
  - `DomainAuthorizationConfig`에 `/api/v2/app-versions/status`를 `permitAll`로 추가했습니다.
  - `QueryAppVersionStatusServiceTest`, `UpsertAppVersionPolicyServiceTest`로 업데이트 상태 계산과 정책 upsert 검증을 추가했습니다.

  테스트:
  - `.\gradlew test`