### PR TITLE
fix(notification): 시작 알림 조사 중복 제거

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/notification/enums/NotificationType.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/enums/NotificationType.java
@@ -17,7 +17,7 @@ public enum NotificationType {
                                     "예약 자동 취소 알림",
                                     "{machineName}의 예약이 시간 초과로 자동 취소되었습니다. 패널티가 부과되었습니다."), PAUSE_TIMEOUT("일시정지 초과 알림",
                                             "{machineName}의 {action} 일시정지가 10분 이상 지속되어 예약이 패널티 없이 취소되었습니다."), STARTED(
-                                                    "세탁 시작 알림",
+                                                    "시작 알림",
                                                     "{machineName}의 {action} 시작되었습니다.\n예상 완료 시간: {completionTime}"), TIMEOUT_WARNING(
                                                             "예약 취소 경고",
                                                             "{machineName}의 예약이 시간 초과로 자동 취소되었습니다.\n첫 번째라 패널티는 없습니다. 다음부터는 패널티가 부과됩니다."), CANCELLATION_BLOCKED(

--- a/src/main/java/team/washer/server/v2/domain/notification/enums/NotificationType.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/enums/NotificationType.java
@@ -18,7 +18,7 @@ public enum NotificationType {
                                     "{machineName}의 예약이 시간 초과로 자동 취소되었습니다. 패널티가 부과되었습니다."), PAUSE_TIMEOUT("일시정지 초과 알림",
                                             "{machineName}의 {action} 일시정지가 10분 이상 지속되어 예약이 패널티 없이 취소되었습니다."), STARTED(
                                                     "세탁 시작 알림",
-                                                    "{machineName}의 {action}이 시작되었습니다.\n예상 완료 시간: {completionTime}"), TIMEOUT_WARNING(
+                                                    "{machineName}의 {action} 시작되었습니다.\n예상 완료 시간: {completionTime}"), TIMEOUT_WARNING(
                                                             "예약 취소 경고",
                                                             "{machineName}의 예약이 시간 초과로 자동 취소되었습니다.\n첫 번째라 패널티는 없습니다. 다음부터는 패널티가 부과됩니다."), CANCELLATION_BLOCKED(
                                                                     "예약 차단 알림",

--- a/src/test/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupportTest.java
@@ -3,6 +3,8 @@ package team.washer.server.v2.domain.notification.support;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -119,6 +121,30 @@ class ReservationNotificationSupportTest {
                 // Then
                 then(notificationRepository).should(times(1)).deleteOldestByUserExceedingLimit(user, 30);
             }
+        }
+    }
+
+    @Nested
+    @DisplayName("시작 알림 메시지는")
+    class Describe_started_notification_message {
+
+        @Test
+        @DisplayName("세탁 시작 문구에 조사가 중복되지 않아야 한다")
+        void it_does_not_duplicate_particle_for_washer_started_message() {
+            // Given
+            User user = createUser();
+            Machine machine = createMachine();
+            LocalDateTime expectedCompletionTime = LocalDateTime.of(2026, 7, 4, 14, 30);
+            given(notificationRepository.save(any(Notification.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+            given(notificationRepository.countByUser(user)).willReturn(1L);
+
+            // When
+            reservationNotificationSupport.sendStarted(user, machine, expectedCompletionTime);
+
+            // Then
+            then(fcmNotificationSupport).should(times(1))
+                    .send(user, "세탁기 시작 알림", "WASHER-3F-L1의 세탁이 시작되었습니다.\n예상 완료 시간: 14:30");
         }
     }
 

--- a/src/test/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupportTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -48,6 +50,11 @@ class ReservationNotificationSupportTest {
 
     private Machine createMachine() {
         return Machine.builder().name("WASHER-3F-L1").type(MachineType.WASHER).floor(3).build();
+    }
+
+    private Machine createMachine(final MachineType machineType) {
+        final String machineName = machineType == MachineType.WASHER ? "WASHER-3F-L1" : "DRYER-3F-R1";
+        return Machine.builder().name(machineName).type(machineType).floor(3).build();
     }
 
     @Nested
@@ -128,12 +135,13 @@ class ReservationNotificationSupportTest {
     @DisplayName("시작 알림 메시지는")
     class Describe_started_notification_message {
 
-        @Test
-        @DisplayName("세탁 시작 문구에 조사가 중복되지 않아야 한다")
-        void it_does_not_duplicate_particle_for_washer_started_message() {
+        @ParameterizedTest
+        @EnumSource(MachineType.class)
+        @DisplayName("세탁/건조 시작 문구에 조사가 중복되지 않아야 한다")
+        void it_does_not_duplicate_particle_for_started_message(final MachineType machineType) {
             // Given
             User user = createUser();
-            Machine machine = createMachine();
+            Machine machine = createMachine(machineType);
             LocalDateTime expectedCompletionTime = LocalDateTime.of(2026, 7, 4, 14, 30);
             given(notificationRepository.save(any(Notification.class)))
                     .willAnswer(invocation -> invocation.getArgument(0));
@@ -143,8 +151,10 @@ class ReservationNotificationSupportTest {
             reservationNotificationSupport.sendStarted(user, machine, expectedCompletionTime);
 
             // Then
+            final String expectedBody = machine.getName() + "의 " + machineType.getActionNoun()
+                    + " 시작되었습니다.\n예상 완료 시간: 14:30";
             then(fcmNotificationSupport).should(times(1))
-                    .send(user, "세탁기 시작 알림", "WASHER-3F-L1의 세탁이 시작되었습니다.\n예상 완료 시간: 14:30");
+                    .send(user, machineType.getDescription() + " 시작 알림", expectedBody);
         }
     }
 


### PR DESCRIPTION
## 작업 내용

  - 세탁/건조 시작 알림 메시지에서 조사가 중복되는 문제 수정
  - 시작 알림 FCM 본문 회귀 테스트 추가

  ## 수정 이유

  `MachineType.actionNoun` 값이 `세탁이`, `건조가`처럼 조사를 포함하고 있는데, 시작 알림 템플릿에서 다시 `이`를 붙여 `세탁이이 시작되었습니다` 형태로 발송되고 있었습니다.

  ## 테스트

  - `.\gradlew test`