### PR TITLE
[user] 임시 해제한 평일 예약 시간 제한 복구

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/user/entity/User.java
+++ b/src/main/java/team/washer/server/v2/domain/user/entity/User.java
@@ -191,13 +191,11 @@ public class User extends BaseEntity {
                 if (time.isBefore(TimeRestrictionConstants.RESTRICTION_START_TIME)) {
                     return;
                 }
-                // TODO(임시): 월~목 21:20 예약 시간 제한 일시 해제. 되돌릴 때 아래 블록 주석 해제할 것.
-                // if (time.isBefore(TimeRestrictionConstants.WEEKDAY_START_TIME)) {
-                // throw new ExpectedException(
-                // String.format("%s 이후에만 예약할 수 있습니다",
-                // TimeRestrictionConstants.WEEKDAY_START_TIME),
-                // HttpStatus.BAD_REQUEST);
-                // }
+                if (time.isBefore(TimeRestrictionConstants.WEEKDAY_START_TIME)) {
+                    throw new ExpectedException(
+                            String.format("%s 이후에만 예약할 수 있습니다", TimeRestrictionConstants.WEEKDAY_START_TIME),
+                            HttpStatus.BAD_REQUEST);
+                }
             }
             case SUNDAY -> {
                 if (time.isBefore(TimeRestrictionConstants.RESTRICTION_START_TIME)) {

--- a/src/test/java/team/washer/server/v2/domain/user/entity/UserTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/entity/UserTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDateTime;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -49,7 +48,6 @@ class UserTest {
         class Context_weekday_user {
 
             @Test
-            @Disabled("임시: 월~목 21:20 예약 시간 제한 해제 기간 동안 비활성화. 제한 복구 시 함께 활성화")
             @DisplayName("21:20 이전이면 예외를 던진다")
             void it_throws_before_2120() {
                 final User user = createUser(1, UserRole.USER);
@@ -78,7 +76,6 @@ class UserTest {
             }
 
             @Test
-            @Disabled("임시: 월~목 21:20 예약 시간 제한 해제 기간 동안 비활성화. 제한 복구 시 함께 활성화")
             @DisplayName("학년과 무관하게 동일한 21:20 기준이 적용된다")
             void it_applies_same_time_regardless_of_grade() {
                 final User grade3 = createUser(3, UserRole.USER);
@@ -206,7 +203,6 @@ class UserTest {
             }
 
             @Test
-            @Disabled("임시: 월~목 21:20 예약 시간 제한 해제 기간 동안 비활성화. 제한 복구 시 함께 활성화")
             @DisplayName("월요일 08:00 정각부터는 제한이 적용되어 예외를 던진다")
             void it_throws_weekday_at_0800() {
                 final User user = createUser(1, UserRole.USER);


### PR DESCRIPTION
## 개요

`#87` / `#89` 로 임시 해제하였던 월~목 `21:20` 이후 예약 시간 제한을 다시 적용하여 원상 복구하였습니다.

## 본문

`#87` 에서 `User.validateTimeRestriction()` 의 평일(월~목) `throw` 블록을 주석 처리하여 모든 시간대 예약이 가능하도록 임시 해제하였고, `#89` 에서는 해당 제한을 검증하던 `UserTest` 3건을 `@Disabled` 로 비활성화하였습니다.

이번 PR 에서는 임시 조치를 종료하고 원래 규칙을 복구하였습니다.

- `User.java`: 평일 분기의 주석 처리된 `throw new ExpectedException(...)` 블록을 복구하여, `21:20` 이전 예약 시 다시 예외가 발생하도록 되돌렸습니다.
- `UserTest.java`: `21:20` 검증 테스트 3건의 `@Disabled` 애너테이션과 미사용 `import org.junit.jupiter.api.Disabled` 를 제거하여 테스트를 재활성화하였습니다.

일요일 학년별 제한(`20:00` / `20:20` / `20:40`), 관리자·기숙사자치위원회의 시간 제한 우회, `08:00` 이전 무제한 로직은 이번 변경과 무관하게 그대로 유지됩니다.

`spotlessApply` 적용 후 `UserTest` 전체를 실행하여 재활성화된 3건을 포함해 모두 통과함을 확인하였습니다.
