### PR TITLE
[appversion] Admin App Version 제거 및 버전 자동 갱신 적용

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/appversion/entity/AppVersionPolicy.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/entity/AppVersionPolicy.java
@@ -68,6 +68,24 @@ public class AppVersionPolicy extends BaseEntity {
     }
 
     /**
+     * 클라이언트가 보고한 버전이 기존 최신 버전보다 높으면 해당 버전을 최신 버전으로 갱신합니다.
+     *
+     * @param versionCode
+     *            클라이언트 앱 버전 코드
+     * @param versionName
+     *            클라이언트 앱 버전 이름
+     */
+    public void registerIfHigherVersion(final int versionCode, final String versionName) {
+        if (versionCode <= this.latestVersionCode) {
+            return;
+        }
+        this.latestVersionCode = versionCode;
+        if (versionName != null && !versionName.isBlank()) {
+            this.latestVersionName = versionName;
+        }
+    }
+
+    /**
      * 현재 앱 버전의 업데이트 상태를 계산합니다.
      *
      * @param versionCode

--- a/src/main/java/team/washer/server/v2/domain/appversion/entity/AppVersionPolicy.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/entity/AppVersionPolicy.java
@@ -79,10 +79,11 @@ public class AppVersionPolicy extends BaseEntity {
         if (versionCode <= this.latestVersionCode) {
             return;
         }
-        this.latestVersionCode = versionCode;
-        if (versionName != null && !versionName.isBlank()) {
-            this.latestVersionName = versionName;
+        if (versionName == null || versionName.isBlank()) {
+            return;
         }
+        this.latestVersionCode = versionCode;
+        this.latestVersionName = versionName;
     }
 
     /**

--- a/src/main/java/team/washer/server/v2/domain/appversion/service/impl/QueryAppVersionStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/service/impl/QueryAppVersionStatusServiceImpl.java
@@ -20,10 +20,11 @@ public class QueryAppVersionStatusServiceImpl implements QueryAppVersionStatusSe
     private final AppVersionPolicyRepository appVersionPolicyRepository;
 
     @Override
-    @Transactional(readOnly = true)
+    @Transactional
     public AppVersionStatusResDto execute(final AppVersionStatusReqDto reqDto) {
         final var policy = appVersionPolicyRepository.findByPlatform(reqDto.platform())
                 .orElseThrow(() -> new ExpectedException("앱 버전 정책을 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+        policy.registerIfHigherVersion(reqDto.versionCode(), reqDto.versionName());
         final var updateStatus = policy.resolveUpdateStatus(reqDto.versionCode());
 
         return mapToStatusResDto(policy, reqDto, updateStatus);

--- a/src/test/java/team/washer/server/v2/domain/appversion/service/QueryAppVersionStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/appversion/service/QueryAppVersionStatusServiceTest.java
@@ -118,8 +118,8 @@ class QueryAppVersionStatusServiceTest {
         }
 
         @Test
-        @DisplayName("클라이언트 버전이 기존 최신 버전보다 높지만 버전 이름이 없으면 버전 코드만 갱신해야 한다")
-        void it_registers_only_version_code_when_version_name_is_missing() {
+        @DisplayName("클라이언트 버전이 기존 최신 버전보다 높지만 버전 이름이 없으면 최신 버전을 갱신하지 않아야 한다")
+        void it_keeps_latest_version_when_version_name_is_missing() {
             // Given
             final var policy = createPolicy();
             final var reqDto = new AppVersionStatusReqDto(AppPlatform.ANDROID, 20, null);
@@ -129,7 +129,7 @@ class QueryAppVersionStatusServiceTest {
             queryAppVersionStatusService.execute(reqDto);
 
             // Then
-            assertThat(policy.getLatestVersionCode()).isEqualTo(20);
+            assertThat(policy.getLatestVersionCode()).isEqualTo(18);
             assertThat(policy.getLatestVersionName()).isEqualTo("1.4.0");
         }
 

--- a/src/test/java/team/washer/server/v2/domain/appversion/service/QueryAppVersionStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/appversion/service/QueryAppVersionStatusServiceTest.java
@@ -97,6 +97,59 @@ class QueryAppVersionStatusServiceTest {
         }
 
         @Test
+        @DisplayName("클라이언트 버전이 기존 최신 버전보다 높으면 최신 버전을 갱신하고 지원 상태를 반환해야 한다")
+        void it_registers_new_latest_version_when_client_version_is_higher() {
+            // Given
+            final var policy = createPolicy();
+            final var reqDto = new AppVersionStatusReqDto(AppPlatform.ANDROID, 20, "1.5.0");
+            given(appVersionPolicyRepository.findByPlatform(AppPlatform.ANDROID)).willReturn(Optional.of(policy));
+
+            // When
+            final var result = queryAppVersionStatusService.execute(reqDto);
+
+            // Then
+            assertThat(policy.getLatestVersionCode()).isEqualTo(20);
+            assertThat(policy.getLatestVersionName()).isEqualTo("1.5.0");
+            assertThat(result.latestVersionCode()).isEqualTo(20);
+            assertThat(result.latestVersionName()).isEqualTo("1.5.0");
+            assertThat(result.updateStatus()).isEqualTo(AppUpdateStatus.SUPPORTED);
+            assertThat(result.updateRequired()).isFalse();
+            assertThat(result.updateAvailable()).isFalse();
+        }
+
+        @Test
+        @DisplayName("클라이언트 버전이 기존 최신 버전보다 높지만 버전 이름이 없으면 버전 코드만 갱신해야 한다")
+        void it_registers_only_version_code_when_version_name_is_missing() {
+            // Given
+            final var policy = createPolicy();
+            final var reqDto = new AppVersionStatusReqDto(AppPlatform.ANDROID, 20, null);
+            given(appVersionPolicyRepository.findByPlatform(AppPlatform.ANDROID)).willReturn(Optional.of(policy));
+
+            // When
+            queryAppVersionStatusService.execute(reqDto);
+
+            // Then
+            assertThat(policy.getLatestVersionCode()).isEqualTo(20);
+            assertThat(policy.getLatestVersionName()).isEqualTo("1.4.0");
+        }
+
+        @Test
+        @DisplayName("클라이언트 버전이 기존 최신 버전과 같으면 최신 버전을 갱신하지 않아야 한다")
+        void it_keeps_latest_version_when_client_version_is_equal() {
+            // Given
+            final var policy = createPolicy();
+            final var reqDto = new AppVersionStatusReqDto(AppPlatform.ANDROID, 18, "1.4.0");
+            given(appVersionPolicyRepository.findByPlatform(AppPlatform.ANDROID)).willReturn(Optional.of(policy));
+
+            // When
+            final var result = queryAppVersionStatusService.execute(reqDto);
+
+            // Then
+            assertThat(policy.getLatestVersionCode()).isEqualTo(18);
+            assertThat(result.updateStatus()).isEqualTo(AppUpdateStatus.SUPPORTED);
+        }
+
+        @Test
         @DisplayName("플랫폼 정책이 없으면 ExpectedException을 던져야 한다")
         void it_throws_expected_exception_when_policy_not_found() {
             // Given


### PR DESCRIPTION
## 개요

관리자용 앱 버전 정책 등록/수정 API를 제거하고, 클라이언트가 보고한 버전 정보를 기반으로 최신 버전을 자동 갱신하도록 변경하였습니다. 아울러 앱 버전 조회 API를 토큰 없이 접근할 수 있도록 허용하였습니다.

## 본문

- `AdminAppVersionController`, `UpsertAppVersionPolicyReqDto`, 관리자용 `AppVersionPolicyResDto`, `QueryAppVersionPoliciesService`, `UpsertAppVersionPolicyService` 및 각 구현체와 관련 테스트(`UpsertAppVersionPolicyServiceTest`)를 삭제하였습니다.
- `AppVersionPolicy` 엔티티에 `registerIfHigherVersion` 메서드를 추가하였습니다. 클라이언트가 보고한 버전 코드가 기존 최신 버전 코드보다 높은 경우에만 최신 버전 코드와 버전 이름을 갱신합니다.
- `QueryAppVersionStatusServiceImpl#execute`에서 정책 조회 후 `registerIfHigherVersion`을 호출하여 최신 버전을 동적으로 갱신하도록 변경하였습니다. 엔티티 갱신을 반영하기 위해 트랜잭션을 `@Transactional(readOnly = true)`에서 `@Transactional`로 변경하였습니다.
- `QueryAppVersionStatusServiceTest`에 버전 상승, 버전 동일, 버전 이름 누락 시나리오에 대한 테스트 케이스를 추가하였습니다.
- 이전 커밋에서 앱 버전 상태 조회 API에 대한 토큰 없는 접근을 허용하도록 수정하였습니다.

관리자가 별도로 버전 정책을 등록/수정하지 않고, 클라이언트 앱이 보고하는 버전 정보로 최신 버전이 자동으로 추적되도록 정책 관리 방식을 전환하는 작업입니다.
