### PR TITLE
[appversion] 앱 버전 정책 관리 Admin API 복구

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/appversion/controller/AdminAppVersionController.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/controller/AdminAppVersionController.java
@@ -1,0 +1,43 @@
+package team.washer.server.v2.domain.appversion.controller;
+
+import java.util.List;
+
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.appversion.dto.request.UpsertAppVersionPolicyReqDto;
+import team.washer.server.v2.domain.appversion.dto.response.AppVersionPolicyResDto;
+import team.washer.server.v2.domain.appversion.enums.AppPlatform;
+import team.washer.server.v2.domain.appversion.service.QueryAppVersionPoliciesService;
+import team.washer.server.v2.domain.appversion.service.UpsertAppVersionPolicyService;
+
+@RestController
+@RequestMapping("/api/v2/admin/app-versions")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "Admin App Version", description = "앱 버전 정책 관리 API")
+public class AdminAppVersionController {
+
+    private final QueryAppVersionPoliciesService queryAppVersionPoliciesService;
+    private final UpsertAppVersionPolicyService upsertAppVersionPolicyService;
+
+    @GetMapping
+    @Operation(summary = "앱 버전 정책 목록 조회", description = "플랫폼별 앱 버전 정책 목록을 조회합니다.")
+    public List<AppVersionPolicyResDto> queryAppVersionPolicies() {
+        return queryAppVersionPoliciesService.execute();
+    }
+
+    @PutMapping("/{platform}")
+    @Operation(summary = "앱 버전 정책 등록/수정", description = "플랫폼별 최신 버전, 최소 지원 버전, 스토어 URL, 업데이트 메시지를 등록하거나 수정합니다.")
+    public AppVersionPolicyResDto upsertAppVersionPolicy(
+            @Parameter(description = "앱 플랫폼") @PathVariable @NotNull final AppPlatform platform,
+            @RequestBody @Valid final UpsertAppVersionPolicyReqDto reqDto) {
+        return upsertAppVersionPolicyService.execute(platform, reqDto);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/dto/request/UpsertAppVersionPolicyReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/dto/request/UpsertAppVersionPolicyReqDto.java
@@ -1,0 +1,17 @@
+package team.washer.server.v2.domain.appversion.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "앱 버전 정책 등록/수정 요청 DTO")
+public record UpsertAppVersionPolicyReqDto(
+        @Schema(description = "최신 앱 버전 이름", example = "1.4.0") @NotBlank(message = "최신 버전 이름은 필수입니다.") @Size(max = 50, message = "최신 버전 이름은 50자를 초과할 수 없습니다.") String latestVersionName,
+        @Schema(description = "최신 앱 버전 코드", example = "18") @NotNull(message = "최신 버전 코드는 필수입니다.") @PositiveOrZero(message = "최신 버전 코드는 0 이상이어야 합니다.") Integer latestVersionCode,
+        @Schema(description = "최소 지원 앱 버전 이름", example = "1.3.0") @NotBlank(message = "최소 지원 버전 이름은 필수입니다.") @Size(max = 50, message = "최소 지원 버전 이름은 50자를 초과할 수 없습니다.") String minSupportedVersionName,
+        @Schema(description = "최소 지원 앱 버전 코드", example = "15") @NotNull(message = "최소 지원 버전 코드는 필수입니다.") @PositiveOrZero(message = "최소 지원 버전 코드는 0 이상이어야 합니다.") Integer minSupportedVersionCode,
+        @Schema(description = "스토어 URL", example = "https://play.google.com/store/apps/details?id=team.washer") @NotBlank(message = "스토어 URL은 필수입니다.") @Size(max = 500, message = "스토어 URL은 500자를 초과할 수 없습니다.") String storeUrl,
+        @Schema(description = "업데이트 안내 메시지", example = "앱 업데이트가 필요합니다.") @NotBlank(message = "업데이트 안내 메시지는 필수입니다.") @Size(max = 255, message = "업데이트 안내 메시지는 255자를 초과할 수 없습니다.") String updateMessage) {
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/dto/response/AppVersionPolicyResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/dto/response/AppVersionPolicyResDto.java
@@ -1,0 +1,14 @@
+package team.washer.server.v2.domain.appversion.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import team.washer.server.v2.domain.appversion.enums.AppPlatform;
+
+@Schema(description = "앱 버전 정책 응답 DTO")
+public record AppVersionPolicyResDto(@Schema(description = "앱 플랫폼", example = "ANDROID") AppPlatform platform,
+        @Schema(description = "최신 앱 버전 이름", example = "1.4.0") String latestVersionName,
+        @Schema(description = "최신 앱 버전 코드", example = "18") Integer latestVersionCode,
+        @Schema(description = "최소 지원 앱 버전 이름", example = "1.3.0") String minSupportedVersionName,
+        @Schema(description = "최소 지원 앱 버전 코드", example = "15") Integer minSupportedVersionCode,
+        @Schema(description = "스토어 URL", example = "https://play.google.com/store/apps/details?id=team.washer") String storeUrl,
+        @Schema(description = "업데이트 안내 메시지", example = "앱 업데이트가 필요합니다.") String updateMessage) {
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/service/QueryAppVersionPoliciesService.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/service/QueryAppVersionPoliciesService.java
@@ -1,0 +1,9 @@
+package team.washer.server.v2.domain.appversion.service;
+
+import java.util.List;
+
+import team.washer.server.v2.domain.appversion.dto.response.AppVersionPolicyResDto;
+
+public interface QueryAppVersionPoliciesService {
+    List<AppVersionPolicyResDto> execute();
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/service/UpsertAppVersionPolicyService.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/service/UpsertAppVersionPolicyService.java
@@ -1,0 +1,9 @@
+package team.washer.server.v2.domain.appversion.service;
+
+import team.washer.server.v2.domain.appversion.dto.request.UpsertAppVersionPolicyReqDto;
+import team.washer.server.v2.domain.appversion.dto.response.AppVersionPolicyResDto;
+import team.washer.server.v2.domain.appversion.enums.AppPlatform;
+
+public interface UpsertAppVersionPolicyService {
+    AppVersionPolicyResDto execute(AppPlatform platform, UpsertAppVersionPolicyReqDto reqDto);
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/service/impl/QueryAppVersionPoliciesServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/service/impl/QueryAppVersionPoliciesServiceImpl.java
@@ -1,0 +1,37 @@
+package team.washer.server.v2.domain.appversion.service.impl;
+
+import java.util.List;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.appversion.dto.response.AppVersionPolicyResDto;
+import team.washer.server.v2.domain.appversion.entity.AppVersionPolicy;
+import team.washer.server.v2.domain.appversion.repository.AppVersionPolicyRepository;
+import team.washer.server.v2.domain.appversion.service.QueryAppVersionPoliciesService;
+
+@Service
+@RequiredArgsConstructor
+public class QueryAppVersionPoliciesServiceImpl implements QueryAppVersionPoliciesService {
+
+    private final AppVersionPolicyRepository appVersionPolicyRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<AppVersionPolicyResDto> execute() {
+        return appVersionPolicyRepository.findAll(Sort.by(Sort.Direction.ASC, "platform")).stream()
+                .map(this::mapToResDto).toList();
+    }
+
+    private AppVersionPolicyResDto mapToResDto(final AppVersionPolicy policy) {
+        return new AppVersionPolicyResDto(policy.getPlatform(),
+                policy.getLatestVersionName(),
+                policy.getLatestVersionCode(),
+                policy.getMinSupportedVersionName(),
+                policy.getMinSupportedVersionCode(),
+                policy.getStoreUrl(),
+                policy.getUpdateMessage());
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/appversion/service/impl/UpsertAppVersionPolicyServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/appversion/service/impl/UpsertAppVersionPolicyServiceImpl.java
@@ -1,0 +1,62 @@
+package team.washer.server.v2.domain.appversion.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.appversion.dto.request.UpsertAppVersionPolicyReqDto;
+import team.washer.server.v2.domain.appversion.dto.response.AppVersionPolicyResDto;
+import team.washer.server.v2.domain.appversion.entity.AppVersionPolicy;
+import team.washer.server.v2.domain.appversion.enums.AppPlatform;
+import team.washer.server.v2.domain.appversion.repository.AppVersionPolicyRepository;
+import team.washer.server.v2.domain.appversion.service.UpsertAppVersionPolicyService;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UpsertAppVersionPolicyServiceImpl implements UpsertAppVersionPolicyService {
+
+    private final AppVersionPolicyRepository appVersionPolicyRepository;
+
+    @Override
+    @Transactional
+    public AppVersionPolicyResDto execute(final AppPlatform platform, final UpsertAppVersionPolicyReqDto reqDto) {
+        validateVersionCodeRange(reqDto);
+
+        final var policy = appVersionPolicyRepository.findByPlatform(platform)
+                .orElseGet(() -> AppVersionPolicy.builder().platform(platform).build());
+
+        policy.updatePolicy(reqDto.latestVersionName(),
+                reqDto.latestVersionCode(),
+                reqDto.minSupportedVersionName(),
+                reqDto.minSupportedVersionCode(),
+                reqDto.storeUrl(),
+                reqDto.updateMessage());
+        final var savedPolicy = appVersionPolicyRepository.save(policy);
+        log.info("App version policy upserted platform={} latestVersionCode={} minSupportedVersionCode={}",
+                platform,
+                reqDto.latestVersionCode(),
+                reqDto.minSupportedVersionCode());
+
+        return mapToResDto(savedPolicy);
+    }
+
+    private void validateVersionCodeRange(final UpsertAppVersionPolicyReqDto reqDto) {
+        if (reqDto.minSupportedVersionCode() > reqDto.latestVersionCode()) {
+            throw new ExpectedException("최소 지원 버전 코드는 최신 버전 코드보다 클 수 없습니다", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private AppVersionPolicyResDto mapToResDto(final AppVersionPolicy policy) {
+        return new AppVersionPolicyResDto(policy.getPlatform(),
+                policy.getLatestVersionName(),
+                policy.getLatestVersionCode(),
+                policy.getMinSupportedVersionName(),
+                policy.getMinSupportedVersionCode(),
+                policy.getStoreUrl(),
+                policy.getUpdateMessage());
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/appversion/service/UpsertAppVersionPolicyServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/appversion/service/UpsertAppVersionPolicyServiceTest.java
@@ -1,0 +1,110 @@
+package team.washer.server.v2.domain.appversion.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.appversion.dto.request.UpsertAppVersionPolicyReqDto;
+import team.washer.server.v2.domain.appversion.entity.AppVersionPolicy;
+import team.washer.server.v2.domain.appversion.enums.AppPlatform;
+import team.washer.server.v2.domain.appversion.repository.AppVersionPolicyRepository;
+import team.washer.server.v2.domain.appversion.service.impl.UpsertAppVersionPolicyServiceImpl;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpsertAppVersionPolicyServiceImpl 클래스는")
+class UpsertAppVersionPolicyServiceTest {
+
+    @InjectMocks
+    private UpsertAppVersionPolicyServiceImpl upsertAppVersionPolicyService;
+
+    @Mock
+    private AppVersionPolicyRepository appVersionPolicyRepository;
+
+    private UpsertAppVersionPolicyReqDto createReqDto() {
+        return new UpsertAppVersionPolicyReqDto("1.4.0",
+                18,
+                "1.3.0",
+                15,
+                "https://play.google.com/store/apps/details?id=team.washer",
+                "앱 업데이트가 필요합니다.");
+    }
+
+    private AppVersionPolicy createPolicy() {
+        return AppVersionPolicy.builder().platform(AppPlatform.ANDROID).latestVersionName("1.3.0").latestVersionCode(15)
+                .minSupportedVersionName("1.2.0").minSupportedVersionCode(12)
+                .storeUrl("https://play.google.com/store/apps/details?id=team.washer").updateMessage("이전 메시지").build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Test
+        @DisplayName("기존 정책이 없으면 새 정책을 저장해야 한다")
+        void it_creates_policy_when_not_exists() {
+            // Given
+            final var reqDto = createReqDto();
+            given(appVersionPolicyRepository.findByPlatform(AppPlatform.ANDROID)).willReturn(Optional.empty());
+            given(appVersionPolicyRepository.save(any(AppVersionPolicy.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // When
+            final var result = upsertAppVersionPolicyService.execute(AppPlatform.ANDROID, reqDto);
+
+            // Then
+            assertThat(result.platform()).isEqualTo(AppPlatform.ANDROID);
+            assertThat(result.latestVersionCode()).isEqualTo(18);
+            assertThat(result.minSupportedVersionCode()).isEqualTo(15);
+            then(appVersionPolicyRepository).should(times(1)).save(any(AppVersionPolicy.class));
+        }
+
+        @Test
+        @DisplayName("기존 정책이 있으면 정책 값을 갱신해야 한다")
+        void it_updates_policy_when_exists() {
+            // Given
+            final var reqDto = createReqDto();
+            final var policy = createPolicy();
+            given(appVersionPolicyRepository.findByPlatform(AppPlatform.ANDROID)).willReturn(Optional.of(policy));
+            given(appVersionPolicyRepository.save(policy)).willReturn(policy);
+
+            // When
+            final var result = upsertAppVersionPolicyService.execute(AppPlatform.ANDROID, reqDto);
+
+            // Then
+            assertThat(result.latestVersionName()).isEqualTo("1.4.0");
+            assertThat(result.latestVersionCode()).isEqualTo(18);
+            assertThat(result.minSupportedVersionName()).isEqualTo("1.3.0");
+            assertThat(result.minSupportedVersionCode()).isEqualTo(15);
+            assertThat(result.updateMessage()).isEqualTo("앱 업데이트가 필요합니다.");
+        }
+
+        @Test
+        @DisplayName("최소 지원 버전 코드가 최신 버전 코드보다 크면 ExpectedException을 던져야 한다")
+        void it_throws_expected_exception_when_min_version_code_is_greater_than_latest() {
+            // Given
+            final var reqDto = new UpsertAppVersionPolicyReqDto("1.4.0",
+                    18,
+                    "1.5.0",
+                    19,
+                    "https://play.google.com/store/apps/details?id=team.washer",
+                    "앱 업데이트가 필요합니다.");
+
+            // When & Then
+            assertThatThrownBy(() -> upsertAppVersionPolicyService.execute(AppPlatform.ANDROID, reqDto))
+                    .isInstanceOf(ExpectedException.class).hasMessage("최소 지원 버전 코드는 최신 버전 코드보다 클 수 없습니다")
+                    .hasFieldOrPropertyWithValue("statusCode", HttpStatus.BAD_REQUEST);
+            then(appVersionPolicyRepository).should(never()).save(any(AppVersionPolicy.class));
+        }
+    }
+}


### PR DESCRIPTION
## 개요

`/api/v2/app-versions/status` 호출 시 항상 `앱 버전 정책을 찾을 수 없습니다` (404) 가 발생하는 문제를 분석한 결과, 정책 데이터를 생성할 수 있는 Admin API가 과거 커밋에서 삭제되어 있었습니다. 삭제되었던 `AdminAppVersionController`와 관련 서비스를 git 히스토리 기반으로 복구하였습니다.

## 본문

### 원인

- `AppVersionPolicyRepository`는 `findByPlatform` 조회만 제공하며, `app_version_policies` 테이블에 row를 생성하는 경로는 운영 코드 어디에도 존재하지 않았습니다.
- `git log` 추적 결과 `delete(appversion): Admin App Version 기능 제거` 커밋에서 정책 생성/조회용 Admin API(`AdminAppVersionController`, `UpsertAppVersionPolicyService`, `QueryAppVersionPoliciesService` 등)가 모두 삭제되었고, 이를 대체할 시드 데이터나 마이그레이션도 추가되지 않았습니다.
- 결과적으로 DB에 해당 플랫폼(`ANDROID`/`IOS`) 정책 row가 없어 `QueryAppVersionStatusServiceImpl`이 항상 `ExpectedException(404)`를 던졌습니다.

### 변경 사항

- `AdminAppVersionController` 복구
  - `GET /api/v2/admin/app-versions`: 플랫폼별 정책 목록 조회
  - `PUT /api/v2/admin/app-versions/{platform}`: 정책 등록/수정 (upsert)
- `QueryAppVersionPoliciesService`/`Impl`, `UpsertAppVersionPolicyService`/`Impl` 복구
- 요청/응답 DTO 복구: `UpsertAppVersionPolicyReqDto`, `AppVersionPolicyResDto`
- `UpsertAppVersionPolicyServiceTest` 복구 (정책 신규 생성, 갱신, 버전 코드 역전 시 예외 케이스 검증)

### 보안 강화

원본 코드는 `DomainAuthorizationConfig`에서 `/api/v2/admin/app-versions/**`를 `permitAll()`로 인증 없이 열어두었습니다. 이번 복구에서는 해당 `permitAll` 설정을 추가하지 않았으며, 기존 `/api/v2/admin/**` 규칙(`hasAnyAuthority("DORMITORY_COUNCIL", "ADMIN")`)에 자연스럽게 포함되도록 하여 관리자 권한이 있는 사용자만 정책을 생성/수정할 수 있도록 하였습니다.

### 검증

- `./gradlew compileJava compileTestJava` 빌드 성공 확인
- `UpsertAppVersionPolicyServiceTest`, `QueryAppVersionStatusServiceTest` 테스트 통과 확인
