### PR TITLE
[datagsm] 이벤트 웹훅 수신 기능 추가

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/datagsm/controller/DataGsmEventController.java
+++ b/src/main/java/team/washer/server/v2/domain/datagsm/controller/DataGsmEventController.java
@@ -1,0 +1,41 @@
+package team.washer.server.v2.domain.datagsm.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import team.themoment.sdk.exception.ExpectedException;
+import team.themoment.sdk.response.CommonApiResponse;
+import team.washer.server.v2.domain.datagsm.service.HandleDataGsmEventService;
+import team.washer.server.v2.domain.datagsm.support.DataGsmEventSignatureVerifier;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v2/events/datagsm")
+@Tag(name = "DataGSM Event", description = "DataGSM 이벤트 수신 API")
+public class DataGsmEventController {
+
+    private static final String SIGNATURE_HEADER = "X-DataGSM-Signature";
+
+    private final DataGsmEventSignatureVerifier signatureVerifier;
+    private final HandleDataGsmEventService handleDataGsmEventService;
+
+    @PostMapping
+    @Operation(summary = "DataGSM 이벤트 수신", description = "DataGSM에서 전달하는 이벤트를 수신하고 서명을 검증한 뒤 처리합니다.")
+    public CommonApiResponse receiveEvent(
+            @RequestHeader(value = SIGNATURE_HEADER, required = false) final String signature,
+            @RequestBody final byte[] rawBody) {
+        if (!signatureVerifier.verify(signature, rawBody)) {
+            throw new ExpectedException("DataGSM 이벤트 서명이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED);
+        }
+
+        handleDataGsmEventService.execute(rawBody);
+        return CommonApiResponse.success("DataGSM 이벤트가 처리되었습니다.");
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/datagsm/service/HandleDataGsmEventService.java
+++ b/src/main/java/team/washer/server/v2/domain/datagsm/service/HandleDataGsmEventService.java
@@ -1,0 +1,5 @@
+package team.washer.server.v2.domain.datagsm.service;
+
+public interface HandleDataGsmEventService {
+    void execute(byte[] rawBody);
+}

--- a/src/main/java/team/washer/server/v2/domain/datagsm/service/impl/HandleDataGsmEventServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/datagsm/service/impl/HandleDataGsmEventServiceImpl.java
@@ -1,0 +1,146 @@
+package team.washer.server.v2.domain.datagsm.service.impl;
+
+import java.io.IOException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.datagsm.service.HandleDataGsmEventService;
+import team.washer.server.v2.domain.datagsm.support.DataGsmEventIdempotencySupport;
+import team.washer.server.v2.domain.user.enums.UserRole;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class HandleDataGsmEventServiceImpl implements HandleDataGsmEventService {
+
+    private static final String STUDENT_UPDATED_EVENT = "student.updated";
+
+    private final ObjectMapper objectMapper;
+    private final UserRepository userRepository;
+    private final DataGsmEventIdempotencySupport idempotencySupport;
+
+    @Override
+    @Transactional
+    public void execute(byte[] rawBody) {
+        final var payload = parsePayload(rawBody);
+        final var eventId = requiredText(payload, "id");
+        if (idempotencySupport.isProcessed(eventId)) {
+            log.info("DataGSM event already processed eventId={}", eventId);
+            return;
+        }
+
+        final var event = requiredText(payload, "event");
+        if (STUDENT_UPDATED_EVENT.equals(event)) {
+            handleStudentUpdated(payload);
+        } else {
+            log.info("DataGSM event ignored eventId={} event={}", eventId, event);
+        }
+
+        markProcessedAfterCommit(eventId);
+    }
+
+    private JsonNode parsePayload(byte[] rawBody) {
+        try {
+            return objectMapper.readTree(rawBody);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("DataGSM 이벤트 페이로드를 파싱할 수 없습니다.", e);
+        }
+    }
+
+    private void handleStudentUpdated(JsonNode payload) {
+        final var newItems = payload.path("data").path("new");
+        if (!newItems.isArray()) {
+            throw new IllegalArgumentException("DataGSM 학생 이벤트의 new 목록이 올바르지 않습니다.");
+        }
+
+        newItems.forEach(item -> {
+            final var student = item.path("object");
+            if (!student.isObject() || student.isEmpty()) {
+                return;
+            }
+
+            final var studentId = extractText(student, "student_id", "studentId", "student_number", "studentNumber");
+            if (studentId == null) {
+                log.warn("DataGSM student event ignored because student id is missing");
+                return;
+            }
+
+            userRepository.findByStudentId(studentId).ifPresentOrElse(user -> {
+                user.updateDataGsmInfo(extractText(student, "name"),
+                        extractText(student, "dormitory_room", "dormitoryRoom", "room_number", "roomNumber"),
+                        extractInteger(student, "grade"),
+                        extractInteger(student, "dormitory_floor", "dormitoryFloor", "floor"),
+                        mapRole(extractText(student, "role")));
+                log.info("DataGSM student event applied studentId={}", studentId);
+            }, () -> log.info("DataGSM student event ignored because user does not exist studentId={}", studentId));
+        });
+    }
+
+    private String requiredText(JsonNode node, String fieldName) {
+        final var value = extractText(node, fieldName);
+        if (value == null) {
+            throw new IllegalArgumentException("DataGSM 이벤트 필수 필드가 누락되었습니다: " + fieldName);
+        }
+        return value;
+    }
+
+    private void markProcessedAfterCommit(String eventId) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            idempotencySupport.markProcessed(eventId);
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                idempotencySupport.markProcessed(eventId);
+            }
+        });
+    }
+
+    private String extractText(JsonNode node, String... fieldNames) {
+        for (final var fieldName : fieldNames) {
+            final var value = node.path(fieldName);
+            if (value.isTextual() && !value.asText().isBlank()) {
+                return value.asText();
+            }
+            if (value.isNumber()) {
+                return value.asText();
+            }
+        }
+        return null;
+    }
+
+    private Integer extractInteger(JsonNode node, String... fieldNames) {
+        for (final var fieldName : fieldNames) {
+            final var value = node.path(fieldName);
+            if (value.isInt()) {
+                return value.asInt();
+            }
+            if (value.isTextual() && value.asText().matches("\\d+")) {
+                return Integer.valueOf(value.asText());
+            }
+        }
+        return null;
+    }
+
+    private UserRole mapRole(String role) {
+        if (role == null) {
+            return null;
+        }
+        final var normalizedRole = role.replace("-", "_").toUpperCase();
+        if ("DORMITORY_MANAGER".equals(normalizedRole) || "DORMITORYMANAGER".equals(normalizedRole)) {
+            return UserRole.DORMITORY_COUNCIL;
+        }
+        return UserRole.USER;
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/datagsm/service/impl/HandleDataGsmEventServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/datagsm/service/impl/HandleDataGsmEventServiceImpl.java
@@ -123,7 +123,7 @@ public class HandleDataGsmEventServiceImpl implements HandleDataGsmEventService 
     private Integer extractInteger(JsonNode node, String... fieldNames) {
         for (final var fieldName : fieldNames) {
             final var value = node.path(fieldName);
-            if (value.isInt()) {
+            if (value.isNumber()) {
                 return value.asInt();
             }
             if (value.isTextual() && value.asText().matches("\\d+")) {

--- a/src/main/java/team/washer/server/v2/domain/datagsm/support/DataGsmEventIdempotencySupport.java
+++ b/src/main/java/team/washer/server/v2/domain/datagsm/support/DataGsmEventIdempotencySupport.java
@@ -1,0 +1,33 @@
+package team.washer.server.v2.domain.datagsm.support;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.global.thirdparty.datagsm.config.DataGsmEventEnvironment;
+
+@Component
+@RequiredArgsConstructor
+public class DataGsmEventIdempotencySupport {
+
+    private static final String EVENT_KEY_PREFIX = "datagsm:event:";
+    private static final String PROCESSED_VALUE = "processed";
+
+    private final StringRedisTemplate redisTemplate;
+    private final DataGsmEventEnvironment environment;
+
+    public boolean isProcessed(String eventId) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(createKey(eventId)));
+    }
+
+    public void markProcessed(String eventId) {
+        redisTemplate.opsForValue()
+                .set(createKey(eventId), PROCESSED_VALUE, Duration.ofDays(environment.idempotencyTtlDays()));
+    }
+
+    private String createKey(String eventId) {
+        return EVENT_KEY_PREFIX + eventId;
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/datagsm/support/DataGsmEventSignatureVerifier.java
+++ b/src/main/java/team/washer/server/v2/domain/datagsm/support/DataGsmEventSignatureVerifier.java
@@ -1,0 +1,50 @@
+package team.washer.server.v2.domain.datagsm.support;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.global.thirdparty.datagsm.config.DataGsmEventEnvironment;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DataGsmEventSignatureVerifier {
+
+    private static final String SIGNATURE_PREFIX = "sha256=";
+    private static final String HMAC_ALGORITHM = "HmacSHA256";
+
+    private final DataGsmEventEnvironment environment;
+
+    public boolean verify(String signatureHeader, byte[] rawBody) {
+        if (signatureHeader == null || !signatureHeader.startsWith(SIGNATURE_PREFIX)) {
+            return false;
+        }
+        if (environment.secret() == null || environment.secret().isBlank()) {
+            log.error("DataGSM event secret is missing");
+            return false;
+        }
+
+        final var received = signatureHeader.substring(SIGNATURE_PREFIX.length());
+        final var expected = calculateSignature(rawBody);
+        return MessageDigest.isEqual(received.getBytes(StandardCharsets.UTF_8),
+                expected.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private String calculateSignature(byte[] rawBody) {
+        try {
+            final var mac = Mac.getInstance(HMAC_ALGORITHM);
+            mac.init(new SecretKeySpec(environment.secret().getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM));
+            return HexFormat.of().formatHex(mac.doFinal(rawBody));
+        } catch (Exception e) {
+            throw new IllegalStateException("DataGSM 이벤트 서명 계산에 실패했습니다.", e);
+        }
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/datagsm/support/DataGsmEventSignatureVerifier.java
+++ b/src/main/java/team/washer/server/v2/domain/datagsm/support/DataGsmEventSignatureVerifier.java
@@ -3,6 +3,7 @@ package team.washer.server.v2.domain.datagsm.support;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.HexFormat;
+import java.util.Locale;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -24,15 +25,20 @@ public class DataGsmEventSignatureVerifier {
     private final DataGsmEventEnvironment environment;
 
     public boolean verify(String signatureHeader, byte[] rawBody) {
-        if (signatureHeader == null || !signatureHeader.startsWith(SIGNATURE_PREFIX)) {
+        if (signatureHeader == null) {
             return false;
         }
+        final var normalizedSignatureHeader = signatureHeader.trim().toLowerCase(Locale.ROOT);
+        if (!normalizedSignatureHeader.startsWith(SIGNATURE_PREFIX)) {
+            return false;
+        }
+
         if (environment.secret() == null || environment.secret().isBlank()) {
             log.error("DataGSM event secret is missing");
             return false;
         }
 
-        final var received = signatureHeader.substring(SIGNATURE_PREFIX.length());
+        final var received = normalizedSignatureHeader.substring(SIGNATURE_PREFIX.length());
         final var expected = calculateSignature(rawBody);
         return MessageDigest.isEqual(received.getBytes(StandardCharsets.UTF_8),
                 expected.getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/team/washer/server/v2/domain/user/entity/User.java
+++ b/src/main/java/team/washer/server/v2/domain/user/entity/User.java
@@ -271,4 +271,29 @@ public class User extends BaseEntity {
             this.floor = floor;
         }
     }
+
+    /**
+     * DataGSM 이벤트로 전달된 사용자 정보를 반영합니다. 관리자 권한은 서비스 내부에서 별도로 지정하므로 DataGSM 역할 변경으로
+     * 덮어쓰지 않습니다.
+     *
+     * @param name
+     *            이름 (null이면 유지)
+     * @param roomNumber
+     *            호실 (null이면 유지)
+     * @param grade
+     *            학년 (null이면 유지)
+     * @param floor
+     *            층 (null이면 유지)
+     * @param role
+     *            사용자 권한 (null이면 유지)
+     */
+    public void updateDataGsmInfo(String name, String roomNumber, Integer grade, Integer floor, UserRole role) {
+        if (name != null) {
+            this.name = name;
+        }
+        updateInfo(roomNumber, grade, floor);
+        if (role != null && !this.role.isAdmin()) {
+            this.role = role;
+        }
+    }
 }

--- a/src/main/java/team/washer/server/v2/global/security/config/DomainAuthorizationConfig.java
+++ b/src/main/java/team/washer/server/v2/global/security/config/DomainAuthorizationConfig.java
@@ -32,7 +32,10 @@ public class DomainAuthorizationConfig {
                 // Swagger UI
                 .requestMatchers(swaggerUiResources, swaggerUiPath, apiDocsPath, apiDocsPath + "/**").permitAll()
                 // 헬스 체크
-                .requestMatchers("/api/v2/health", "/api/v2/admin/smartthings/**", "/api/v2/app-versions/status")
+                .requestMatchers("/api/v2/health",
+                        "/api/v2/admin/smartthings/**",
+                        "/api/v2/app-versions/status",
+                        "/api/v2/events/datagsm")
                 .permitAll()
                 // 인증 엔드포인트
                 .requestMatchers("/api/v2/auth/login", "/api/v2/auth/refresh", "/api/v2/auth/token/status").permitAll()

--- a/src/main/java/team/washer/server/v2/global/thirdparty/datagsm/config/DataGsmEventEnvironment.java
+++ b/src/main/java/team/washer/server/v2/global/thirdparty/datagsm/config/DataGsmEventEnvironment.java
@@ -1,0 +1,14 @@
+package team.washer.server.v2.global.thirdparty.datagsm.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "third-party.datagsm.event")
+public record DataGsmEventEnvironment(String secret, long idempotencyTtlDays) {
+    private static final long DEFAULT_IDEMPOTENCY_TTL_DAYS = 30;
+
+    public DataGsmEventEnvironment {
+        if (idempotencyTtlDays <= 0) {
+            idempotencyTtlDays = DEFAULT_IDEMPOTENCY_TTL_DAYS;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,6 +54,9 @@ third-party:
     client-secret: ${THIRD_PARTY_DATAGSM_CLIENT_SECRET:your-client-secret}
     client-id: ${THIRD_PARTY_DATAGSM_CLIENT_ID:your-client-id}
     redirect-uri: ${THIRD_PARTY_DATAGSM_REDIRECT_URI:http://localhost:8080/api/v2/admin/datagsm/oauth/callback}
+    event:
+      secret: ${THIRD_PARTY_DATAGSM_EVENT_SECRET:}
+      idempotency-ttl-days: ${THIRD_PARTY_DATAGSM_EVENT_IDEMPOTENCY_TTL_DAYS:30}
   fcm:
     service-account-json: ${THIRD_PARTY_FCM_SERVICE_ACCOUNT_JSON:}
 reservation:

--- a/src/test/java/team/washer/server/v2/domain/datagsm/controller/DataGsmEventControllerTest.java
+++ b/src/test/java/team/washer/server/v2/domain/datagsm/controller/DataGsmEventControllerTest.java
@@ -1,0 +1,66 @@
+package team.washer.server.v2.domain.datagsm.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.datagsm.service.HandleDataGsmEventService;
+import team.washer.server.v2.domain.datagsm.support.DataGsmEventSignatureVerifier;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DataGsmEventController 클래스는")
+class DataGsmEventControllerTest {
+
+    @InjectMocks
+    private DataGsmEventController dataGsmEventController;
+
+    @Mock
+    private DataGsmEventSignatureVerifier signatureVerifier;
+
+    @Mock
+    private HandleDataGsmEventService handleDataGsmEventService;
+
+    @Nested
+    @DisplayName("receiveEvent 메서드는")
+    class Describe_receive_event {
+
+        @Test
+        @DisplayName("서명이 유효하면 이벤트 처리를 위임한다")
+        void it_delegates_event_handling_when_signature_is_valid() {
+            // Given
+            final byte[] rawBody = "{\"id\":\"evt_1\"}".getBytes(StandardCharsets.UTF_8);
+            given(signatureVerifier.verify("sha256=valid", rawBody)).willReturn(true);
+
+            // When
+            dataGsmEventController.receiveEvent("sha256=valid", rawBody);
+
+            // Then
+            then(handleDataGsmEventService).should(times(1)).execute(rawBody);
+        }
+
+        @Test
+        @DisplayName("서명이 유효하지 않으면 인증 예외를 발생시킨다")
+        void it_throws_exception_when_signature_is_invalid() {
+            // Given
+            final byte[] rawBody = "{\"id\":\"evt_1\"}".getBytes(StandardCharsets.UTF_8);
+            given(signatureVerifier.verify("sha256=invalid", rawBody)).willReturn(false);
+
+            // When & Then
+            assertThatThrownBy(() -> dataGsmEventController.receiveEvent("sha256=invalid", rawBody))
+                    .isInstanceOfSatisfying(ExpectedException.class,
+                            exception -> assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED));
+            then(handleDataGsmEventService).shouldHaveNoInteractions();
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/datagsm/service/HandleDataGsmEventServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/datagsm/service/HandleDataGsmEventServiceTest.java
@@ -54,8 +54,8 @@ class HandleDataGsmEventServiceTest {
                       "student_id": "20210001",
                       "name": "김세탁",
                       "dormitory_room": 401,
-                      "grade": 3,
-                      "dormitory_floor": 4,
+                      "grade": 3.0,
+                      "dormitory_floor": 4.0,
                       "role": "DORMITORY_MANAGER"
                     }
                     """);

--- a/src/test/java/team/washer/server/v2/domain/datagsm/service/HandleDataGsmEventServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/datagsm/service/HandleDataGsmEventServiceTest.java
@@ -1,0 +1,197 @@
+package team.washer.server.v2.domain.datagsm.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import team.washer.server.v2.domain.datagsm.service.impl.HandleDataGsmEventServiceImpl;
+import team.washer.server.v2.domain.datagsm.support.DataGsmEventIdempotencySupport;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.enums.UserRole;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("HandleDataGsmEventService 클래스는")
+class HandleDataGsmEventServiceTest {
+
+    @InjectMocks
+    private HandleDataGsmEventServiceImpl handleDataGsmEventService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private DataGsmEventIdempotencySupport idempotencySupport;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Nested
+    @DisplayName("student.updated 이벤트가 들어오면")
+    class Describe_student_updated_event {
+
+        @Test
+        @DisplayName("기존 사용자 정보를 DataGSM 변경 정보로 갱신한다")
+        void it_updates_existing_user() {
+            // Given
+            handleDataGsmEventService = new HandleDataGsmEventServiceImpl(objectMapper,
+                    userRepository,
+                    idempotencySupport);
+            final var user = createUser();
+            final byte[] rawBody = eventPayload("""
+                    {
+                      "student_id": "20210001",
+                      "name": "김세탁",
+                      "dormitory_room": 401,
+                      "grade": 3,
+                      "dormitory_floor": 4,
+                      "role": "DORMITORY_MANAGER"
+                    }
+                    """);
+            given(idempotencySupport.isProcessed("evt_student_1")).willReturn(false);
+            given(userRepository.findByStudentId("20210001")).willReturn(Optional.of(user));
+
+            // When
+            handleDataGsmEventService.execute(rawBody);
+
+            // Then
+            assertThat(user.getName()).isEqualTo("김세탁");
+            assertThat(user.getRoomNumber()).isEqualTo("401");
+            assertThat(user.getGrade()).isEqualTo(3);
+            assertThat(user.getFloor()).isEqualTo(4);
+            assertThat(user.getRole()).isEqualTo(UserRole.DORMITORY_COUNCIL);
+            then(idempotencySupport).should(times(1)).markProcessed("evt_student_1");
+        }
+
+        @Test
+        @DisplayName("이미 처리한 이벤트이면 사용자 정보를 조회하지 않는다")
+        void it_skips_when_event_already_processed() {
+            // Given
+            handleDataGsmEventService = new HandleDataGsmEventServiceImpl(objectMapper,
+                    userRepository,
+                    idempotencySupport);
+            final byte[] rawBody = eventPayload("""
+                    {
+                      "student_id": "20210001",
+                      "name": "김세탁"
+                    }
+                    """);
+            given(idempotencySupport.isProcessed("evt_student_1")).willReturn(true);
+
+            // When
+            handleDataGsmEventService.execute(rawBody);
+
+            // Then
+            then(userRepository).shouldHaveNoInteractions();
+            then(idempotencySupport).should(never()).markProcessed(anyString());
+        }
+
+        @Test
+        @DisplayName("기존 사용자가 없으면 생성하지 않고 처리 완료로 기록한다")
+        void it_does_not_create_user_when_user_does_not_exist() {
+            // Given
+            handleDataGsmEventService = new HandleDataGsmEventServiceImpl(objectMapper,
+                    userRepository,
+                    idempotencySupport);
+            final byte[] rawBody = eventPayload("""
+                    {
+                      "student_id": "20210001",
+                      "name": "김세탁"
+                    }
+                    """);
+            given(idempotencySupport.isProcessed("evt_student_1")).willReturn(false);
+            given(userRepository.findByStudentId("20210001")).willReturn(Optional.empty());
+
+            // When
+            handleDataGsmEventService.execute(rawBody);
+
+            // Then
+            then(userRepository).should(never()).save(any(User.class));
+            then(idempotencySupport).should(times(1)).markProcessed("evt_student_1");
+        }
+    }
+
+    @Nested
+    @DisplayName("지원하지 않는 이벤트가 들어오면")
+    class Describe_unsupported_event {
+
+        @Test
+        @DisplayName("도메인 처리를 하지 않고 처리 완료로 기록한다")
+        void it_marks_processed_without_domain_handling() {
+            // Given
+            handleDataGsmEventService = new HandleDataGsmEventServiceImpl(objectMapper,
+                    userRepository,
+                    idempotencySupport);
+            final byte[] rawBody = """
+                    {
+                      "id": "evt_club_1",
+                      "event": "club.updated",
+                      "timestamp": "2026-06-23T05:21:48.123Z",
+                      "data": { "old": [], "new": [] }
+                    }
+                    """.getBytes(StandardCharsets.UTF_8);
+            given(idempotencySupport.isProcessed("evt_club_1")).willReturn(false);
+
+            // When
+            handleDataGsmEventService.execute(rawBody);
+
+            // Then
+            then(userRepository).shouldHaveNoInteractions();
+            then(idempotencySupport).should(times(1)).markProcessed("evt_club_1");
+        }
+    }
+
+    @Nested
+    @DisplayName("필수 필드가 없으면")
+    class Describe_invalid_event {
+
+        @Test
+        @DisplayName("예외를 발생시킨다")
+        void it_throws_exception() {
+            // Given
+            handleDataGsmEventService = new HandleDataGsmEventServiceImpl(objectMapper,
+                    userRepository,
+                    idempotencySupport);
+            final byte[] rawBody = """
+                    {
+                      "event": "student.updated",
+                      "data": { "old": [], "new": [] }
+                    }
+                    """.getBytes(StandardCharsets.UTF_8);
+
+            // When & Then
+            assertThatThrownBy(() -> handleDataGsmEventService.execute(rawBody))
+                    .isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    private byte[] eventPayload(String studentObject) {
+        return """
+                {
+                  "id": "evt_student_1",
+                  "event": "student.updated",
+                  "timestamp": "2026-06-23T05:21:48.123Z",
+                  "data": {
+                    "old": [{ "index": 0, "object": {} }],
+                    "new": [{ "index": 0, "object": %s }]
+                  }
+                }
+                """.formatted(studentObject).getBytes(StandardCharsets.UTF_8);
+    }
+
+    private User createUser() {
+        return User.builder().name("김기존").studentId("20210001").roomNumber("301").grade(2).floor(3).role(UserRole.USER)
+                .build();
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/datagsm/support/DataGsmEventSignatureVerifierTest.java
+++ b/src/test/java/team/washer/server/v2/domain/datagsm/support/DataGsmEventSignatureVerifierTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HexFormat;
+import java.util.Locale;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -32,6 +33,20 @@ class DataGsmEventSignatureVerifierTest {
             // Given
             final byte[] rawBody = "{\"id\":\"evt_1\"}".getBytes(StandardCharsets.UTF_8);
             final String signature = "sha256=" + calculateSignature(rawBody);
+
+            // When
+            final boolean result = verifier.verify(signature, rawBody);
+
+            // Then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("서명 접두사와 Hex 값의 대소문자가 달라도 true를 반환한다")
+        void it_returns_true_for_case_insensitive_signature() throws Exception {
+            // Given
+            final byte[] rawBody = "{\"id\":\"evt_1\"}".getBytes(StandardCharsets.UTF_8);
+            final String signature = "  SHA256=" + calculateSignature(rawBody).toUpperCase(Locale.ROOT) + "  ";
 
             // When
             final boolean result = verifier.verify(signature, rawBody);

--- a/src/test/java/team/washer/server/v2/domain/datagsm/support/DataGsmEventSignatureVerifierTest.java
+++ b/src/test/java/team/washer/server/v2/domain/datagsm/support/DataGsmEventSignatureVerifierTest.java
@@ -1,0 +1,75 @@
+package team.washer.server.v2.domain.datagsm.support;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import team.washer.server.v2.global.thirdparty.datagsm.config.DataGsmEventEnvironment;
+
+@DisplayName("DataGsmEventSignatureVerifier 클래스는")
+class DataGsmEventSignatureVerifierTest {
+
+    private static final String SECRET = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    private final DataGsmEventSignatureVerifier verifier = new DataGsmEventSignatureVerifier(
+            new DataGsmEventEnvironment(SECRET, 30));
+
+    @Nested
+    @DisplayName("verify 메서드는")
+    class Describe_verify {
+
+        @Test
+        @DisplayName("올바른 HMAC-SHA256 서명이면 true를 반환한다")
+        void it_returns_true_for_valid_signature() throws Exception {
+            // Given
+            final byte[] rawBody = "{\"id\":\"evt_1\"}".getBytes(StandardCharsets.UTF_8);
+            final String signature = "sha256=" + calculateSignature(rawBody);
+
+            // When
+            final boolean result = verifier.verify(signature, rawBody);
+
+            // Then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("서명이 다르면 false를 반환한다")
+        void it_returns_false_for_invalid_signature() {
+            // Given
+            final byte[] rawBody = "{\"id\":\"evt_1\"}".getBytes(StandardCharsets.UTF_8);
+
+            // When
+            final boolean result = verifier.verify("sha256=invalid", rawBody);
+
+            // Then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("서명 헤더가 없으면 false를 반환한다")
+        void it_returns_false_when_signature_header_is_missing() {
+            // Given
+            final byte[] rawBody = "{\"id\":\"evt_1\"}".getBytes(StandardCharsets.UTF_8);
+
+            // When
+            final boolean result = verifier.verify(null, rawBody);
+
+            // Then
+            assertThat(result).isFalse();
+        }
+    }
+
+    private String calculateSignature(byte[] rawBody) throws Exception {
+        final var mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(SECRET.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+        return HexFormat.of().formatHex(mac.doFinal(rawBody));
+    }
+}


### PR DESCRIPTION
## 개요

  `DataGSM` 이벤트 웹훅을 수신하여 학생 정보 변경 이벤트를 처리하는 기능을 추가하였습니다.
  `student.updated` 이벤트를 기반으로 기존 사용자 정보를 갱신하고, 이벤트 서명 검증과 중복 처리 방지를 함께 적용하였습니다.

  ## 본문

  `POST /api/v2/events/datagsm` 엔드포인트를 추가하여 `DataGSM` 이벤트를 수신하도록 구성하였습니다. 수신 요청은 `X-DataGSM-Signature` 헤더를 기준으로
  `HmacSHA256` 서명을 검증하며, 서명이 유효하지 않으면 `ExpectedException`으로 `UNAUTHORIZED` 응답을 반환하도록 하였습니다.

  `student.updated` 이벤트 처리 로직을 추가하였습니다. 이벤트 payload의 `data.new[].object`에서 학생 정보를 읽고, `studentId` 기준으로 기존 `User`를 조회한 뒤 이
  름, 호실, 학년, 층, 권한 정보를 갱신하도록 하였습니다. 기존 사용자가 없는 경우 새로 생성하지 않고 무시하도록 처리하였습니다.

  동일 이벤트가 중복 처리되지 않도록 `DataGsmEventIdempotencySupport`를 추가하였습니다. 이벤트 `id`를 `Redis`에 저장하며, 실제 도메인 변경 트랜잭션이 커밋된 이후
  처리 완료로 기록되도록 구성하였습니다.

  운영 환경에서 사용할 수 있도록 `THIRD_PARTY_DATAGSM_EVENT_SECRET`, `THIRD_PARTY_DATAGSM_EVENT_IDEMPOTENCY_TTL_DAYS` 설정을 추가하였습니다. 또한 웹훅 경로는 인
  증 필터에서 통과시키되, 컨트롤러에서 서명 검증을 수행하도록 `DomainAuthorizationConfig`에 허용 경로를 추가하였습니다.

  테스트는 `DataGsmEventControllerTest`, `HandleDataGsmEventServiceTest`, `DataGsmEventSignatureVerifierTest`를 추가하여 서명 검증, 이벤트 위임, 중복 이벤트 무
  시, 기존 사용자 정보 갱신, 미지원 이벤트 처리 동작을 검증하였습니다.
