### PR TITLE
[global] 어드민 요청 CORS 오류 수정

### DIFF
--- a/src/main/java/team/washer/server/v2/global/security/config/CorsConfig.java
+++ b/src/main/java/team/washer/server/v2/global/security/config/CorsConfig.java
@@ -25,11 +25,15 @@ public class CorsConfig {
     @Bean
     public CorsConfigurationSource configure() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(corsEnvironment.getAllowedOrigins());
+        if (corsEnvironment.getAllowedOriginPatterns().isEmpty()) {
+            configuration.setAllowedOrigins(corsEnvironment.getAllowedOrigins());
+        } else {
+            configuration.setAllowedOriginPatterns(corsEnvironment.getAllowedOriginPatterns());
+        }
         configuration.setAllowedMethods(
                 Arrays.stream(HttpMethod.values()).map(HttpMethod::name).collect(Collectors.toList()));
         configuration.addAllowedHeader("*");
-        configuration.setAllowCredentials(true);
+        configuration.setAllowCredentials(corsEnvironment.isAllowCredentials());
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);

--- a/src/main/java/team/washer/server/v2/global/security/config/CorsConfig.java
+++ b/src/main/java/team/washer/server/v2/global/security/config/CorsConfig.java
@@ -1,6 +1,7 @@
 package team.washer.server.v2.global.security.config;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -16,6 +17,8 @@ import team.washer.server.v2.global.security.data.CorsEnvironment;
 @Configuration
 @EnableConfigurationProperties(CorsEnvironment.class)
 public class CorsConfig {
+    private static final String ALL_ORIGINS = "*";
+
     private final CorsEnvironment corsEnvironment;
 
     public CorsConfig(CorsEnvironment corsEnvironment) {
@@ -25,10 +28,14 @@ public class CorsConfig {
     @Bean
     public CorsConfigurationSource configure() {
         CorsConfiguration configuration = new CorsConfiguration();
-        if (corsEnvironment.getAllowedOriginPatterns().isEmpty()) {
-            configuration.setAllowedOrigins(corsEnvironment.getAllowedOrigins());
+        final var allowedOriginPatterns = emptyIfNull(corsEnvironment.getAllowedOriginPatterns());
+        final var allowedOrigins = emptyIfNull(corsEnvironment.getAllowedOrigins());
+
+        if (allowedOriginPatterns.isEmpty()) {
+            validateAllowedOrigins(allowedOrigins);
+            configuration.setAllowedOrigins(allowedOrigins);
         } else {
-            configuration.setAllowedOriginPatterns(corsEnvironment.getAllowedOriginPatterns());
+            configuration.setAllowedOriginPatterns(allowedOriginPatterns);
         }
         configuration.setAllowedMethods(
                 Arrays.stream(HttpMethod.values()).map(HttpMethod::name).collect(Collectors.toList()));
@@ -38,5 +45,15 @@ public class CorsConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    private void validateAllowedOrigins(List<String> allowedOrigins) {
+        if (corsEnvironment.isAllowCredentials() && allowedOrigins.contains(ALL_ORIGINS)) {
+            throw new IllegalStateException("인증 정보를 허용할 때는 모든 Origin을 허용할 수 없습니다.");
+        }
+    }
+
+    private static List<String> emptyIfNull(List<String> values) {
+        return values == null ? List.of() : values;
     }
 }

--- a/src/main/java/team/washer/server/v2/global/security/data/CorsEnvironment.java
+++ b/src/main/java/team/washer/server/v2/global/security/data/CorsEnvironment.java
@@ -7,6 +7,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "spring.security.cors")
 public class CorsEnvironment {
     private List<String> allowedOrigins = List.of("*");
+    private List<String> allowedOriginPatterns = List.of();
+    private boolean allowCredentials;
 
     public List<String> getAllowedOrigins() {
         return allowedOrigins;
@@ -14,5 +16,21 @@ public class CorsEnvironment {
 
     public void setAllowedOrigins(List<String> allowedOrigins) {
         this.allowedOrigins = allowedOrigins;
+    }
+
+    public List<String> getAllowedOriginPatterns() {
+        return allowedOriginPatterns;
+    }
+
+    public void setAllowedOriginPatterns(List<String> allowedOriginPatterns) {
+        this.allowedOriginPatterns = allowedOriginPatterns;
+    }
+
+    public boolean isAllowCredentials() {
+        return allowCredentials;
+    }
+
+    public void setAllowCredentials(boolean allowCredentials) {
+        this.allowCredentials = allowCredentials;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,7 @@ spring:
           max-wait: -1ms
   security:
     cors:
+      allow-credentials: false
       allowed-origins:
         - '*'
   docker:

--- a/src/test/java/team/washer/server/v2/global/security/config/CorsConfigTest.java
+++ b/src/test/java/team/washer/server/v2/global/security/config/CorsConfigTest.java
@@ -23,16 +23,16 @@ class CorsConfigTest {
         @Test
         @DisplayName("기본 설정에서 모든 Origin의 POST preflight 요청을 허용한다")
         void it_allows_post_preflight_with_default_origin() {
-            // Given
+            // 준비
             var corsEnvironment = new CorsEnvironment();
             var corsConfigurationSource = (UrlBasedCorsConfigurationSource) new CorsConfig(corsEnvironment).configure();
             var request = new MockHttpServletRequest(HttpMethod.OPTIONS.name(), "/api/v2/admin/machines");
             request.addHeader("Origin", "http://localhost:3000");
 
-            // When
+            // 실행
             var corsConfiguration = corsConfigurationSource.getCorsConfiguration(request);
 
-            // Then
+            // 검증
             assertThat(corsConfiguration).isNotNull();
             assertThat(corsConfiguration.getAllowCredentials()).isFalse();
             assertThat(corsConfiguration.checkOrigin("http://localhost:3000")).isEqualTo("*");
@@ -44,7 +44,7 @@ class CorsConfigTest {
         @Test
         @DisplayName("Origin 패턴이 설정되면 명시된 패턴을 사용한다")
         void it_uses_allowed_origin_patterns() {
-            // Given
+            // 준비
             var corsEnvironment = new CorsEnvironment();
             corsEnvironment.setAllowedOriginPatterns(List.of("http://localhost:*"));
             corsEnvironment.setAllowCredentials(true);
@@ -52,14 +52,39 @@ class CorsConfigTest {
             var request = new MockHttpServletRequest(HttpMethod.OPTIONS.name(), "/api/v2/admin/machines");
             request.addHeader("Origin", "http://localhost:3000");
 
-            // When
+            // 실행
             var corsConfiguration = corsConfigurationSource.getCorsConfiguration(request);
 
-            // Then
+            // 검증
             assertThat(corsConfiguration).isNotNull();
             assertThat(corsConfiguration.getAllowCredentials()).isTrue();
             assertThat(corsConfiguration.getAllowedOriginPatterns()).containsExactly("http://localhost:*");
             assertThat(corsConfiguration.checkOrigin("http://localhost:3000")).isEqualTo("http://localhost:3000");
+        }
+
+        @Test
+        @DisplayName("Origin 설정이 null이어도 예외가 발생하지 않는다")
+        void it_handles_null_origin_properties() {
+            // 준비
+            var corsEnvironment = new CorsEnvironment();
+            corsEnvironment.setAllowedOrigins(null);
+            corsEnvironment.setAllowedOriginPatterns(null);
+
+            // 실행 및 검증
+            assertThatCode(() -> new CorsConfig(corsEnvironment).configure()).doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("인증 정보 허용 시 모든 Origin을 allowed-origins로 설정하면 예외가 발생한다")
+        void it_rejects_all_origins_with_credentials() {
+            // 준비
+            var corsEnvironment = new CorsEnvironment();
+            corsEnvironment.setAllowCredentials(true);
+            corsEnvironment.setAllowedOrigins(List.of("*"));
+
+            // 실행 및 검증
+            assertThatThrownBy(() -> new CorsConfig(corsEnvironment).configure())
+                    .isInstanceOf(IllegalStateException.class).hasMessage("인증 정보를 허용할 때는 모든 Origin을 허용할 수 없습니다.");
         }
     }
 }

--- a/src/test/java/team/washer/server/v2/global/security/config/CorsConfigTest.java
+++ b/src/test/java/team/washer/server/v2/global/security/config/CorsConfigTest.java
@@ -1,0 +1,65 @@
+package team.washer.server.v2.global.security.config;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import team.washer.server.v2.global.security.data.CorsEnvironment;
+
+@DisplayName("CorsConfig 클래스의")
+class CorsConfigTest {
+
+    @Nested
+    @DisplayName("configure 메서드는")
+    class Describe_configure {
+
+        @Test
+        @DisplayName("기본 설정에서 모든 Origin의 POST preflight 요청을 허용한다")
+        void it_allows_post_preflight_with_default_origin() {
+            // Given
+            var corsEnvironment = new CorsEnvironment();
+            var corsConfigurationSource = (UrlBasedCorsConfigurationSource) new CorsConfig(corsEnvironment).configure();
+            var request = new MockHttpServletRequest(HttpMethod.OPTIONS.name(), "/api/v2/admin/machines");
+            request.addHeader("Origin", "http://localhost:3000");
+
+            // When
+            var corsConfiguration = corsConfigurationSource.getCorsConfiguration(request);
+
+            // Then
+            assertThat(corsConfiguration).isNotNull();
+            assertThat(corsConfiguration.getAllowCredentials()).isFalse();
+            assertThat(corsConfiguration.checkOrigin("http://localhost:3000")).isEqualTo("*");
+            assertThat(corsConfiguration.checkHttpMethod(HttpMethod.POST)).contains(HttpMethod.POST);
+            assertThat(corsConfiguration.checkHeaders(List.of("authorization", "content-type")))
+                    .containsExactly("authorization", "content-type");
+        }
+
+        @Test
+        @DisplayName("Origin 패턴이 설정되면 명시된 패턴을 사용한다")
+        void it_uses_allowed_origin_patterns() {
+            // Given
+            var corsEnvironment = new CorsEnvironment();
+            corsEnvironment.setAllowedOriginPatterns(List.of("http://localhost:*"));
+            corsEnvironment.setAllowCredentials(true);
+            var corsConfigurationSource = (UrlBasedCorsConfigurationSource) new CorsConfig(corsEnvironment).configure();
+            var request = new MockHttpServletRequest(HttpMethod.OPTIONS.name(), "/api/v2/admin/machines");
+            request.addHeader("Origin", "http://localhost:3000");
+
+            // When
+            var corsConfiguration = corsConfigurationSource.getCorsConfiguration(request);
+
+            // Then
+            assertThat(corsConfiguration).isNotNull();
+            assertThat(corsConfiguration.getAllowCredentials()).isTrue();
+            assertThat(corsConfiguration.getAllowedOriginPatterns()).containsExactly("http://localhost:*");
+            assertThat(corsConfiguration.checkOrigin("http://localhost:3000")).isEqualTo("http://localhost:3000");
+        }
+    }
+}


### PR DESCRIPTION
## 개요

  `CORS` 설정의 인증 정보 허용 기본값을 조정하여 `POST`, `PUT` 등 `preflight` 요청에서 발생하던 `403 Invalid CORS request` 문제를 수정했습니다.

  ## 본문

  `CorsConfig`에서 `allowCredentials` 값을 설정 프로퍼티로 제어하도록 변경했습니다. 기본 설정은 `false`로 두어 `allowed-origins: '*'`와 충돌하지 않도록 했습니다.

  `CorsEnvironment`에 `allowedOriginPatterns`와 `allowCredentials` 설정을 추가했습니다. 쿠키 기반 인증처럼 인증 정보 포함 요청이 필요한 환경에서는 명시적인 `Origin` 패
  턴과 함께 사용할 수 있습니다.

  `CorsConfigTest`를 추가하여 기본 설정에서 `POST preflight` 요청이 허용되는지 검증하고, `allowed-origin-patterns` 설정이 적용되는지도 확인했습니다.
