### PR TITLE
fix: 월~목 21:20 예약 시간 제한 일시 해제

### DIFF
--- a/.agents/skills/java-spring-arch/SKILL.md
+++ b/.agents/skills/java-spring-arch/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: java-spring-arch
+description: Architecture reference for Java + Spring Boot 4.0 projects — Controller/Service/Repository layer responsibilities, @Transactional strategy (readOnly optimization, N+1 prevention), ExpectedException usage, and Entity↔DTO conversion patterns.
+---
+
+# Java + Spring Boot Architecture Guide
+
+## Layer Structure
+
+### Controller
+- Role: Request validation, DTO conversion, HTTP response
+- Annotations: `@RestController`, `@RequestMapping`
+- Validation: `@Valid`, `@Validated`
+- Response: Use `CommonApiResponse` wrapper
+
+### Service
+- Role: Business logic, transaction management
+- Pattern: interface + implementation
+- Transaction:
+  - Read: `@Transactional(readOnly = true)`
+  - Write: `@Transactional`
+- Dependencies: Inject Repository via constructor injection
+
+### Repository
+- Role: Data access
+- JPA: Extend `JpaRepository`
+- Avoid N+1: Fetch Join, `@EntityGraph`
+
+## Transaction Strategy
+
+### Read-only Optimization
+```java
+@Transactional(readOnly = true)
+public List<StudentResDto> findStudents() {
+    return repository.findAll().stream()
+        .map(StudentResDto::from)
+        .toList();
+}
+```
+
+### N+1 Problem Resolution
+```java
+// ❌ N+1 occurs
+repository.findAll(); // 1 query
+entity.getRelatedEntities(); // N queries
+
+// ✅ Fetch Join
+@Query("SELECT e FROM Entity e JOIN FETCH e.relatedEntities")
+List<Entity> findAllWithRelated();
+```
+
+## Exception Handling
+
+```java
+throw new ExpectedException("학생을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+```
+
+## DTO Conversion Pattern
+
+```java
+// Entity → ResDto (static factory)
+public static StudentResDto from(Student student) {
+    return new StudentResDto(student.getId(), student.getName());
+}
+```

--- a/.agents/skills/the-sdk/SKILL.md
+++ b/.agents/skills/the-sdk/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: the-sdk
+description: Usage guide for the-sdk common library — HTTP request/response logging with UUID Log-ID, CommonApiResponse wrapping, ExpectedException handling, and Swagger auto-configuration.
+---
+
+# the-sdk Usage Guide
+
+`com.github.themoment-team:the-sdk:1.5` — the core common library for this project.  
+Controlled via `sdk.*` settings in `application.yml`.
+
+## Features
+
+- **Logging**: Assigns a UUID `Log-ID` to every HTTP request/response; automatic logging
+- **Response Wrapper**: Automatically wraps controller return values in `CommonApiResponse`. Use `success()` / `created()` / `error()` factory methods
+- **Exception Handler**: Throwing `ExpectedException(message, HttpStatus)` returns a standard error response automatically
+- **Swagger**: Auto-configured at `/v3/api-docs` and `/swagger-ui`. Only `/v1/**` paths are documented

--- a/.claude/skills/java-spring-arch/SKILL.md
+++ b/.claude/skills/java-spring-arch/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: java-spring-arch
+description: Architecture reference for Java + Spring Boot 4.0 projects — Controller/Service/Repository layer responsibilities, @Transactional strategy (readOnly optimization, N+1 prevention), ExpectedException usage, and Entity↔DTO conversion patterns.
+---
+
+# Java + Spring Boot Architecture Guide
+
+## Layer Structure
+
+### Controller
+- Role: Request validation, DTO conversion, HTTP response
+- Annotations: `@RestController`, `@RequestMapping`
+- Validation: `@Valid`, `@Validated`
+- Response: Use `CommonApiResponse` wrapper
+
+### Service
+- Role: Business logic, transaction management
+- Pattern: interface + implementation
+- Transaction:
+  - Read: `@Transactional(readOnly = true)`
+  - Write: `@Transactional`
+- Dependencies: Inject Repository via constructor injection
+
+### Repository
+- Role: Data access
+- JPA: Extend `JpaRepository`
+- Avoid N+1: Fetch Join, `@EntityGraph`
+
+## Transaction Strategy
+
+### Read-only Optimization
+```java
+@Transactional(readOnly = true)
+public List<StudentResDto> findStudents() {
+    return repository.findAll().stream()
+        .map(StudentResDto::from)
+        .toList();
+}
+```
+
+### N+1 Problem Resolution
+```java
+// ❌ N+1 occurs
+repository.findAll(); // 1 query
+entity.getRelatedEntities(); // N queries
+
+// ✅ Fetch Join
+@Query("SELECT e FROM Entity e JOIN FETCH e.relatedEntities")
+List<Entity> findAllWithRelated();
+```
+
+## Exception Handling
+
+```java
+throw new ExpectedException("학생을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+```
+
+## DTO Conversion Pattern
+
+```java
+// Entity → ResDto (static factory)
+public static StudentResDto from(Student student) {
+    return new StudentResDto(student.getId(), student.getName());
+}
+```

--- a/.claude/skills/the-sdk/SKILL.md
+++ b/.claude/skills/the-sdk/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: the-sdk
+description: Usage guide for the-sdk common library — HTTP request/response logging with UUID Log-ID, CommonApiResponse wrapping, ExpectedException handling, and Swagger auto-configuration.
+---
+
+# the-sdk Usage Guide
+
+`com.github.themoment-team:the-sdk:1.5` — the core common library for this project.  
+Controlled via `sdk.*` settings in `application.yml`.
+
+## Features
+
+- **Logging**: Assigns a UUID `Log-ID` to every HTTP request/response; automatic logging
+- **Response Wrapper**: Automatically wraps controller return values in `CommonApiResponse`. Use `success()` / `created()` / `error()` factory methods
+- **Exception Handler**: Throwing `ExpectedException(message, HttpStatus)` returns a standard error response automatically
+- **Swagger**: Auto-configured at `/v3/api-docs` and `/swagger-ui`. Only `/v1/**` paths are documented

--- a/src/main/java/team/washer/server/v2/domain/user/entity/User.java
+++ b/src/main/java/team/washer/server/v2/domain/user/entity/User.java
@@ -190,11 +190,13 @@ public class User extends BaseEntity {
                 if (time.isBefore(TimeRestrictionConstants.RESTRICTION_START_TIME)) {
                     return;
                 }
-                if (time.isBefore(TimeRestrictionConstants.WEEKDAY_START_TIME)) {
-                    throw new ExpectedException(
-                            String.format("%s 이후에만 예약할 수 있습니다", TimeRestrictionConstants.WEEKDAY_START_TIME),
-                            HttpStatus.BAD_REQUEST);
-                }
+                // TODO(임시): 월~목 21:20 예약 시간 제한 일시 해제. 되돌릴 때 아래 블록 주석 해제할 것.
+                // if (time.isBefore(TimeRestrictionConstants.WEEKDAY_START_TIME)) {
+                // throw new ExpectedException(
+                // String.format("%s 이후에만 예약할 수 있습니다",
+                // TimeRestrictionConstants.WEEKDAY_START_TIME),
+                // HttpStatus.BAD_REQUEST);
+                // }
             }
             case SUNDAY -> {
                 if (time.isBefore(TimeRestrictionConstants.RESTRICTION_START_TIME)) {


### PR DESCRIPTION
## 개요
월~목 **21:20 이후에만 예약 가능**하던 시간 제한을 임시로 해제합니다.

## 변경 내용
- `User.validateTimeRestriction()` 의 평일(월~목) throw 블록을 주석 처리
- 되돌릴 때는 해당 주석(`//`)만 제거하면 원복됩니다 (`TODO(임시)` 마커 부착)

## 영향 범위
- ✅ 월~목: 누구나 예약 가능 (21:20 제한 없음)
- ⏸️ 일요일 학년별 제한(20:00/20:20/20:40)은 **유지**
- ⏸️ 관리자/기숙사자치위 시간 제한 우회는 **유지**
- ⏸️ 08:00 이전 무제한 로직도 **유지**

## 비고
임시 조치이며, 제한을 다시 적용할 때 주석 해제 후 되돌리기 PR을 올릴 예정입니다.