### PR TITLE
[smartthings] 작동 중 기기 자동 종료 방지

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/ShutdownIdleMachinesServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/ShutdownIdleMachinesServiceImpl.java
@@ -56,6 +56,7 @@ public class ShutdownIdleMachinesServiceImpl implements ShutdownIdleMachinesServ
 
         var poweredOff = new ArrayList<String>();
         var unauthorizedStopped = new ArrayList<String>();
+        var skippedOperating = new ArrayList<String>();
         var failed = new ArrayList<String>();
 
         for (var machine : idleCandidates) {
@@ -70,6 +71,7 @@ public class ShutdownIdleMachinesServiceImpl implements ShutdownIdleMachinesServ
                                 machine.getName(),
                                 machine.getDeviceId());
                     }
+                    case SKIPPED_OPERATING -> skippedOperating.add(machine.getName());
                     case SKIPPED_UNKNOWN -> {
                         // 상태 불명, 안전을 위해 종료하지 않음
                     }
@@ -93,13 +95,16 @@ public class ShutdownIdleMachinesServiceImpl implements ShutdownIdleMachinesServ
             }
         }
 
-        if (!poweredOff.isEmpty() || !unauthorizedStopped.isEmpty() || !failed.isEmpty()) {
+        if (!poweredOff.isEmpty() || !unauthorizedStopped.isEmpty() || !skippedOperating.isEmpty()
+                || !failed.isEmpty()) {
             log.info(
-                    "idle shutdown batch done. powered_off={} {} unauthorized_stopped={} {} skipped_active_reservation={} failed={}{}",
+                    "idle shutdown batch done. powered_off={} {} unauthorized_stopped={} {} skipped_operating={} {} skipped_active_reservation={} failed={}{}",
                     poweredOff.size(),
                     poweredOff,
                     unauthorizedStopped.size(),
                     unauthorizedStopped,
+                    skippedOperating.size(),
+                    skippedOperating,
                     skippedActiveCount,
                     failed.size(),
                     failed.isEmpty() ? "" : " " + failed);

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupport.java
@@ -57,25 +57,14 @@ public class DeviceShutdownSupport {
         }
 
         if (isOperating(machine, status)) {
-            SmartThingsCommandReqDto stopCommand;
-            if (machine.isWasher()) {
-                stopCommand = SmartThingsCommandReqDto.stopWasher();
-            } else if (machine.isDryer()) {
-                stopCommand = SmartThingsCommandReqDto.stopDryer();
-            } else {
-                log.warn("unknown machine type, skip shutdown machine={} deviceId={}",
-                        machine.getName(),
-                        machine.getDeviceId());
-                return ShutdownResult.SKIPPED_UNKNOWN;
-            }
-            if (!status.isRemoteControlEnabled()) {
-                log.info("remote control disabled but attempting stop anyway machine={} deviceId={}",
-                        machine.getName(),
-                        machine.getDeviceId());
-            }
-            sendDeviceCommandService.execute(machine.getDeviceId(), stopCommand);
-            log.info("device safely stopped machine={} deviceId={}", machine.getName(), machine.getDeviceId());
-            return ShutdownResult.STOPPED;
+            log.warn(
+                    "operating device detected without active reservation, skip shutdown machine={} deviceId={} machineState={} switchStatus={} remoteControlEnabled={}",
+                    machine.getName(),
+                    machine.getDeviceId(),
+                    extractMachineState(machine, status),
+                    status.getSwitchStatus(),
+                    status.isRemoteControlEnabled());
+            return ShutdownResult.SKIPPED_UNKNOWN;
         }
 
         if ("off".equalsIgnoreCase(status.getSwitchStatus())) {
@@ -94,12 +83,17 @@ public class DeviceShutdownSupport {
      * 기기가 물리적으로 작동 중(run 또는 pause)인지 판정한다. 세탁기/건조기는 타입에 맞는 machineState를 본다.
      */
     private boolean isOperating(Machine machine, SmartThingsDeviceStatusResDto status) {
+        var machineState = extractMachineState(machine, status);
+        return "run".equalsIgnoreCase(machineState) || "pause".equalsIgnoreCase(machineState);
+    }
+
+    private String extractMachineState(Machine machine, SmartThingsDeviceStatusResDto status) {
         String machineState = null;
         if (machine.isWasher()) {
             machineState = status.getWasherOperatingState();
         } else if (machine.isDryer()) {
             machineState = status.getDryerOperatingState();
         }
-        return "run".equalsIgnoreCase(machineState) || "pause".equalsIgnoreCase(machineState);
+        return machineState;
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupport.java
@@ -32,6 +32,8 @@ public class DeviceShutdownSupport {
         POWERED_OFF,
         /** 작동 중인 기기를 안전하게 정지시킴 */
         STOPPED,
+        /** 작동 중인 기기라 종료 명령을 보내지 않음 */
+        SKIPPED_OPERATING,
         /** 기기 상태를 알 수 없어 종료하지 않음 */
         SKIPPED_UNKNOWN
     }
@@ -64,7 +66,7 @@ public class DeviceShutdownSupport {
                     extractMachineState(machine, status),
                     status.getSwitchStatus(),
                     status.isRemoteControlEnabled());
-            return ShutdownResult.SKIPPED_UNKNOWN;
+            return ShutdownResult.SKIPPED_OPERATING;
         }
 
         if ("off".equalsIgnoreCase(status.getSwitchStatus())) {

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/TestDeviceCycleRunner.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/TestDeviceCycleRunner.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.jspecify.annotations.NonNull;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,7 @@ import team.washer.server.v2.domain.smartthings.service.SendDeviceCommandService
  * 시작되지 않을 수 있습니다. 핵심 목적은 명령 전달 및 종료 명령 적용 여부 확인입니다.
  */
 @Component
+@ConditionalOnProperty(prefix = "smartthings.test-cycle", name = "enabled", havingValue = "true")
 @RequiredArgsConstructor
 @Slf4j
 public class TestDeviceCycleRunner implements ApplicationRunner {

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/TestDeviceCycleRunner.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/TestDeviceCycleRunner.java
@@ -145,6 +145,7 @@ public class TestDeviceCycleRunner implements ApplicationRunner {
         return switch (result) {
             case STOPPED -> "작동 중 → 안전 정지 명령 전송됨 (STOPPED)";
             case POWERED_OFF -> "유휴 상태 → 전원 차단됨 (POWERED_OFF)";
+            case SKIPPED_OPERATING -> "작동 중 → 종료하지 않음 (SKIPPED_OPERATING)";
             case SKIPPED_UNKNOWN -> "상태 불명 → 종료하지 않음 (SKIPPED_UNKNOWN)";
         };
     }

--- a/src/test/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupportTest.java
@@ -75,13 +75,8 @@ class DeviceShutdownSupportTest {
 
             var result = deviceShutdownSupport.shutdown(machine, washerStatus("run", true));
 
-            assertThat(result).isEqualTo(ShutdownResult.STOPPED);
-            var captor = ArgumentCaptor.forClass(SmartThingsCommandReqDto.class);
-            then(sendDeviceCommandService).should(times(1)).execute(eq("device-1"), captor.capture());
-            var command = captor.getValue().commands().get(0);
-            assertThat(command.capability()).isEqualTo("washerOperatingState");
-            assertThat(command.command()).isEqualTo("setMachineState");
-            assertThat(command.arguments()).containsExactly("stop");
+            assertThat(result).isEqualTo(ShutdownResult.SKIPPED_UNKNOWN);
+            then(sendDeviceCommandService).should(never()).execute(any(), any());
         }
 
         @Test
@@ -91,10 +86,8 @@ class DeviceShutdownSupportTest {
 
             var result = deviceShutdownSupport.shutdown(machine, dryerStatus("pause", true));
 
-            assertThat(result).isEqualTo(ShutdownResult.STOPPED);
-            var captor = ArgumentCaptor.forClass(SmartThingsCommandReqDto.class);
-            then(sendDeviceCommandService).should(times(1)).execute(eq("device-1"), captor.capture());
-            assertThat(captor.getValue().commands().get(0).capability()).isEqualTo("dryerOperatingState");
+            assertThat(result).isEqualTo(ShutdownResult.SKIPPED_UNKNOWN);
+            then(sendDeviceCommandService).should(never()).execute(any(), any());
         }
 
         @Test
@@ -104,13 +97,8 @@ class DeviceShutdownSupportTest {
 
             var result = deviceShutdownSupport.shutdown(machine, washerStatus("run", false));
 
-            assertThat(result).isEqualTo(ShutdownResult.STOPPED);
-            var captor = ArgumentCaptor.forClass(SmartThingsCommandReqDto.class);
-            then(sendDeviceCommandService).should(times(1)).execute(eq("device-1"), captor.capture());
-            var command = captor.getValue().commands().get(0);
-            assertThat(command.capability()).isEqualTo("washerOperatingState");
-            assertThat(command.command()).isEqualTo("setMachineState");
-            assertThat(command.arguments()).containsExactly("stop");
+            assertThat(result).isEqualTo(ShutdownResult.SKIPPED_UNKNOWN);
+            then(sendDeviceCommandService).should(never()).execute(any(), any());
         }
     }
 

--- a/src/test/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupportTest.java
@@ -69,35 +69,35 @@ class DeviceShutdownSupportTest {
     class OperatingMachine {
 
         @Test
-        @DisplayName("세탁기가 run이고 원격 제어가 켜져 있으면 setMachineState stop으로 안전 정지하고 전원을 차단하지 않는다")
-        void shouldSafelyStopWasher_WhenRunningAndRemoteEnabled() {
+        @DisplayName("세탁기가 run이면 종료 명령을 보내지 않고 작동 중 스킵을 반환한다")
+        void shouldSkipWasherShutdown_WhenRunningAndRemoteEnabled() {
             var machine = machine(MachineType.WASHER);
 
             var result = deviceShutdownSupport.shutdown(machine, washerStatus("run", true));
 
-            assertThat(result).isEqualTo(ShutdownResult.SKIPPED_UNKNOWN);
+            assertThat(result).isEqualTo(ShutdownResult.SKIPPED_OPERATING);
             then(sendDeviceCommandService).should(never()).execute(any(), any());
         }
 
         @Test
-        @DisplayName("건조기가 pause이고 원격 제어가 켜져 있으면 dryerOperatingState로 안전 정지한다")
-        void shouldSafelyStopDryer_WhenPausedAndRemoteEnabled() {
+        @DisplayName("건조기가 pause이면 종료 명령을 보내지 않고 작동 중 스킵을 반환한다")
+        void shouldSkipDryerShutdown_WhenPausedAndRemoteEnabled() {
             var machine = machine(MachineType.DRYER);
 
             var result = deviceShutdownSupport.shutdown(machine, dryerStatus("pause", true));
 
-            assertThat(result).isEqualTo(ShutdownResult.SKIPPED_UNKNOWN);
+            assertThat(result).isEqualTo(ShutdownResult.SKIPPED_OPERATING);
             then(sendDeviceCommandService).should(never()).execute(any(), any());
         }
 
         @Test
-        @DisplayName("작동 중이고 원격 제어가 꺼져 있어도 stop은 원격 제어 없이 동작하므로 정지를 시도하고 STOPPED를 반환한다")
-        void shouldStop_WhenRunningEvenIfRemoteDisabled() {
+        @DisplayName("작동 중이고 원격 제어가 꺼져 있어도 종료 명령을 보내지 않고 작동 중 스킵을 반환한다")
+        void shouldSkipShutdown_WhenRunningEvenIfRemoteDisabled() {
             var machine = machine(MachineType.WASHER);
 
             var result = deviceShutdownSupport.shutdown(machine, washerStatus("run", false));
 
-            assertThat(result).isEqualTo(ShutdownResult.SKIPPED_UNKNOWN);
+            assertThat(result).isEqualTo(ShutdownResult.SKIPPED_OPERATING);
             then(sendDeviceCommandService).should(never()).execute(any(), any());
         }
     }


### PR DESCRIPTION
## 개요

  작동 중인 세탁기/건조기가 서버 배치나 테스트 러너에 의해 예기치 않게 종료될 수 있는 경로를 차단했습니다.

  ## 본문

  - `DeviceShutdownSupport`가 `run` 또는 `pause` 상태의 기기를 발견해도 `stopWasher()` / `stopDryer()` 명령을 보내지 않도록 변경했습니다.
  - 활성 예약 조회가 일시적으로 꼬이거나 완료 상태가 오판된 경우에도 유휴 종료 배치가 작동 중인 기기를 멈추지 않고 로그만 남기도록 했습니다.
  - `TestDeviceCycleRunner`가 서버 부팅 시 기본 실행되지 않도록 `smartthings.test-cycle.enabled=true` 조건을 추가했습니다.
  - 작동 중인 기기에는 SmartThings 종료 명령을 보내지 않는 방향으로 `DeviceShutdownSupportTest`를 수정했습니다.

  검증:
  - `.\gradlew test`
  - `.\gradlew spotlessCheck`