### PR TITLE
[reservation] SmartThings 완료 판정 보강

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
@@ -34,6 +34,8 @@ import team.washer.server.v2.global.util.DateTimeUtil;
 @Slf4j
 public class ReservationLifecycleProcessor {
 
+    private static final long COMPLETION_EARLY_TOLERANCE_MINUTES = 2;
+
     private final ReservationRepository reservationRepository;
     private final MachineRepository machineRepository;
     private final MachineStateDetectionSupport machineStateDetectionSupport;
@@ -96,10 +98,12 @@ public class ReservationLifecycleProcessor {
         var completionTime = machineStateDetectionSupport.isCompleted(status, isWasher);
 
         if (completionTime.isPresent()) {
-            if (isStaleCompletion(reservation, completionTime.get())) {
-                log.debug("Stale completion ignored reservationId={} startTime={} completionTime={}",
+            if (shouldDeferCompletion(reservation, status, isWasher, completionTime.get())) {
+                log.debug(
+                        "completion deferred reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
                         reservation.getId(),
                         reservation.getStartTime(),
+                        reservation.getExpectedCompletionTime(),
                         completionTime.get());
                 return;
             }
@@ -177,8 +181,57 @@ public class ReservationLifecycleProcessor {
         }
     }
 
-    private boolean isStaleCompletion(Reservation reservation, LocalDateTime completionTime) {
+    private boolean shouldDeferCompletion(Reservation reservation,
+            SmartThingsDeviceStatusResDto status,
+            boolean isWasher,
+            LocalDateTime completionTime) {
+        return isStaleCompletion(reservation, status, isWasher, completionTime)
+                || isTooEarlyCompletion(reservation, completionTime);
+    }
+
+    private boolean isStaleCompletion(Reservation reservation,
+            SmartThingsDeviceStatusResDto status,
+            boolean isWasher,
+            LocalDateTime completionTime) {
         var startTime = reservation.getStartTime();
-        return startTime != null && completionTime.isBefore(startTime);
+        if (startTime == null) {
+            return false;
+        }
+        if (completionTime.isBefore(startTime)) {
+            return true;
+        }
+        return isTimestampBeforeStart(getOperatingStateTimestamp(status, isWasher), startTime)
+                || isTimestampBeforeStart(getJobStateTimestamp(status, isWasher), startTime);
+    }
+
+    private boolean isTooEarlyCompletion(Reservation reservation, LocalDateTime completionTime) {
+        var expectedCompletionTime = reservation.getExpectedCompletionTime();
+        if (expectedCompletionTime == null) {
+            return false;
+        }
+        var earliestCompletionTime = expectedCompletionTime.minusMinutes(COMPLETION_EARLY_TOLERANCE_MINUTES);
+        return LocalDateTime.now().isBefore(earliestCompletionTime) && completionTime.isBefore(earliestCompletionTime);
+    }
+
+    private boolean isTimestampBeforeStart(String timestamp, LocalDateTime startTime) {
+        if (timestamp == null || timestamp.isBlank()) {
+            return false;
+        }
+        var updatedAt = DateTimeUtil.parseAndConvertToKoreaTime(timestamp);
+        return updatedAt != null && updatedAt.isBefore(startTime);
+    }
+
+    private String getOperatingStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        if (status == null) {
+            return null;
+        }
+        return isWasher ? status.getWasherOperatingStateTimestamp() : status.getDryerOperatingStateTimestamp();
+    }
+
+    private String getJobStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        if (status == null) {
+            return null;
+        }
+        return isWasher ? status.getWasherJobStateTimestamp() : status.getDryerJobStateTimestamp();
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
@@ -2,6 +2,7 @@ package team.washer.server.v2.domain.reservation.service.impl;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 import org.springframework.stereotype.Component;
@@ -35,6 +36,7 @@ import team.washer.server.v2.global.util.DateTimeUtil;
 public class ReservationLifecycleProcessor {
 
     private static final long COMPLETION_EARLY_TOLERANCE_MINUTES = 2;
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
     private final ReservationRepository reservationRepository;
     private final MachineRepository machineRepository;
@@ -210,7 +212,8 @@ public class ReservationLifecycleProcessor {
             return false;
         }
         var earliestCompletionTime = expectedCompletionTime.minusMinutes(COMPLETION_EARLY_TOLERANCE_MINUTES);
-        return LocalDateTime.now().isBefore(earliestCompletionTime) && completionTime.isBefore(earliestCompletionTime);
+        return LocalDateTime.now(KOREA_ZONE).isBefore(earliestCompletionTime)
+                && completionTime.isBefore(earliestCompletionTime);
     }
 
     private boolean isTimestampBeforeStart(String timestamp, LocalDateTime startTime) {

--- a/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsDeviceStatusResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsDeviceStatusResDto.java
@@ -68,6 +68,16 @@ public record SmartThingsDeviceStatusResDto(
         return ms != null ? ms.value() : null;
     }
 
+    /** 세탁기 machineState 갱신 시각 반환 */
+    public String getWasherOperatingStateTimestamp() {
+        var main = getMainComponent();
+        if (main == null || main.washerOperatingState() == null) {
+            return null;
+        }
+        var ms = main.washerOperatingState().machineState();
+        return ms != null ? ms.timestamp() : null;
+    }
+
     /** 건조기 machineState 값 반환: "run" | "pause" | "stop" */
     public String getDryerOperatingState() {
         var main = getMainComponent();
@@ -76,6 +86,16 @@ public record SmartThingsDeviceStatusResDto(
         }
         var ms = main.dryerOperatingState().machineState();
         return ms != null ? ms.value() : null;
+    }
+
+    /** 건조기 machineState 갱신 시각 반환 */
+    public String getDryerOperatingStateTimestamp() {
+        var main = getMainComponent();
+        if (main == null || main.dryerOperatingState() == null) {
+            return null;
+        }
+        var ms = main.dryerOperatingState().machineState();
+        return ms != null ? ms.timestamp() : null;
     }
 
     /** washerJobState 값 반환: "wash" | "rinse" | "spin" | "finish" | ... */
@@ -88,6 +108,16 @@ public record SmartThingsDeviceStatusResDto(
         return js != null ? js.value() : null;
     }
 
+    /** washerJobState 갱신 시각 반환 */
+    public String getWasherJobStateTimestamp() {
+        var main = getMainComponent();
+        if (main == null || main.washerOperatingState() == null) {
+            return null;
+        }
+        var js = main.washerOperatingState().washerJobState();
+        return js != null ? js.timestamp() : null;
+    }
+
     /** dryerJobState 값 반환: "drying" | "cooling" | "finished" | ... */
     public String getDryerJobState() {
         var main = getMainComponent();
@@ -96,6 +126,16 @@ public record SmartThingsDeviceStatusResDto(
         }
         var js = main.dryerOperatingState().dryerJobState();
         return js != null ? js.value() : null;
+    }
+
+    /** dryerJobState 갱신 시각 반환 */
+    public String getDryerJobStateTimestamp() {
+        var main = getMainComponent();
+        if (main == null || main.dryerOperatingState() == null) {
+            return null;
+        }
+        var js = main.dryerOperatingState().dryerJobState();
+        return js != null ? js.timestamp() : null;
     }
 
     /** 세탁기 완료 예정 시간 반환 */

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
@@ -36,6 +36,7 @@ import team.washer.server.v2.global.common.constants.ReservationConstants;
 class ReservationLifecycleProcessorTest {
 
     private static final Long RESERVATION_ID = 1L;
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
     @InjectMocks
     private ReservationLifecycleProcessor reservationLifecycleProcessor;
@@ -80,8 +81,7 @@ class ReservationLifecycleProcessorTest {
     }
 
     private String isoUtc(LocalDateTime koreaTime) {
-        return koreaTime.atZone(ZoneId.of("Asia/Seoul")).withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime()
-                .toString() + "Z";
+        return koreaTime.atZone(KOREA_ZONE).withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime().toString() + "Z";
     }
 
     @Nested
@@ -200,7 +200,7 @@ class ReservationLifecycleProcessorTest {
         @DisplayName("완료 신호의 갱신 시각이 예약 시작 전이면 이전 상태로 보고 완료 처리하지 않는다")
         void shouldNotCompleteReservation_WhenCompletionSignalTimestampBeforeReservationStartTime() {
             // Given
-            var startTime = LocalDateTime.now();
+            var startTime = LocalDateTime.now(KOREA_ZONE);
             var staleTimestamp = isoUtc(startTime.minusMinutes(1));
             var deviceStatus = buildWasherStatusWithTimestamp(staleTimestamp, staleTimestamp);
             givenRunningReservation();
@@ -225,10 +225,11 @@ class ReservationLifecycleProcessorTest {
         void shouldNotCompleteReservation_WhenCompletionDetectedTooEarly() {
             // Given
             var deviceStatus = buildDeviceStatus(null);
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
             givenRunningReservation();
-            when(reservation.getExpectedCompletionTime()).thenReturn(LocalDateTime.now().plusMinutes(10));
+            when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.plusMinutes(10));
             when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.of(LocalDateTime.now()));
+                    .thenReturn(Optional.of(nowKst));
 
             // When
             reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Map;
 import java.util.Optional;
 
@@ -65,6 +66,22 @@ class ReservationLifecycleProcessorTest {
         var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(null, null, completionTimeAttr);
         var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null, null);
         return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
+    }
+
+    private SmartThingsDeviceStatusResDto buildWasherStatusWithTimestamp(String machineStateTimestamp,
+            String jobStateTimestamp) {
+        var machineStateAttr = new SmartThingsDeviceStatusResDto.AttributeState("stop", machineStateTimestamp, null);
+        var jobStateAttr = new SmartThingsDeviceStatusResDto.AttributeState("finish", jobStateTimestamp, null);
+        var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(machineStateAttr,
+                jobStateAttr,
+                null);
+        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null, null);
+        return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
+    }
+
+    private String isoUtc(LocalDateTime koreaTime) {
+        return koreaTime.atZone(ZoneId.of("Asia/Seoul")).withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime()
+                .toString() + "Z";
     }
 
     @Nested
@@ -167,6 +184,51 @@ class ReservationLifecycleProcessorTest {
             when(reservation.getStartTime()).thenReturn(LocalDateTime.now());
             when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(Optional.of(staleCompletionTime));
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, never()).complete();
+            verify(machine, never()).markAsAvailable();
+            verify(reservationRepository, never()).save(reservation);
+            verify(machineRepository, never()).save(machine);
+            verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
+        }
+
+        @Test
+        @DisplayName("완료 신호의 갱신 시각이 예약 시작 전이면 이전 상태로 보고 완료 처리하지 않는다")
+        void shouldNotCompleteReservation_WhenCompletionSignalTimestampBeforeReservationStartTime() {
+            // Given
+            var startTime = LocalDateTime.now();
+            var staleTimestamp = isoUtc(startTime.minusMinutes(1));
+            var deviceStatus = buildWasherStatusWithTimestamp(staleTimestamp, staleTimestamp);
+            givenRunningReservation();
+            when(machine.isWasher()).thenReturn(true);
+            when(reservation.getStartTime()).thenReturn(startTime);
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(Optional.of(startTime.plusMinutes(1)));
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, never()).complete();
+            verify(machine, never()).markAsAvailable();
+            verify(reservationRepository, never()).save(reservation);
+            verify(machineRepository, never()).save(machine);
+            verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
+        }
+
+        @Test
+        @DisplayName("예상 완료 시간이 충분히 남아 있으면 완료 신호를 보류하고 예약을 유지한다")
+        void shouldNotCompleteReservation_WhenCompletionDetectedTooEarly() {
+            // Given
+            var deviceStatus = buildDeviceStatus(null);
+            givenRunningReservation();
+            when(reservation.getExpectedCompletionTime()).thenReturn(LocalDateTime.now().plusMinutes(10));
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(Optional.of(LocalDateTime.now()));
 
             // When
             reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);


### PR DESCRIPTION
## 개요

  `SmartThings`의 이전 상태값 또는 조기 완료 신호로 인해 세탁 예약이 실제 종료 전 `COMPLETED` 처리되는 문제를 방어했습니다.

  ## 본문

  `ReservationLifecycleProcessor`에서 완료 처리 전 보류 조건을 추가했습니다. 완료 신호의 `machineState`, `jobState` 갱신 시각이 현재 예약 시작 전이면 이전 상태로 보고
  완료 처리하지 않도록 했습니다.

  또한 `expectedCompletionTime`이 충분히 남아 있는 상태에서 완료 신호가 들어오면 예약을 유지하도록 완화했습니다. 이를 통해 `RUNNING` 예약이 조기 완료되어
  `MachineAvailability.AVAILABLE`로 풀리고 다른 사용자가 예약 가능한 상태가 되는 상황을 줄였습니다.

  `SmartThingsDeviceStatusResDto`에는 `machineState`, `jobState`의 `timestamp` 접근자를 추가했습니다.

  검증:
  - `.\gradlew test`
  - 전체 326개 테스트 통과