### PR TITLE
[reservation] 완료 경계 정지 상태 오판 방지

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
@@ -3,6 +3,7 @@ package team.washer.server.v2.domain.reservation.service.impl;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -10,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.notification.support.ReservationNotificationSupport;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
@@ -35,6 +37,7 @@ import team.washer.server.v2.global.util.DateTimeUtil;
 public class ReservationLifecycleProcessor {
 
     private static final long COMPLETION_EARLY_LOG_TOLERANCE_MINUTES = 2;
+    private static final long COMPLETION_BOUNDARY_GRACE_MINUTES = 5;
     private static final long MAX_REASONABLE_CYCLE_MINUTES = 240;
 
     private final ReservationRepository reservationRepository;
@@ -120,22 +123,17 @@ public class ReservationLifecycleProcessor {
                 }
                 logEarlyCompletionAccepted(reservation, completionTime.get());
             }
-            reservation.complete();
-            machine.markAsAvailable();
-            reservationRepository.save(reservation);
-            machineRepository.save(machine);
+            completeReservation(reservation, machine, completionTime.get(), "smartthings_completed");
+            return;
+        }
 
-            reservationNotificationSupport.sendCompletion(reservation.getUser(), machine);
+        var stoppedNearCompletionTime = getStoppedNearCompletionTime(reservation, status, isWasher);
+        if (stoppedNearCompletionTime.isPresent()) {
+            processStoppedNearCompletion(reservation, machine, stoppedNearCompletionTime.get());
+            return;
+        }
 
-            log.info(
-                    "Reservation completed reservationId={} userId={} machineId={} machineName={} completionTime={} expectedCompletionTime={}",
-                    reservation.getId(),
-                    reservation.getUser().getId(),
-                    machine.getId(),
-                    machine.getName(),
-                    completionTime.get(),
-                    reservation.getExpectedCompletionTime());
-        } else if (machineStateDetectionSupport.isInterrupted(status, isWasher)) {
+        if (machineStateDetectionSupport.isInterrupted(status, isWasher)) {
             // 사이클 단계 전환 중 순간적으로 보고되는 정지를 진짜 중단으로 오판하지 않도록, 연속으로 중단이
             // 감지될 때만 취소를 확정한다.
             reservation.incrementInterruptionCount();
@@ -199,6 +197,84 @@ public class ReservationLifecycleProcessor {
                 reservationRepository.save(reservation);
             }
         }
+    }
+
+    private void processStoppedNearCompletion(Reservation reservation, Machine machine, LocalDateTime completionTime) {
+        if (!completionTime.isAfter(DateTimeUtil.nowInKorea())) {
+            completeReservation(reservation, machine, completionTime, "stopped_near_completion");
+            return;
+        }
+
+        var changed = false;
+        if (reservation.getInterruptionCount() > 0) {
+            reservation.clearInterruptionCount();
+            changed = true;
+        }
+
+        var current = reservation.getExpectedCompletionTime();
+        if (current == null || Math.abs(Duration.between(current, completionTime).toSeconds()) >= 60) {
+            reservation.updateExpectedCompletionTime(completionTime);
+            changed = true;
+        }
+
+        if (changed) {
+            reservationRepository.save(reservation);
+        }
+
+        log.info(
+                "completion deferred reason=stopped_near_completion reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
+                reservation.getId(),
+                reservation.getStartTime(),
+                reservation.getExpectedCompletionTime(),
+                completionTime);
+    }
+
+    private Optional<LocalDateTime> getStoppedNearCompletionTime(Reservation reservation,
+            SmartThingsDeviceStatusResDto status,
+            boolean isWasher) {
+        var machineState = getOperatingState(status, isWasher);
+        if (!"stop".equalsIgnoreCase(machineState)) {
+            return Optional.empty();
+        }
+
+        var completionTime = DateTimeUtil.parseAndConvertToKoreaTime(getCompletionTime(status, isWasher));
+        if (completionTime == null) {
+            return Optional.empty();
+        }
+
+        var startTime = reservation.getStartTime();
+        if (startTime != null && completionTime.isBefore(startTime)) {
+            return Optional.empty();
+        }
+
+        var secondsFromNow = Math.abs(Duration.between(DateTimeUtil.nowInKorea(), completionTime).toSeconds());
+        if (secondsFromNow > Duration.ofMinutes(COMPLETION_BOUNDARY_GRACE_MINUTES).toSeconds()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(completionTime);
+    }
+
+    private void completeReservation(Reservation reservation,
+            Machine machine,
+            LocalDateTime completionTime,
+            String reason) {
+        reservation.complete();
+        machine.markAsAvailable();
+        reservationRepository.save(reservation);
+        machineRepository.save(machine);
+
+        reservationNotificationSupport.sendCompletion(reservation.getUser(), machine);
+
+        log.info(
+                "Reservation completed reason={} reservationId={} userId={} machineId={} machineName={} completionTime={} expectedCompletionTime={}",
+                reason,
+                reservation.getId(),
+                reservation.getUser().getId(),
+                machine.getId(),
+                machine.getName(),
+                completionTime,
+                reservation.getExpectedCompletionTime());
     }
 
     private boolean isStaleCompletion(Reservation reservation,
@@ -288,6 +364,13 @@ public class ReservationLifecycleProcessor {
             return null;
         }
         return isWasher ? status.getWasherCompletionTime() : status.getDryerCompletionTime();
+    }
+
+    private String getOperatingState(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        if (status == null) {
+            return null;
+        }
+        return isWasher ? status.getWasherOperatingState() : status.getDryerOperatingState();
     }
 
     private String getOperatingStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
@@ -89,6 +89,28 @@ class ReservationLifecycleProcessorTest {
         return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
     }
 
+    private SmartThingsDeviceStatusResDto buildWasherStoppedStatus(String jobState, String completionTime) {
+        var machineStateAttr = new SmartThingsDeviceStatusResDto.AttributeState("stop", null, null);
+        var jobStateAttr = new SmartThingsDeviceStatusResDto.AttributeState(jobState, null, null);
+        var completionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState(completionTime, null, null);
+        var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(machineStateAttr,
+                jobStateAttr,
+                completionTimeAttr);
+        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null, null);
+        return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
+    }
+
+    private SmartThingsDeviceStatusResDto buildDryerStoppedStatus(String jobState, String completionTime) {
+        var machineStateAttr = new SmartThingsDeviceStatusResDto.AttributeState("stop", null, null);
+        var jobStateAttr = new SmartThingsDeviceStatusResDto.AttributeState(jobState, null, null);
+        var completionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState(completionTime, null, null);
+        var dryerOpState = new SmartThingsDeviceStatusResDto.DryerOperatingState(machineStateAttr,
+                jobStateAttr,
+                completionTimeAttr);
+        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(null, dryerOpState, null, null);
+        return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
+    }
+
     private String isoUtc(LocalDateTime koreaTime) {
         return koreaTime.atZone(KOREA_ZONE).withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime().toString() + "Z";
     }
@@ -323,6 +345,89 @@ class ReservationLifecycleProcessorTest {
             verify(reservation, times(1)).updateExpectedCompletionTime(any(LocalDateTime.class));
             verify(reservationRepository, times(1)).save(reservation);
             verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
+        }
+
+        @Test
+        @DisplayName("완료 예정 시각 근처에서 정지 상태가 감지되면 중단 취소를 보류한다")
+        void shouldDeferInterruption_WhenStoppedNearFutureCompletionTime() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var completionTime = nowKst.plusMinutes(3);
+            var deviceStatus = buildWasherStoppedStatus("spin", isoUtc(completionTime));
+            givenRunningReservation();
+            when(machine.isWasher()).thenReturn(true);
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(40));
+            when(reservation.getExpectedCompletionTime()).thenReturn(completionTime);
+            when(reservation.getInterruptionCount()).thenReturn(1);
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(Optional.empty());
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, times(1)).clearInterruptionCount();
+            verify(reservationRepository, times(1)).save(reservation);
+            verify(reservation, never()).incrementInterruptionCount();
+            verify(reservation, never()).cancel();
+            verify(reservationNotificationSupport, never()).sendInterruption(any(), any());
+            verify(machineStateDetectionSupport, never()).isInterrupted(any(), anyBoolean());
+        }
+
+        @Test
+        @DisplayName("완료 예정 시각 근처 정지 상태에서 완료 시각이 지나면 완료 처리한다")
+        void shouldComplete_WhenStoppedNearCompletionTimeAndTimePassed() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var completionTime = nowKst.minusMinutes(1);
+            var deviceStatus = buildWasherStoppedStatus("spin", isoUtc(completionTime));
+            givenRunningReservation();
+            when(machine.isWasher()).thenReturn(true);
+            when(reservation.getUser()).thenReturn(user);
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(40));
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(Optional.empty());
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, times(1)).complete();
+            verify(machine, times(1)).markAsAvailable();
+            verify(reservationRepository, times(1)).save(reservation);
+            verify(machineRepository, times(1)).save(machine);
+            verify(reservationNotificationSupport, times(1)).sendCompletion(user, machine);
+            verify(reservation, never()).cancel();
+            verify(reservationNotificationSupport, never()).sendInterruption(any(), any());
+            verify(machineStateDetectionSupport, never()).isInterrupted(any(), anyBoolean());
+        }
+
+        @Test
+        @DisplayName("건조기도 완료 예정 시각 근처 정지 상태에서 완료 시각이 지나면 완료 처리한다")
+        void shouldCompleteDryer_WhenStoppedNearCompletionTimeAndTimePassed() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var completionTime = nowKst.minusMinutes(1);
+            var deviceStatus = buildDryerStoppedStatus("drying", isoUtc(completionTime));
+            givenRunningReservation();
+            when(machine.isWasher()).thenReturn(false);
+            when(reservation.getUser()).thenReturn(user);
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(40));
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(Optional.empty());
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, times(1)).complete();
+            verify(machine, times(1)).markAsAvailable();
+            verify(reservationRepository, times(1)).save(reservation);
+            verify(machineRepository, times(1)).save(machine);
+            verify(reservationNotificationSupport, times(1)).sendCompletion(user, machine);
+            verify(reservation, never()).cancel();
+            verify(reservationNotificationSupport, never()).sendInterruption(any(), any());
+            verify(machineStateDetectionSupport, never()).isInterrupted(any(), anyBoolean());
         }
 
         @Test


### PR DESCRIPTION
## 개요

  `SmartThings`에서 완료 예정 시각 근처에 `machineState=stop` 상태가 먼저 감지될 때 예약이 `CANCELLED`로 오판되는 문제를 완화했습니다.

  ## 본문

  - `ReservationLifecycleProcessor`에서 완료 판정 실패 후 바로 중단 판정으로 넘어가기 전에 완료 예정 시각 근처의 정지 상태를 별도로 처리하도록 보강했습니다.
  - `completionTime`이 현재 시각 기준 5분 이내이고 기기가 `stop` 상태이면 중단 카운트를 누적하지 않고 완료 경계 상태로 보류합니다.
  - 완료 예정 시각이 이미 지난 경우에는 `jobState`가 `spin`, `drying`처럼 남아 있어도 완료 처리로 회복하도록 했습니다.
  - 세탁기와 건조기 모두 동일한 완료 경계 보정 경로를 타도록 테스트를 추가했습니다.

  검증:
  - `.\gradlew test --tests "team.washer.server.v2.domain.reservation.service.ReservationLifecycleProcessorTest" --tests
  "team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupportTest"`
  - `.\gradlew test`