### PR TITLE
fix(smartthings): 무예약 기기 정지 처리

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupport.java
@@ -60,13 +60,14 @@ public class DeviceShutdownSupport {
 
         if (isOperating(machine, status)) {
             log.warn(
-                    "operating device detected without active reservation, skip shutdown machine={} deviceId={} machineState={} switchStatus={} remoteControlEnabled={}",
+                    "operating device detected without active reservation, stop command sent machine={} deviceId={} machineState={} switchStatus={} remoteControlEnabled={}",
                     machine.getName(),
                     machine.getDeviceId(),
                     extractMachineState(machine, status),
                     status.getSwitchStatus(),
                     status.isRemoteControlEnabled());
-            return ShutdownResult.SKIPPED_OPERATING;
+            sendDeviceCommandService.execute(machine.getDeviceId(), createStopCommand(machine));
+            return ShutdownResult.STOPPED;
         }
 
         if ("off".equalsIgnoreCase(status.getSwitchStatus())) {
@@ -87,6 +88,13 @@ public class DeviceShutdownSupport {
     private boolean isOperating(Machine machine, SmartThingsDeviceStatusResDto status) {
         var machineState = extractMachineState(machine, status);
         return "run".equalsIgnoreCase(machineState) || "pause".equalsIgnoreCase(machineState);
+    }
+
+    private SmartThingsCommandReqDto createStopCommand(Machine machine) {
+        if (machine.isWasher()) {
+            return SmartThingsCommandReqDto.stopWasher();
+        }
+        return SmartThingsCommandReqDto.stopDryer();
     }
 
     private String extractMachineState(Machine machine, SmartThingsDeviceStatusResDto status) {

--- a/src/test/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/support/DeviceShutdownSupportTest.java
@@ -65,49 +65,59 @@ class DeviceShutdownSupportTest {
     }
 
     @Nested
-    @DisplayName("작동 중인 기기")
+    @DisplayName("작동 중인 기기는")
     class OperatingMachine {
 
         @Test
-        @DisplayName("세탁기가 run이면 종료 명령을 보내지 않고 작동 중 스킵을 반환한다")
-        void shouldSkipWasherShutdown_WhenRunningAndRemoteEnabled() {
+        @DisplayName("세탁기가 run 상태이면 세탁 정지 명령을 보내야 한다")
+        void shouldStopWasher_WhenRunningAndRemoteEnabled() {
             var machine = machine(MachineType.WASHER);
 
             var result = deviceShutdownSupport.shutdown(machine, washerStatus("run", true));
 
-            assertThat(result).isEqualTo(ShutdownResult.SKIPPED_OPERATING);
-            then(sendDeviceCommandService).should(never()).execute(any(), any());
+            assertThat(result).isEqualTo(ShutdownResult.STOPPED);
+            var captor = ArgumentCaptor.forClass(SmartThingsCommandReqDto.class);
+            then(sendDeviceCommandService).should(times(1)).execute(eq("device-1"), captor.capture());
+            var command = captor.getValue().commands().get(0);
+            assertThat(command.capability()).isEqualTo("washerOperatingState");
+            assertThat(command.command()).isEqualTo("setMachineState");
+            assertThat(command.arguments()).containsExactly("stop");
         }
 
         @Test
-        @DisplayName("건조기가 pause이면 종료 명령을 보내지 않고 작동 중 스킵을 반환한다")
-        void shouldSkipDryerShutdown_WhenPausedAndRemoteEnabled() {
+        @DisplayName("건조기가 pause 상태이면 건조 정지 명령을 보내야 한다")
+        void shouldStopDryer_WhenPausedAndRemoteEnabled() {
             var machine = machine(MachineType.DRYER);
 
             var result = deviceShutdownSupport.shutdown(machine, dryerStatus("pause", true));
 
-            assertThat(result).isEqualTo(ShutdownResult.SKIPPED_OPERATING);
-            then(sendDeviceCommandService).should(never()).execute(any(), any());
+            assertThat(result).isEqualTo(ShutdownResult.STOPPED);
+            var captor = ArgumentCaptor.forClass(SmartThingsCommandReqDto.class);
+            then(sendDeviceCommandService).should(times(1)).execute(eq("device-1"), captor.capture());
+            var command = captor.getValue().commands().get(0);
+            assertThat(command.capability()).isEqualTo("dryerOperatingState");
+            assertThat(command.command()).isEqualTo("setMachineState");
+            assertThat(command.arguments()).containsExactly("stop");
         }
 
         @Test
-        @DisplayName("작동 중이고 원격 제어가 꺼져 있어도 종료 명령을 보내지 않고 작동 중 스킵을 반환한다")
-        void shouldSkipShutdown_WhenRunningEvenIfRemoteDisabled() {
+        @DisplayName("원격 제어 상태와 무관하게 정지 명령을 시도해야 한다")
+        void shouldTryStop_WhenRunningEvenIfRemoteDisabled() {
             var machine = machine(MachineType.WASHER);
 
             var result = deviceShutdownSupport.shutdown(machine, washerStatus("run", false));
 
-            assertThat(result).isEqualTo(ShutdownResult.SKIPPED_OPERATING);
-            then(sendDeviceCommandService).should(never()).execute(any(), any());
+            assertThat(result).isEqualTo(ShutdownResult.STOPPED);
+            then(sendDeviceCommandService).should(times(1)).execute(eq("device-1"), any());
         }
     }
 
     @Nested
-    @DisplayName("유휴/불명 기기")
+    @DisplayName("유휴/불명 기기는")
     class IdleMachine {
 
         @Test
-        @DisplayName("정지(stop) 상태인 유휴 기기는 switch off로 전원을 정리한다")
+        @DisplayName("정지 상태이면 switch off로 전원을 정리해야 한다")
         void shouldPowerOff_WhenIdle() {
             var machine = machine(MachineType.WASHER);
 
@@ -122,7 +132,7 @@ class DeviceShutdownSupportTest {
         }
 
         @Test
-        @DisplayName("상태가 null이면 안전을 위해 종료하지 않고 SKIPPED_UNKNOWN을 반환한다")
+        @DisplayName("상태가 null이면 안전을 위해 종료하지 않고 SKIPPED_UNKNOWN을 반환해야 한다")
         void shouldSkip_WhenStatusNull() {
             var machine = machine(MachineType.WASHER);
 


### PR DESCRIPTION
## 개요

  예약이 없는 세탁기/건조기가 작동 중일 때 서버가 정지 명령을 보내도록 수정했습니다.

  ## 본문

  - 무예약 기기가 `run` 또는 `pause` 상태이면 `SKIPPED_OPERATING`으로 넘기지 않고 기기 타입에 맞는 `setMachineState(stop)` 명령을 전송하도록 변경했습니다.
  - 세탁기는 `washerOperatingState`, 건조기는 `dryerOperatingState` 기반 정지 명령을 사용합니다.
  - 유휴 상태 기기의 `switch off` 처리와 상태 불명 기기 스킵 처리는 기존 동작을 유지했습니다.
  - `DeviceShutdownSupportTest`에서 세탁기/건조기 작동 중 정지 명령 전송 케이스를 검증하도록 수정했습니다.

  참고로 브랜치 push 자체는 현재 워크플로우 조건상 CI가 바로 안 돌고, PR을 열면 pull_request 조건으로 CI가 실행됩니다.