### PR TITLE
[global] `@EnableWebMvc` 제거로 CORS preflight 차단 수정

### DIFF
--- a/src/main/java/team/washer/server/v2/global/common/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/team/washer/server/v2/global/common/error/handler/GlobalExceptionHandler.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.NoHandlerFoundException;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
@@ -22,7 +21,6 @@ import team.themoment.sdk.response.CommonApiResponse;
 import team.washer.server.v2.global.thirdparty.discord.service.DiscordErrorNotificationService;
 
 @Slf4j
-@EnableWebMvc
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 


### PR DESCRIPTION
## 개요

관리자 화면에서 조회(GET)는 정상 동작하지만 신고 상태 변경(`PUT`)·패널티 해제(`DELETE`) 등 변경 요청만 `403 Invalid CORS request`로 거부되던 버그를 수정하였습니다. 원인은 `GlobalExceptionHandler`에 잘못 추가된 `@EnableWebMvc` 어노테이션이었습니다.

## 본문

### 증상

- 신고 데이터 조회 등 `GET` 요청은 정상 처리되었습니다.
- 신고 상태 변경(`PUT /api/v2/admin/malfunction-reports/{id}/status`), 세탁 패널티 해제(`DELETE /api/v2/admin/reservations/users/{userId}/penalty`) 등 변경 요청은 `403 Invalid CORS request` 응답을 받았습니다.

### 근본 원인

`GlobalExceptionHandler`(`@RestControllerAdvice`)에 `@EnableWebMvc`가 붙어 있었습니다. 이 어노테이션은 Spring Boot의 `WebMvcAutoConfiguration`을 비활성화시키며, 그 결과 요청 경로 매칭 인프라가 변경되어 `CorsConfig`의 `UrlBasedCorsConfigurationSource`가 `/**` 패턴을 매칭하지 못하고 `getCorsConfiguration()`이 `null`을 반환하게 되었습니다.

`DefaultCorsProcessor`는 CORS 설정이 `null`일 때 다음과 같이 분기합니다.

- preflight 요청(`OPTIONS`): 거부(`403 Invalid CORS request`)
- 비 preflight 요청: 통과

따라서 preflight가 없는 `GET`은 통과하고, preflight가 선행되는 `PUT`·`PATCH`·`DELETE` 변경 요청만 거부되는 현상이 발생하였습니다.

### 변경 사항

- `GlobalExceptionHandler`에서 `@EnableWebMvc` 어노테이션과 관련 `import`를 제거하였습니다.
- `CorsConfig` 자체는 정상이었으며 수정하지 않았습니다. `@EnableWebMvc` 제거로 `WebMvcAutoConfiguration`이 복원되어 CORS 경로 매칭이 정상화됩니다.

### 검증 방법

애플리케이션 재시작 후 프론트엔드에서 신고 상태 변경·패널티 해제 등 변경 요청이 정상 처리되는지 확인이 필요합니다.
