### PR TITLE
[user] 관리자 사용자 권한 변경 API 추가

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/user/controller/AdminUserController.java
+++ b/src/main/java/team/washer/server/v2/domain/user/controller/AdminUserController.java
@@ -14,9 +14,12 @@ import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import team.themoment.sdk.response.CommonApiResponse;
 import team.washer.server.v2.domain.user.dto.request.UpdateUserReqDto;
+import team.washer.server.v2.domain.user.dto.request.UpdateUserRoleReqDto;
 import team.washer.server.v2.domain.user.dto.response.UserListResDto;
 import team.washer.server.v2.domain.user.dto.response.UserResDto;
+import team.washer.server.v2.domain.user.dto.response.UserRoleUpdateResDto;
 import team.washer.server.v2.domain.user.dto.response.UserUpdateResDto;
+import team.washer.server.v2.domain.user.service.ChangeUserRoleService;
 import team.washer.server.v2.domain.user.service.DeleteUserService;
 import team.washer.server.v2.domain.user.service.QueryUserByIdService;
 import team.washer.server.v2.domain.user.service.SearchUserService;
@@ -33,6 +36,7 @@ public class AdminUserController {
     private final QueryUserByIdService queryUserByIdService;
     private final UpdateUserInfoService updateUserInfoService;
     private final DeleteUserService deleteUserService;
+    private final ChangeUserRoleService changeUserRoleService;
 
     @GetMapping
     @Operation(summary = "전체 사용자 조회", description = "필터링 옵션으로 사용자 목록을 조회합니다. 이름, 학번(부분 검색) 및 페이지네이션을 지원합니다.")
@@ -56,6 +60,13 @@ public class AdminUserController {
     public UserUpdateResDto updateUser(@Parameter(description = "사용자 ID") @PathVariable @NotNull Long id,
             @Valid @RequestBody UpdateUserReqDto request) {
         return updateUserInfoService.execute(id, request.roomNumber(), request.grade(), request.floor());
+    }
+
+    @PatchMapping("/{id}/role")
+    @Operation(summary = "사용자 권한 변경", description = "사용자의 권한(role)을 변경합니다. 관리자(ADMIN)만 호출할 수 있습니다.")
+    public UserRoleUpdateResDto changeUserRole(@Parameter(description = "사용자 ID") @PathVariable @NotNull Long id,
+            @Valid @RequestBody UpdateUserRoleReqDto request) {
+        return changeUserRoleService.execute(id, request.role());
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/team/washer/server/v2/domain/user/dto/request/UpdateUserRoleReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/user/dto/request/UpdateUserRoleReqDto.java
@@ -1,0 +1,10 @@
+package team.washer.server.v2.domain.user.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import team.washer.server.v2.domain.user.enums.UserRole;
+
+@Schema(description = "사용자 권한 변경 요청 DTO")
+public record UpdateUserRoleReqDto(
+        @Schema(description = "변경할 권한", example = "DORMITORY_COUNCIL") @NotNull(message = "권한은 필수입니다") UserRole role) {
+}

--- a/src/main/java/team/washer/server/v2/domain/user/dto/response/UserRoleUpdateResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/user/dto/response/UserRoleUpdateResDto.java
@@ -1,0 +1,11 @@
+package team.washer.server.v2.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import team.washer.server.v2.domain.user.enums.UserRole;
+
+@Schema(description = "사용자 권한 변경 응답 DTO")
+public record UserRoleUpdateResDto(@Schema(description = "사용자 ID", example = "1") Long id,
+        @Schema(description = "이름", example = "김철수") String name,
+        @Schema(description = "학번", example = "20241234") String studentId,
+        @Schema(description = "변경된 권한", example = "DORMITORY_COUNCIL") UserRole role) {
+}

--- a/src/main/java/team/washer/server/v2/domain/user/entity/User.java
+++ b/src/main/java/team/washer/server/v2/domain/user/entity/User.java
@@ -249,6 +249,16 @@ public class User extends BaseEntity {
     }
 
     /**
+     * 사용자 권한을 변경합니다.
+     *
+     * @param newRole
+     *            새 권한
+     */
+    public void changeRole(final UserRole newRole) {
+        this.role = newRole;
+    }
+
+    /**
      * 사용자 정보 수정
      *
      * @param roomNumber

--- a/src/main/java/team/washer/server/v2/domain/user/repository/UserRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/user/repository/UserRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.enums.UserRole;
 import team.washer.server.v2.domain.user.repository.custom.UserRepositoryCustom;
 
 @Repository
@@ -26,6 +27,8 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
     List<User> findByGrade(Integer grade);
 
     List<User> findByNameContaining(String name);
+
+    long countByRole(UserRole role);
 
     @Query("SELECT u FROM User u WHERE u.floor = :floor AND u.grade = :grade")
     List<User> findByFloorAndGrade(@Param("floor") Integer floor, @Param("grade") Integer grade);

--- a/src/main/java/team/washer/server/v2/domain/user/service/ChangeUserRoleService.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/ChangeUserRoleService.java
@@ -1,0 +1,8 @@
+package team.washer.server.v2.domain.user.service;
+
+import team.washer.server.v2.domain.user.dto.response.UserRoleUpdateResDto;
+import team.washer.server.v2.domain.user.enums.UserRole;
+
+public interface ChangeUserRoleService {
+    UserRoleUpdateResDto execute(Long targetUserId, UserRole newRole);
+}

--- a/src/main/java/team/washer/server/v2/domain/user/service/impl/ChangeUserRoleServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/impl/ChangeUserRoleServiceImpl.java
@@ -1,0 +1,59 @@
+package team.washer.server.v2.domain.user.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.user.dto.response.UserRoleUpdateResDto;
+import team.washer.server.v2.domain.user.enums.UserRole;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.domain.user.service.ChangeUserRoleService;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChangeUserRoleServiceImpl implements ChangeUserRoleService {
+
+    private final UserRepository userRepository;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    @Transactional
+    public UserRoleUpdateResDto execute(final Long targetUserId, final UserRole newRole) {
+        final var actorId = currentUserProvider.getCurrentUserId();
+        final var actor = userRepository.findById(actorId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        if (!actor.getRole().isAdmin()) {
+            throw new ExpectedException("권한을 변경할 수 있는 관리자가 아닙니다.", HttpStatus.FORBIDDEN);
+        }
+
+        if (actorId.equals(targetUserId)) {
+            throw new ExpectedException("자신의 권한은 변경할 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        final var target = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        final var currentRole = target.getRole();
+        if (currentRole == newRole) {
+            throw new ExpectedException("이미 해당 권한을 가진 사용자입니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        if (currentRole == UserRole.ADMIN && newRole != UserRole.ADMIN
+                && userRepository.countByRole(UserRole.ADMIN) <= 1) {
+            throw new ExpectedException("마지막 관리자의 권한은 변경할 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        target.changeRole(newRole);
+        userRepository.save(target);
+
+        log.info("user role changed actorId={} targetId={} from={} to={}", actorId, targetUserId, currentRole, newRole);
+
+        return new UserRoleUpdateResDto(target.getId(), target.getName(), target.getStudentId(), target.getRole());
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/user/service/ChangeUserRoleServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/service/ChangeUserRoleServiceTest.java
@@ -1,0 +1,221 @@
+package team.washer.server.v2.domain.user.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.enums.UserRole;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.domain.user.service.impl.ChangeUserRoleServiceImpl;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ChangeUserRoleServiceImpl 클래스의")
+class ChangeUserRoleServiceTest {
+
+    @InjectMocks
+    private ChangeUserRoleServiceImpl changeUserRoleService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CurrentUserProvider currentUserProvider;
+
+    private User createAdmin() {
+        return User.builder().name("관리자").studentId("20210001").roomNumber("301").grade(3).floor(3).role(UserRole.ADMIN)
+                .build();
+    }
+
+    private User createCouncil() {
+        return User.builder().name("자치위원").studentId("20210003").roomNumber("303").grade(3).floor(3)
+                .role(UserRole.DORMITORY_COUNCIL).build();
+    }
+
+    private User createUser() {
+        return User.builder().name("일반사용자").studentId("20210002").roomNumber("302").grade(3).floor(3)
+                .role(UserRole.USER).build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("관리자가 일반 사용자를 자치위원회로 승격할 때")
+        class Context_with_admin_promoting_user {
+
+            @Test
+            @DisplayName("권한을 정상적으로 변경하고 변경된 정보를 반환해야 한다")
+            void it_changes_role() {
+                // Given
+                var adminId = 1L;
+                var targetId = 2L;
+                var admin = createAdmin();
+                var target = createUser();
+                given(currentUserProvider.getCurrentUserId()).willReturn(adminId);
+                given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+                given(userRepository.findById(targetId)).willReturn(Optional.of(target));
+
+                // When
+                var result = changeUserRoleService.execute(targetId, UserRole.DORMITORY_COUNCIL);
+
+                // Then
+                assertThat(result.role()).isEqualTo(UserRole.DORMITORY_COUNCIL);
+                assertThat(target.getRole()).isEqualTo(UserRole.DORMITORY_COUNCIL);
+                then(userRepository).should(times(1)).save(target);
+            }
+        }
+
+        @Nested
+        @DisplayName("관리자가 다른 관리자를 강등할 때 (관리자가 2명 이상)")
+        class Context_with_admin_demoting_another_admin {
+
+            @Test
+            @DisplayName("권한을 정상적으로 강등해야 한다")
+            void it_demotes_admin() {
+                // Given
+                var adminId = 1L;
+                var targetId = 2L;
+                var admin = createAdmin();
+                var target = createAdmin();
+                given(currentUserProvider.getCurrentUserId()).willReturn(adminId);
+                given(userRepository.findById(adminId)).willReturn(Optional.of(admin));
+                given(userRepository.findById(targetId)).willReturn(Optional.of(target));
+                given(userRepository.countByRole(UserRole.ADMIN)).willReturn(2L);
+
+                // When
+                var result = changeUserRoleService.execute(targetId, UserRole.USER);
+
+                // Then
+                assertThat(result.role()).isEqualTo(UserRole.USER);
+                assertThat(target.getRole()).isEqualTo(UserRole.USER);
+            }
+        }
+
+        @Nested
+        @DisplayName("자치위원회가 권한 변경을 시도할 때")
+        class Context_with_council_actor {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 FORBIDDEN 상태를 반환해야 한다")
+            void it_throws_forbidden_exception() {
+                // Given
+                var councilId = 1L;
+                given(currentUserProvider.getCurrentUserId()).willReturn(councilId);
+                given(userRepository.findById(councilId)).willReturn(Optional.of(createCouncil()));
+
+                // When & Then
+                assertThatThrownBy(() -> changeUserRoleService.execute(2L, UserRole.DORMITORY_COUNCIL))
+                        .isInstanceOf(ExpectedException.class).hasMessage("권한을 변경할 수 있는 관리자가 아닙니다.")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.FORBIDDEN));
+
+                then(userRepository).should(never()).save(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 호출자 ID로 요청할 때")
+        class Context_with_nonexistent_actor {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 NOT_FOUND 상태를 반환해야 한다")
+            void it_throws_not_found_exception() {
+                // Given
+                var actorId = 999L;
+                given(currentUserProvider.getCurrentUserId()).willReturn(actorId);
+                given(userRepository.findById(actorId)).willReturn(Optional.empty());
+
+                // When & Then
+                assertThatThrownBy(() -> changeUserRoleService.execute(1L, UserRole.ADMIN))
+                        .isInstanceOf(ExpectedException.class).hasMessage("사용자를 찾을 수 없습니다")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.NOT_FOUND));
+            }
+        }
+
+        @Nested
+        @DisplayName("관리자가 자기 자신의 권한을 변경하려 할 때")
+        class Context_with_self_change {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 BAD_REQUEST 상태를 반환해야 한다")
+            void it_throws_bad_request_exception() {
+                // Given
+                var adminId = 1L;
+                given(currentUserProvider.getCurrentUserId()).willReturn(adminId);
+                given(userRepository.findById(adminId)).willReturn(Optional.of(createAdmin()));
+
+                // When & Then
+                assertThatThrownBy(() -> changeUserRoleService.execute(adminId, UserRole.USER))
+                        .isInstanceOf(ExpectedException.class).hasMessage("자신의 권한은 변경할 수 없습니다.")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.BAD_REQUEST));
+
+                then(userRepository).should(never()).save(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("대상 사용자가 이미 해당 권한을 가지고 있을 때")
+        class Context_with_same_role {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 BAD_REQUEST 상태를 반환해야 한다")
+            void it_throws_bad_request_exception() {
+                // Given
+                var adminId = 1L;
+                var targetId = 2L;
+                given(currentUserProvider.getCurrentUserId()).willReturn(adminId);
+                given(userRepository.findById(adminId)).willReturn(Optional.of(createAdmin()));
+                given(userRepository.findById(targetId)).willReturn(Optional.of(createUser()));
+
+                // When & Then
+                assertThatThrownBy(() -> changeUserRoleService.execute(targetId, UserRole.USER))
+                        .isInstanceOf(ExpectedException.class).hasMessage("이미 해당 권한을 가진 사용자입니다.")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.BAD_REQUEST));
+
+                then(userRepository).should(never()).save(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("마지막 관리자를 강등하려 할 때 (관리자가 1명)")
+        class Context_with_last_admin {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 BAD_REQUEST 상태를 반환해야 한다")
+            void it_throws_bad_request_exception() {
+                // Given
+                var adminId = 1L;
+                var targetId = 2L;
+                given(currentUserProvider.getCurrentUserId()).willReturn(adminId);
+                given(userRepository.findById(adminId)).willReturn(Optional.of(createAdmin()));
+                given(userRepository.findById(targetId)).willReturn(Optional.of(createAdmin()));
+                given(userRepository.countByRole(UserRole.ADMIN)).willReturn(1L);
+
+                // When & Then
+                assertThatThrownBy(() -> changeUserRoleService.execute(targetId, UserRole.USER))
+                        .isInstanceOf(ExpectedException.class).hasMessage("마지막 관리자의 권한은 변경할 수 없습니다.")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.BAD_REQUEST));
+
+                then(userRepository).should(never()).save(any());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 개요

인원관리 페이지(관리자 웹)에서 사용할 사용자 권한 변경 API를 추가하였습니다. 관리자(`ADMIN`)가 특정 사용자의 권한(`UserRole`)을 승격·강등할 수 있으며, 권한 상승을 방지하기 위한 안전장치를 함께 구현하였습니다.

## 본문

`PATCH /api/v2/admin/users/{id}/role` 엔드포인트를 `AdminUserController`에 추가하였습니다. 요청 본문으로 목표 권한(`role`)을 전달받아 승격과 강등을 하나의 API로 처리하도록 구성하였습니다.

인가는 `ADMIN` 전용으로 제한하였습니다. URL 레벨 인가(`/api/v2/admin/**`)에 더해 `ChangeUserRoleServiceImpl`에서 `CurrentUserProvider`로 호출자를 조회하여 `ADMIN` 여부를 별도로 검증하였으며, `DORMITORY_COUNCIL`이 호출할 경우 `403`을 반환하도록 하였습니다.

다음과 같은 안전장치를 적용하였습니다.

- 호출자가 `ADMIN`이 아닌 경우 `403 FORBIDDEN`
- 자기 자신의 권한을 변경하려는 경우 `400 BAD_REQUEST`
- 대상 사용자가 존재하지 않는 경우 `404 NOT_FOUND`
- 대상이 이미 해당 권한을 가진 경우 `400 BAD_REQUEST`
- 마지막 관리자를 강등하려는 경우 `400 BAD_REQUEST` (`countByRole`로 방어적 검증)

권한 변경 시 `log.info`로 `actorId`, `targetId`, 변경 전후 권한을 감사 로그로 남기도록 하였습니다.

관련하여 `User` 엔티티에 `changeRole` 비즈니스 메서드를, `UserRepository`에 `countByRole` 쿼리 메서드를 추가하였으며, 요청·응답 DTO로 `UpdateUserRoleReqDto`와 `UserRoleUpdateResDto`를 신규 작성하였습니다.

`ChangeUserRoleServiceTest`에 승격/강등 성공 및 모든 예외 케이스를 포함한 8개 시나리오를 BDD 방식으로 작성하였으며, 전부 통과함을 확인하였습니다.
