### PR TITLE
[reservation] 완료 알림 누락 방어

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
@@ -158,7 +158,7 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
     }
 
     private Long calculateRemainingMinutes(LocalDateTime completionTime) {
-        var now = LocalDateTime.now();
+        var now = DateTimeUtil.nowInKorea();
         var duration = Duration.between(now, completionTime);
         return Math.max(0, duration.toMinutes());
     }

--- a/src/main/java/team/washer/server/v2/domain/notification/support/FcmNotificationSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/support/FcmNotificationSupport.java
@@ -37,7 +37,7 @@ public class FcmNotificationSupport {
     public void send(final User user, final String title, final String body) {
         final String token = user.getFcmToken();
         if (token == null || token.isBlank()) {
-            log.debug("FCM token not found skipping notification userId={}", user.getId());
+            log.info("FCM token not found skipping notification userId={}", user.getId());
             return;
         }
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/entity/Reservation.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/entity/Reservation.java
@@ -14,6 +14,7 @@ import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.global.common.entity.BaseEntity;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @Entity
 @Table(name = "reservations", indexes = {@Index(name = "idx_status", columnList = "status"),
@@ -76,7 +77,7 @@ public class Reservation extends BaseEntity {
      * 기기 일시정지 시각을 기록합니다.
      */
     public void markAsPaused() {
-        this.pausedAt = LocalDateTime.now();
+        this.pausedAt = DateTimeUtil.nowInKorea();
     }
 
     /**
@@ -107,7 +108,7 @@ public class Reservation extends BaseEntity {
      * @return 타임아웃 초과 여부
      */
     public boolean isExpired() {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = DateTimeUtil.nowInKorea();
 
         return switch (this.status) {
             case RESERVED ->
@@ -122,7 +123,7 @@ public class Reservation extends BaseEntity {
      * @return 타임아웃까지 남은 시간
      */
     public Duration getRemainingTimeUntilTimeout() {
-        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime now = DateTimeUtil.nowInKorea();
 
         return switch (this.status) {
             case RESERVED -> {
@@ -145,7 +146,7 @@ public class Reservation extends BaseEntity {
             throw new ExpectedException("예약 중인 예약만 시작할 수 있습니다", HttpStatus.BAD_REQUEST);
         }
         this.status = ReservationStatus.RUNNING;
-        this.startTime = LocalDateTime.now();
+        this.startTime = DateTimeUtil.nowInKorea();
         this.expectedCompletionTime = expectedCompletionTime;
     }
 
@@ -170,7 +171,7 @@ public class Reservation extends BaseEntity {
             throw new ExpectedException("실행 중인 예약만 완료할 수 있습니다", HttpStatus.BAD_REQUEST);
         }
         this.status = ReservationStatus.COMPLETED;
-        this.actualCompletionTime = LocalDateTime.now();
+        this.actualCompletionTime = DateTimeUtil.nowInKorea();
     }
 
     /**
@@ -181,7 +182,7 @@ public class Reservation extends BaseEntity {
             throw new ExpectedException("완료된 예약은 취소할 수 없습니다", HttpStatus.BAD_REQUEST);
         }
         this.status = ReservationStatus.CANCELLED;
-        this.cancelledAt = LocalDateTime.now();
+        this.cancelledAt = DateTimeUtil.nowInKorea();
     }
 
     /**

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
@@ -1,6 +1,5 @@
 package team.washer.server.v2.domain.reservation.service.impl;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.http.HttpStatus;
@@ -25,6 +24,7 @@ import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @Slf4j
 @Service
@@ -65,7 +65,7 @@ public class CreateReservationServiceImpl implements CreateReservationService {
 
         // 시간 제한 검증 (학년별 예약 시작 시각, 개발환경에서는 비활성화 가능)
         if (!reservationEnvironment.disableTimeRestriction()) {
-            user.validateTimeRestriction(LocalDateTime.now());
+            user.validateTimeRestriction(DateTimeUtil.nowInKorea());
         }
 
         // 동일 기기 동시 예약 직렬화를 위해 비관적 쓰기 락으로 조회
@@ -107,7 +107,7 @@ public class CreateReservationServiceImpl implements CreateReservationService {
                     machine.getType().getDescription()), HttpStatus.BAD_REQUEST);
         }
 
-        final var now = LocalDateTime.now();
+        final var now = DateTimeUtil.nowInKorea();
         final Reservation reservation = Reservation.builder().user(user).machine(machine).reservedAt(now)
                 .dayOfWeek(now.getDayOfWeek()).status(ReservationStatus.RESERVED).build();
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/OverdueReservationProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/OverdueReservationProcessor.java
@@ -1,6 +1,5 @@
 package team.washer.server.v2.domain.reservation.service.impl;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Component;
@@ -60,8 +59,9 @@ public class OverdueReservationProcessor {
     @Transactional(readOnly = true)
     public List<OverdueTarget> findExpiredTargets() {
         // reservedAt 기준 타임아웃 상수 초과
-        var threshold = LocalDateTime.now().minusMinutes(ReservationStatus.RESERVED.getTimeoutMinutes());
-        var recentCutoff = LocalDateTime.now().minusHours(24);
+        var now = DateTimeUtil.nowInKorea();
+        var threshold = now.minusMinutes(ReservationStatus.RESERVED.getTimeoutMinutes());
+        var recentCutoff = now.minusHours(24);
 
         return reservationRepository.findExpiredReservations(ReservationStatus.RESERVED, threshold, recentCutoff)
                 .stream()

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryPenaltyStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryPenaltyStatusServiceImpl.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.reservation.dto.response.PenaltyStatusResDto;
 import team.washer.server.v2.domain.reservation.service.QueryPenaltyStatusService;
 import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @Slf4j
 @Service
@@ -22,7 +23,7 @@ public class QueryPenaltyStatusServiceImpl implements QueryPenaltyStatusService 
     @Override
     @Transactional(readOnly = true)
     public PenaltyStatusResDto execute(final Long userId) {
-        final LocalDateTime now = LocalDateTime.now();
+        final LocalDateTime now = DateTimeUtil.nowInKorea();
         final LocalDateTime penaltyExpiresAt = penaltyRedisUtil.getPenaltyExpiryTime(userId);
         final boolean isPenalized = penaltyExpiresAt != null && now.isBefore(penaltyExpiresAt);
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
@@ -2,7 +2,6 @@ package team.washer.server.v2.domain.reservation.service.impl;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 
 import org.springframework.stereotype.Component;
@@ -35,8 +34,7 @@ import team.washer.server.v2.global.util.DateTimeUtil;
 @Slf4j
 public class ReservationLifecycleProcessor {
 
-    private static final long COMPLETION_EARLY_TOLERANCE_MINUTES = 2;
-    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+    private static final long COMPLETION_EARLY_LOG_TOLERANCE_MINUTES = 2;
 
     private final ReservationRepository reservationRepository;
     private final MachineRepository machineRepository;
@@ -100,15 +98,16 @@ public class ReservationLifecycleProcessor {
         var completionTime = machineStateDetectionSupport.isCompleted(status, isWasher);
 
         if (completionTime.isPresent()) {
-            if (shouldDeferCompletion(reservation, status, isWasher, completionTime.get())) {
-                log.debug(
-                        "completion deferred reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
+            if (isStaleCompletion(reservation, status, isWasher, completionTime.get())) {
+                log.info(
+                        "completion deferred reason=stale_completion reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
                         reservation.getId(),
                         reservation.getStartTime(),
                         reservation.getExpectedCompletionTime(),
                         completionTime.get());
                 return;
             }
+            logEarlyCompletionSignalIfNeeded(reservation, completionTime.get());
             reservation.complete();
             machine.markAsAvailable();
             reservationRepository.save(reservation);
@@ -116,7 +115,14 @@ public class ReservationLifecycleProcessor {
 
             reservationNotificationSupport.sendCompletion(reservation.getUser(), machine);
 
-            log.info("Reservation {} completed (RUNNING → COMPLETED)", reservation.getId());
+            log.info(
+                    "Reservation completed reservationId={} userId={} machineId={} machineName={} completionTime={} expectedCompletionTime={}",
+                    reservation.getId(),
+                    reservation.getUser().getId(),
+                    machine.getId(),
+                    machine.getName(),
+                    completionTime.get(),
+                    reservation.getExpectedCompletionTime());
         } else if (machineStateDetectionSupport.isInterrupted(status, isWasher)) {
             // 사이클 단계 전환 중 순간적으로 보고되는 정지를 진짜 중단으로 오판하지 않도록, 연속으로 중단이
             // 감지될 때만 취소를 확정한다.
@@ -149,7 +155,7 @@ public class ReservationLifecycleProcessor {
                 reservation.markAsPaused();
                 reservationRepository.save(reservation);
                 log.info("Reservation {} pause started, tracking pause time", reservation.getId());
-            } else if (Duration.between(reservation.getPausedAt(), LocalDateTime.now())
+            } else if (Duration.between(reservation.getPausedAt(), DateTimeUtil.nowInKorea())
                     .toMinutes() >= ReservationConstants.PAUSE_TIMEOUT_MINUTES) {
                 reservation.cancel();
                 reservation.clearPausedAt();
@@ -183,14 +189,6 @@ public class ReservationLifecycleProcessor {
         }
     }
 
-    private boolean shouldDeferCompletion(Reservation reservation,
-            SmartThingsDeviceStatusResDto status,
-            boolean isWasher,
-            LocalDateTime completionTime) {
-        return isStaleCompletion(reservation, status, isWasher, completionTime)
-                || isTooEarlyCompletion(reservation, completionTime);
-    }
-
     private boolean isStaleCompletion(Reservation reservation,
             SmartThingsDeviceStatusResDto status,
             boolean isWasher,
@@ -206,14 +204,21 @@ public class ReservationLifecycleProcessor {
                 || isTimestampBeforeStart(getJobStateTimestamp(status, isWasher), startTime);
     }
 
-    private boolean isTooEarlyCompletion(Reservation reservation, LocalDateTime completionTime) {
+    private void logEarlyCompletionSignalIfNeeded(Reservation reservation, LocalDateTime completionTime) {
         var expectedCompletionTime = reservation.getExpectedCompletionTime();
         if (expectedCompletionTime == null) {
-            return false;
+            return;
         }
-        var earliestCompletionTime = expectedCompletionTime.minusMinutes(COMPLETION_EARLY_TOLERANCE_MINUTES);
-        return LocalDateTime.now(KOREA_ZONE).isBefore(earliestCompletionTime)
-                && completionTime.isBefore(earliestCompletionTime);
+        var earliestCompletionTime = expectedCompletionTime.minusMinutes(COMPLETION_EARLY_LOG_TOLERANCE_MINUTES);
+        if (DateTimeUtil.nowInKorea().isBefore(earliestCompletionTime)
+                && completionTime.isBefore(earliestCompletionTime)) {
+            log.info(
+                    "completion accepted before expected time reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
+                    reservation.getId(),
+                    reservation.getStartTime(),
+                    expectedCompletionTime,
+                    completionTime);
+        }
     }
 
     private boolean isTimestampBeforeStart(String timestamp, LocalDateTime startTime) {

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
@@ -35,6 +35,7 @@ import team.washer.server.v2.global.util.DateTimeUtil;
 public class ReservationLifecycleProcessor {
 
     private static final long COMPLETION_EARLY_LOG_TOLERANCE_MINUTES = 2;
+    private static final long MAX_REASONABLE_CYCLE_MINUTES = 240;
 
     private final ReservationRepository reservationRepository;
     private final MachineRepository machineRepository;
@@ -107,7 +108,18 @@ public class ReservationLifecycleProcessor {
                         completionTime.get());
                 return;
             }
-            logEarlyCompletionSignalIfNeeded(reservation, completionTime.get());
+            if (isTooEarlyCompletion(reservation, completionTime.get())) {
+                if (!canAcceptEarlyCompletion(reservation, status, isWasher, completionTime.get())) {
+                    log.info(
+                            "completion deferred reason=too_early_completion reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
+                            reservation.getId(),
+                            reservation.getStartTime(),
+                            reservation.getExpectedCompletionTime(),
+                            completionTime.get());
+                    return;
+                }
+                logEarlyCompletionAccepted(reservation, completionTime.get());
+            }
             reservation.complete();
             machine.markAsAvailable();
             reservationRepository.save(reservation);
@@ -204,21 +216,55 @@ public class ReservationLifecycleProcessor {
                 || isTimestampBeforeStart(getJobStateTimestamp(status, isWasher), startTime);
     }
 
-    private void logEarlyCompletionSignalIfNeeded(Reservation reservation, LocalDateTime completionTime) {
+    private boolean isTooEarlyCompletion(Reservation reservation, LocalDateTime completionTime) {
         var expectedCompletionTime = reservation.getExpectedCompletionTime();
         if (expectedCompletionTime == null) {
-            return;
+            return false;
         }
         var earliestCompletionTime = expectedCompletionTime.minusMinutes(COMPLETION_EARLY_LOG_TOLERANCE_MINUTES);
-        if (DateTimeUtil.nowInKorea().isBefore(earliestCompletionTime)
-                && completionTime.isBefore(earliestCompletionTime)) {
-            log.info(
-                    "completion accepted before expected time reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
-                    reservation.getId(),
-                    reservation.getStartTime(),
-                    expectedCompletionTime,
-                    completionTime);
+        return completionTime.isBefore(earliestCompletionTime);
+    }
+
+    private boolean canAcceptEarlyCompletion(Reservation reservation,
+            SmartThingsDeviceStatusResDto status,
+            boolean isWasher,
+            LocalDateTime completionTime) {
+        return hasSuspiciousExpectedCompletionTime(reservation)
+                && hasFreshCompletionEvidence(reservation, status, isWasher, completionTime);
+    }
+
+    private boolean hasSuspiciousExpectedCompletionTime(Reservation reservation) {
+        var startTime = reservation.getStartTime();
+        var expectedCompletionTime = reservation.getExpectedCompletionTime();
+        if (startTime == null || expectedCompletionTime == null) {
+            return false;
         }
+        return Duration.between(startTime, expectedCompletionTime).toMinutes() > MAX_REASONABLE_CYCLE_MINUTES;
+    }
+
+    private boolean hasFreshCompletionEvidence(Reservation reservation,
+            SmartThingsDeviceStatusResDto status,
+            boolean isWasher,
+            LocalDateTime completionTime) {
+        var startTime = reservation.getStartTime();
+        if (startTime == null) {
+            return false;
+        }
+        var completionTimeStr = getCompletionTime(status, isWasher);
+        if (completionTimeStr != null && !completionTimeStr.isBlank() && !completionTime.isBefore(startTime)) {
+            return true;
+        }
+        return isTimestampAtOrAfterStart(getOperatingStateTimestamp(status, isWasher), startTime)
+                || isTimestampAtOrAfterStart(getJobStateTimestamp(status, isWasher), startTime);
+    }
+
+    private void logEarlyCompletionAccepted(Reservation reservation, LocalDateTime completionTime) {
+        log.info(
+                "completion accepted reason=suspicious_expected_completion_time reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
+                reservation.getId(),
+                reservation.getStartTime(),
+                reservation.getExpectedCompletionTime(),
+                completionTime);
     }
 
     private boolean isTimestampBeforeStart(String timestamp, LocalDateTime startTime) {
@@ -227,6 +273,21 @@ public class ReservationLifecycleProcessor {
         }
         var updatedAt = DateTimeUtil.parseAndConvertToKoreaTime(timestamp);
         return updatedAt != null && updatedAt.isBefore(startTime);
+    }
+
+    private boolean isTimestampAtOrAfterStart(String timestamp, LocalDateTime startTime) {
+        if (timestamp == null || timestamp.isBlank()) {
+            return false;
+        }
+        var updatedAt = DateTimeUtil.parseAndConvertToKoreaTime(timestamp);
+        return updatedAt != null && !updatedAt.isBefore(startTime);
+    }
+
+    private String getCompletionTime(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        if (status == null) {
+            return null;
+        }
+        return isWasher ? status.getWasherCompletionTime() : status.getDryerCompletionTime();
     }
 
     private String getOperatingStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {

--- a/src/main/java/team/washer/server/v2/domain/reservation/util/PenaltyRedisUtil.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/util/PenaltyRedisUtil.java
@@ -18,6 +18,7 @@ import team.washer.server.v2.domain.reservation.repository.redis.TimeoutWarningR
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.global.common.constants.PenaltyConstants;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @Slf4j
 @Component
@@ -62,7 +63,7 @@ public class PenaltyRedisUtil {
         if (remainingSeconds == null || remainingSeconds <= 0) {
             return null;
         }
-        return LocalDateTime.now().plusSeconds(remainingSeconds);
+        return DateTimeUtil.nowInKorea().plusSeconds(remainingSeconds);
     }
 
     private Long cooldownRemainingTtlSeconds(final Long userId, final MachineType machineType) {
@@ -225,7 +226,7 @@ public class PenaltyRedisUtil {
                 .save(CancellationBlockEntity.builder().roomNumber(roomNumber).ttl(newTtl).build());
         log.info("block extended roomNumber={} additionalDays={} newTtlSeconds={}", roomNumber, additionalDays, newTtl);
 
-        return LocalDateTime.now().plusSeconds(newTtl);
+        return DateTimeUtil.nowInKorea().plusSeconds(newTtl);
     }
 
     /**

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
@@ -1,7 +1,6 @@
 package team.washer.server.v2.domain.smartthings.support;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Optional;
 
 import org.springframework.stereotype.Component;
@@ -20,12 +19,6 @@ import team.washer.server.v2.global.util.DateTimeUtil;
 @Component
 @Slf4j
 public class MachineStateDetectionSupport {
-
-    /**
-     * completionTime은 항상 한국 시각(Asia/Seoul)으로 변환되므로, 비교 기준 시각도 시스템 타임존과 무관하게 한국 시각으로
-     * 고정한다.
-     */
-    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
     /**
      * 기기가 작동 중인지 감지한다. 세탁기는 washerOperatingState, 건조기는 dryerOperatingState의
@@ -56,7 +49,7 @@ public class MachineStateDetectionSupport {
         if (status == null) {
             return Optional.empty();
         }
-        var now = LocalDateTime.now(KOREA_ZONE);
+        var now = DateTimeUtil.nowInKorea();
         if (isWasher) {
             return evaluateCompletion(status.getWasherJobState(),
                     "finish",

--- a/src/main/java/team/washer/server/v2/domain/user/entity/User.java
+++ b/src/main/java/team/washer/server/v2/domain/user/entity/User.java
@@ -20,6 +20,7 @@ import team.washer.server.v2.domain.user.enums.UserRole;
 import team.washer.server.v2.global.common.constants.NotificationConstants;
 import team.washer.server.v2.global.common.constants.TimeRestrictionConstants;
 import team.washer.server.v2.global.common.entity.BaseEntity;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @Entity
 @Table(name = "users", indexes = {@Index(name = "idx_student_id", columnList = "student_id"),
@@ -126,7 +127,7 @@ public class User extends BaseEntity {
      * 마지막 취소 시각을 현재 시각으로 갱신합니다.
      */
     public void updateLastCancellationTime() {
-        this.lastCancellationAt = LocalDateTime.now();
+        this.lastCancellationAt = DateTimeUtil.nowInKorea();
     }
 
     /**
@@ -165,7 +166,7 @@ public class User extends BaseEntity {
             return false;
         }
         LocalDateTime penaltyExpiry = this.lastCancellationAt.plusMinutes(penaltyMinutes);
-        return LocalDateTime.now().isBefore(penaltyExpiry);
+        return DateTimeUtil.nowInKorea().isBefore(penaltyExpiry);
     }
 
     /**
@@ -240,8 +241,8 @@ public class User extends BaseEntity {
      *            패널티 만료 시각 (null이면 패널티 없음)
      */
     public void validateNotPenalized(final LocalDateTime penaltyExpiresAt) {
-        if (penaltyExpiresAt != null && LocalDateTime.now().isBefore(penaltyExpiresAt)) {
-            final long remainingMinutes = Duration.between(LocalDateTime.now(), penaltyExpiresAt).toMinutes();
+        if (penaltyExpiresAt != null && DateTimeUtil.nowInKorea().isBefore(penaltyExpiresAt)) {
+            final long remainingMinutes = Duration.between(DateTimeUtil.nowInKorea(), penaltyExpiresAt).toMinutes();
             throw new ExpectedException(String.format("현재 예약이 제한되어 있습니다. 제한 해제까지 %d분 남았습니다.", remainingMinutes),
                     HttpStatus.BAD_REQUEST);
         }

--- a/src/main/java/team/washer/server/v2/domain/user/service/impl/QueryMyInfoServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/impl/QueryMyInfoServiceImpl.java
@@ -13,6 +13,7 @@ import team.washer.server.v2.domain.user.dto.response.MyInfoResDto;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.domain.user.service.QueryMyInfoService;
 import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @Service
 @RequiredArgsConstructor
@@ -30,7 +31,7 @@ public class QueryMyInfoServiceImpl implements QueryMyInfoService {
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
         final LocalDateTime penaltyExpiresAt = penaltyRedisUtil.getPenaltyExpiryTime(userId);
-        final boolean canReserve = penaltyExpiresAt == null || LocalDateTime.now().isAfter(penaltyExpiresAt);
+        final boolean canReserve = penaltyExpiresAt == null || DateTimeUtil.nowInKorea().isAfter(penaltyExpiresAt);
 
         return new MyInfoResDto(user.getId(),
                 user.getName(),

--- a/src/main/java/team/washer/server/v2/domain/user/service/impl/QueryUserByIdServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/impl/QueryUserByIdServiceImpl.java
@@ -14,6 +14,7 @@ import team.washer.server.v2.domain.user.dto.response.UserResDto;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.domain.user.service.QueryUserByIdService;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @Service
 @RequiredArgsConstructor
@@ -29,11 +30,10 @@ public class QueryUserByIdServiceImpl implements QueryUserByIdService {
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
         final LocalDateTime penaltyExpiresAt = penaltyRedisUtil.getPenaltyExpiryTime(user.getId());
-        final boolean isPenalized = penaltyExpiresAt != null && LocalDateTime.now().isBefore(penaltyExpiresAt);
+        final LocalDateTime now = DateTimeUtil.nowInKorea();
+        final boolean isPenalized = penaltyExpiresAt != null && now.isBefore(penaltyExpiresAt);
 
-        final Long penaltyRemainMinutes = isPenalized
-                ? Duration.between(LocalDateTime.now(), penaltyExpiresAt).toMinutes()
-                : null;
+        final Long penaltyRemainMinutes = isPenalized ? Duration.between(now, penaltyExpiresAt).toMinutes() : null;
         final String penaltyReason = isPenalized ? buildPenaltyReason(user.getId()) : null;
 
         return new UserResDto(user.getId(),

--- a/src/main/java/team/washer/server/v2/domain/user/service/impl/SearchUserServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/impl/SearchUserServiceImpl.java
@@ -15,6 +15,7 @@ import team.washer.server.v2.domain.user.dto.response.UserResDto;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.domain.user.service.SearchUserService;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @Service
 @RequiredArgsConstructor
@@ -47,11 +48,10 @@ public class SearchUserServiceImpl implements SearchUserService {
 
     private UserResDto toUserResDto(User user) {
         final LocalDateTime penaltyExpiresAt = penaltyRedisUtil.getPenaltyExpiryTime(user.getId());
-        final boolean isPenalized = penaltyExpiresAt != null && LocalDateTime.now().isBefore(penaltyExpiresAt);
+        final LocalDateTime now = DateTimeUtil.nowInKorea();
+        final boolean isPenalized = penaltyExpiresAt != null && now.isBefore(penaltyExpiresAt);
 
-        final Long penaltyRemainMinutes = isPenalized
-                ? Duration.between(LocalDateTime.now(), penaltyExpiresAt).toMinutes()
-                : null;
+        final Long penaltyRemainMinutes = isPenalized ? Duration.between(now, penaltyExpiresAt).toMinutes() : null;
         final String penaltyReason = isPenalized ? buildPenaltyReason(user.getId()) : null;
 
         return new UserResDto(user.getId(),

--- a/src/main/java/team/washer/server/v2/global/config/TimezoneConfig.java
+++ b/src/main/java/team/washer/server/v2/global/config/TimezoneConfig.java
@@ -1,12 +1,12 @@
 package team.washer.server.v2.global.config;
 
-import java.time.LocalDateTime;
 import java.util.TimeZone;
 
 import org.springframework.context.annotation.Configuration;
 
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @Configuration
 @Slf4j
@@ -16,6 +16,6 @@ class TimezoneConfig {
     public void setDefaultTimezone() {
         System.setProperty("user.timezone", "Asia/Seoul");
         TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
-        log.info("Default timezone set to {}: {}", TimeZone.getDefault().getID(), LocalDateTime.now());
+        log.info("Default timezone set timezoneId={} now={}", TimeZone.getDefault().getID(), DateTimeUtil.nowInKorea());
     }
 }

--- a/src/main/java/team/washer/server/v2/global/util/DateTimeUtil.java
+++ b/src/main/java/team/washer/server/v2/global/util/DateTimeUtil.java
@@ -10,14 +10,20 @@ import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport
 @Slf4j
 public final class DateTimeUtil {
 
+    public static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
     private DateTimeUtil() {
         throw new UnsupportedOperationException("Utility class cannot be instantiated");
+    }
+
+    public static LocalDateTime nowInKorea() {
+        return LocalDateTime.now(KOREA_ZONE);
     }
 
     public static LocalDateTime parseAndConvertToKoreaTime(String timeStr) {
         try {
             var utcTime = ZonedDateTime.parse(timeStr);
-            return utcTime.withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+            return utcTime.withZoneSameInstant(KOREA_ZONE).toLocalDateTime();
         } catch (Exception e) {
             log.warn("Failed to parse time: {}", timeStr, e);
             return null;

--- a/src/test/java/team/washer/server/v2/domain/notification/support/FcmNotificationSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/support/FcmNotificationSupportTest.java
@@ -36,6 +36,10 @@ class FcmNotificationSupportTest {
         return user;
     }
 
+    private User createUserWithoutToken() {
+        return User.builder().name("테스트").studentId("20210001").roomNumber("301").grade(3).floor(3).build();
+    }
+
     @Nested
     @DisplayName("send 메서드는")
     class Describe_send {
@@ -62,6 +66,17 @@ class FcmNotificationSupportTest {
             // When & Then
             assertThatCode(() -> fcmNotificationSupport.send(user, "제목", null)).doesNotThrowAnyException();
             then(firebaseMessaging).should(times(1)).send(any(Message.class));
+        }
+
+        @Test
+        @DisplayName("FCM 토큰이 없으면 발송을 시도하지 않아야 한다")
+        void it_skips_sending_when_fcm_token_is_missing() throws Exception {
+            // Given
+            User user = createUserWithoutToken();
+
+            // When & Then
+            assertThatCode(() -> fcmNotificationSupport.send(user, "제목", "본문")).doesNotThrowAnyException();
+            then(firebaseMessaging).should(never()).send(any(Message.class));
         }
     }
 }

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/QueryPenaltyStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/QueryPenaltyStatusServiceTest.java
@@ -3,8 +3,6 @@ package team.washer.server.v2.domain.reservation.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import java.time.LocalDateTime;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -15,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import team.washer.server.v2.domain.reservation.service.impl.QueryPenaltyStatusServiceImpl;
 import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("QueryPenaltyStatusServiceImpl 클래스의")
@@ -39,7 +38,7 @@ class QueryPenaltyStatusServiceTest {
             void it_returns_penalized_but_not_room_blocked() {
                 // Given
                 var userId = 1L;
-                var expiresAt = LocalDateTime.now().plusMinutes(5);
+                var expiresAt = DateTimeUtil.nowInKorea().plusMinutes(5);
                 given(penaltyRedisUtil.getPenaltyExpiryTime(userId)).willReturn(expiresAt);
                 given(penaltyRedisUtil.getBlockExpiryTime(userId)).willReturn(null);
 
@@ -66,7 +65,7 @@ class QueryPenaltyStatusServiceTest {
             void it_returns_penalized_and_room_blocked() {
                 // Given
                 var userId = 1L;
-                var blockExpiresAt = LocalDateTime.now().plusHours(40);
+                var blockExpiresAt = DateTimeUtil.nowInKorea().plusHours(40);
                 given(penaltyRedisUtil.getPenaltyExpiryTime(userId)).willReturn(blockExpiresAt);
                 given(penaltyRedisUtil.getBlockExpiryTime(userId)).willReturn(blockExpiresAt);
 
@@ -115,7 +114,7 @@ class QueryPenaltyStatusServiceTest {
             void it_returns_no_penalty_for_expired() {
                 // Given
                 var userId = 1L;
-                var expiredAt = LocalDateTime.now().minusMinutes(1);
+                var expiredAt = DateTimeUtil.nowInKorea().minusMinutes(1);
                 given(penaltyRedisUtil.getPenaltyExpiryTime(userId)).willReturn(expiredAt);
                 given(penaltyRedisUtil.getBlockExpiryTime(userId)).willReturn(null);
 

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
@@ -163,7 +163,7 @@ class ReservationLifecycleProcessorTest {
             givenRunningReservation();
             when(reservation.getUser()).thenReturn(user);
             when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.of(LocalDateTime.now()));
+                    .thenReturn(Optional.of(LocalDateTime.now(KOREA_ZONE)));
 
             // When
             reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
@@ -179,9 +179,10 @@ class ReservationLifecycleProcessorTest {
         void shouldNotCompleteReservation_WhenCompletionTimeBeforeReservationStartTime() {
             // Given
             var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
-            var staleCompletionTime = LocalDateTime.now().minusMinutes(5);
+            var startTime = LocalDateTime.now(KOREA_ZONE);
+            var staleCompletionTime = startTime.minusMinutes(5);
             givenRunningReservation();
-            when(reservation.getStartTime()).thenReturn(LocalDateTime.now());
+            when(reservation.getStartTime()).thenReturn(startTime);
             when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(Optional.of(staleCompletionTime));
 
@@ -221,13 +222,14 @@ class ReservationLifecycleProcessorTest {
         }
 
         @Test
-        @DisplayName("예상 완료 시간이 충분히 남아 있으면 완료 신호를 보류하고 예약을 유지한다")
-        void shouldNotCompleteReservation_WhenCompletionDetectedTooEarly() {
+        @DisplayName("예상 완료 시간이 미래로 튀어도 완료 신호가 있으면 완료 처리한다")
+        void shouldCompleteReservation_WhenCompletionDetectedBeforeExpectedCompletionTime() {
             // Given
             var deviceStatus = buildDeviceStatus(null);
             var nowKst = LocalDateTime.now(KOREA_ZONE);
             givenRunningReservation();
-            when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.plusMinutes(10));
+            when(reservation.getUser()).thenReturn(user);
+            when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.plusHours(10));
             when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(Optional.of(nowKst));
 
@@ -235,11 +237,11 @@ class ReservationLifecycleProcessorTest {
             reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
 
             // Then
-            verify(reservation, never()).complete();
-            verify(machine, never()).markAsAvailable();
-            verify(reservationRepository, never()).save(reservation);
-            verify(machineRepository, never()).save(machine);
-            verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
+            verify(reservation, times(1)).complete();
+            verify(machine, times(1)).markAsAvailable();
+            verify(reservationRepository, times(1)).save(reservation);
+            verify(machineRepository, times(1)).save(machine);
+            verify(reservationNotificationSupport, times(1)).sendCompletion(user, machine);
         }
 
         @Test

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
@@ -80,6 +80,15 @@ class ReservationLifecycleProcessorTest {
         return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
     }
 
+    private SmartThingsDeviceStatusResDto buildDryerStatusWithTimestamp(String machineStateTimestamp,
+            String jobStateTimestamp) {
+        var machineStateAttr = new SmartThingsDeviceStatusResDto.AttributeState("stop", machineStateTimestamp, null);
+        var jobStateAttr = new SmartThingsDeviceStatusResDto.AttributeState("finished", jobStateTimestamp, null);
+        var dryerOpState = new SmartThingsDeviceStatusResDto.DryerOperatingState(machineStateAttr, jobStateAttr, null);
+        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(null, dryerOpState, null, null);
+        return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
+    }
+
     private String isoUtc(LocalDateTime koreaTime) {
         return koreaTime.atZone(KOREA_ZONE).withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime().toString() + "Z";
     }
@@ -222,13 +231,37 @@ class ReservationLifecycleProcessorTest {
         }
 
         @Test
-        @DisplayName("예상 완료 시간이 미래로 튀어도 완료 신호가 있으면 완료 처리한다")
-        void shouldCompleteReservation_WhenCompletionDetectedBeforeExpectedCompletionTime() {
+        @DisplayName("예상 완료 시간이 정상 범위이면 너무 이른 완료 신호를 보류한다")
+        void shouldNotCompleteReservation_WhenCompletionDetectedTooEarlyWithNormalExpectedTime() {
             // Given
-            var deviceStatus = buildDeviceStatus(null);
             var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var deviceStatus = buildDryerStatusWithTimestamp(isoUtc(nowKst), isoUtc(nowKst));
+            givenRunningReservation();
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(1));
+            when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.plusMinutes(10));
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(Optional.of(nowKst));
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, never()).complete();
+            verify(machine, never()).markAsAvailable();
+            verify(reservationRepository, never()).save(reservation);
+            verify(machineRepository, never()).save(machine);
+            verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
+        }
+
+        @Test
+        @DisplayName("예상 완료 시간이 비정상적으로 길고 최신 완료 증거가 있으면 완료 처리한다")
+        void shouldCompleteReservation_WhenExpectedCompletionTimeIsSuspiciousAndCompletionEvidenceIsFresh() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var deviceStatus = buildDryerStatusWithTimestamp(isoUtc(nowKst), isoUtc(nowKst));
             givenRunningReservation();
             when(reservation.getUser()).thenReturn(user);
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(10));
             when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.plusHours(10));
             when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(Optional.of(nowKst));
@@ -242,6 +275,29 @@ class ReservationLifecycleProcessorTest {
             verify(reservationRepository, times(1)).save(reservation);
             verify(machineRepository, times(1)).save(machine);
             verify(reservationNotificationSupport, times(1)).sendCompletion(user, machine);
+        }
+
+        @Test
+        @DisplayName("예상 완료 시간이 비정상적으로 길어도 최신 완료 증거가 없으면 완료 신호를 보류한다")
+        void shouldNotCompleteReservation_WhenExpectedCompletionTimeIsSuspiciousButCompletionEvidenceIsMissing() {
+            // Given
+            var deviceStatus = buildDeviceStatus(null);
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            givenRunningReservation();
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(10));
+            when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.plusHours(10));
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(Optional.of(nowKst));
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, never()).complete();
+            verify(machine, never()).markAsAvailable();
+            verify(reservationRepository, never()).save(reservation);
+            verify(machineRepository, never()).save(machine);
+            verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
         }
 
         @Test

--- a/src/test/java/team/washer/server/v2/domain/reservation/util/PenaltyRedisUtilTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/util/PenaltyRedisUtilTest.java
@@ -26,6 +26,7 @@ import team.washer.server.v2.domain.reservation.repository.redis.TimeoutWarningR
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.global.common.constants.PenaltyConstants;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("PenaltyRedisUtil 단위 테스트")
@@ -70,7 +71,8 @@ class PenaltyRedisUtilTest {
             LocalDateTime result = penaltyRedisUtil.getPenaltyExpiryTime(userId);
 
             // Then
-            assertThat(result).isBetween(LocalDateTime.now().plusSeconds(290), LocalDateTime.now().plusSeconds(310));
+            assertThat(result).isBetween(DateTimeUtil.nowInKorea().plusSeconds(290),
+                    DateTimeUtil.nowInKorea().plusSeconds(310));
         }
 
         @Test
@@ -91,7 +93,8 @@ class PenaltyRedisUtilTest {
             LocalDateTime result = penaltyRedisUtil.getPenaltyExpiryTime(userId);
 
             // Then
-            assertThat(result).isBetween(LocalDateTime.now().plusSeconds(3590), LocalDateTime.now().plusSeconds(3610));
+            assertThat(result).isBetween(DateTimeUtil.nowInKorea().plusSeconds(3590),
+                    DateTimeUtil.nowInKorea().plusSeconds(3610));
         }
 
         @Test

--- a/src/test/java/team/washer/server/v2/domain/user/service/QueryMyInfoServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/service/QueryMyInfoServiceTest.java
@@ -3,7 +3,6 @@ package team.washer.server.v2.domain.user.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -21,6 +20,7 @@ import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.domain.user.service.impl.QueryMyInfoServiceImpl;
 import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("QueryMyInfoServiceImpl 클래스의")
@@ -84,7 +84,7 @@ class QueryMyInfoServiceTest {
                 // Given
                 var userId = 1L;
                 var user = createUser();
-                var penaltyExpiresAt = LocalDateTime.now().plusMinutes(30);
+                var penaltyExpiresAt = DateTimeUtil.nowInKorea().plusMinutes(30);
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
                 given(userRepository.findById(userId)).willReturn(Optional.of(user));
                 given(penaltyRedisUtil.getPenaltyExpiryTime(userId)).willReturn(penaltyExpiresAt);


### PR DESCRIPTION
## 개요

  SmartThings 완료 신호가 있어도 비정상적인 완료 예정 시간이나 서버 타임존 차이로 예약이 RUNNING에 머물러 완료 알림이 생성되지 않을 수 있는 문제를 개선했습니다.

  ## 본문

  - 완료 신호가 현재 예약 시작 이후의 유효한 신호라면 expectedCompletionTime이 미래로 튀어 있어도 완료 처리하도록 수정했습니다.
  - 예약 시작/완료/취소/일시정지 및 남은 시간 계산 기준을 KST로 통일했습니다.
  - 오래된 완료 신호로 인한 오판은 계속 방어하되, 보류 사유를 INFO 로그로 남기도록 했습니다.
  - FCM 토큰이 없어 알림 발송을 건너뛰는 경우를 운영 로그에서 확인할 수 있도록 했습니다.
  - 완료 전환 회귀 테스트와 FCM 토큰 누락 테스트를 보강했습니다.

  검증:
  - `.\gradlew test`
