### PR TITLE
test: 예약 시간 제한 해제로 깨진 평일 21:20 검증 테스트 비활성화

### DIFF
--- a/src/test/java/team/washer/server/v2/domain/user/entity/UserTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/entity/UserTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDateTime;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,7 @@ class UserTest {
         class Context_weekday_user {
 
             @Test
+            @Disabled("임시: 월~목 21:20 예약 시간 제한 해제 기간 동안 비활성화. 제한 복구 시 함께 활성화")
             @DisplayName("21:20 이전이면 예외를 던진다")
             void it_throws_before_2120() {
                 final User user = createUser(1, UserRole.USER);
@@ -76,6 +78,7 @@ class UserTest {
             }
 
             @Test
+            @Disabled("임시: 월~목 21:20 예약 시간 제한 해제 기간 동안 비활성화. 제한 복구 시 함께 활성화")
             @DisplayName("학년과 무관하게 동일한 21:20 기준이 적용된다")
             void it_applies_same_time_regardless_of_grade() {
                 final User grade3 = createUser(3, UserRole.USER);
@@ -203,6 +206,7 @@ class UserTest {
             }
 
             @Test
+            @Disabled("임시: 월~목 21:20 예약 시간 제한 해제 기간 동안 비활성화. 제한 복구 시 함께 활성화")
             @DisplayName("월요일 08:00 정각부터는 제한이 적용되어 예외를 던진다")
             void it_throws_weekday_at_0800() {
                 final User user = createUser(1, UserRole.USER);


### PR DESCRIPTION
## 배경
#87 로 월~목 21:20 예약 시간 제한을 임시 해제하면서, 해당 제한의 예외 발생을 검증하던 `UserTest` 3건이 실패해 **develop CI가 깨진 상태**입니다.

## 실패 테스트
- `21:20 이전이면 예외를 던진다`
- `학년과 무관하게 동일한 21:20 기준이 적용된다`
- `월요일 08:00 정각부터는 제한이 적용되어 예외를 던진다`

## 변경 내용
- 위 3개 테스트에 `@Disabled` 부착 (임시 해제 기간 동안 비활성화)
- 사유 메시지에 '제한 복구 시 함께 활성화' 명시

## 비고
- 임시 조치입니다. 21:20 제한을 다시 켤 때 `User.java` 주석 복구와 함께 이 `@Disabled` 도 제거해야 합니다.
- 일요일 학년별 제한 / 관리자 우회 / 08:00 이전 로직 관련 테스트는 그대로 유지됩니다.