### PR TITLE
[smartthings] 기기 유형별 완료 예정 시간 조회 수정

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
@@ -78,7 +78,7 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
             switchStatus = deviceStatus.getSwitchStatus();
 
             if (reservation != null) {
-                var completionTimeStr = deviceStatus.getCompletionTime();
+                var completionTimeStr = deviceStatus.getCompletionTime(machine.isWasher());
                 if (completionTimeStr != null && !completionTimeStr.isBlank()) {
                     expectedCompletionTime = DateTimeUtil.parseAndConvertToKoreaTime(completionTimeStr);
                     if (expectedCompletionTime != null) {

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/OverdueReservationProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/OverdueReservationProcessor.java
@@ -81,7 +81,8 @@ public class OverdueReservationProcessor {
         var machine = reservation.getMachine();
 
         if (machineStateDetectionSupport.isRunning(status, machine.isWasher())) {
-            var expectedCompletionTime = DateTimeUtil.parseAndConvertToKoreaTime(status.getCompletionTime());
+            var expectedCompletionTime = DateTimeUtil
+                    .parseAndConvertToKoreaTime(status.getCompletionTime(machine.isWasher()));
             reservation.start(expectedCompletionTime);
             machine.markAsInUse();
             reservationRepository.save(reservation);

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
@@ -76,7 +76,8 @@ public class ReservationLifecycleProcessor {
             return;
         }
 
-        var expectedCompletionTime = DateTimeUtil.parseAndConvertToKoreaTime(status.getCompletionTime());
+        var expectedCompletionTime = DateTimeUtil
+                .parseAndConvertToKoreaTime(status.getCompletionTime(machine.isWasher()));
         reservation.start(expectedCompletionTime);
         machine.markAsInUse();
         reservationRepository.save(reservation);
@@ -189,7 +190,8 @@ public class ReservationLifecycleProcessor {
                 reservation.clearPausedAt();
                 log.info("Reservation {} resumed from pause, clearing pause tracking", reservation.getId());
             }
-            var updatedExpectedCompletionTime = DateTimeUtil.parseAndConvertToKoreaTime(status.getCompletionTime());
+            var updatedExpectedCompletionTime = DateTimeUtil
+                    .parseAndConvertToKoreaTime(getCompletionTime(status, isWasher));
             var current = reservation.getExpectedCompletionTime();
             if (updatedExpectedCompletionTime != null && (current == null
                     || Math.abs(Duration.between(current, updatedExpectedCompletionTime).toSeconds()) >= 60)) {

--- a/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsDeviceStatusResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsDeviceStatusResDto.java
@@ -173,6 +173,10 @@ public record SmartThingsDeviceStatusResDto(
     }
 
     /** 스위치 상태 값 반환: "on" | "off" */
+    public String getCompletionTime(boolean isWasher) {
+        return isWasher ? getWasherCompletionTime() : getDryerCompletionTime();
+    }
+
     public String getSwitchStatus() {
         var main = getMainComponent();
         if (main == null || main.switchCapability() == null) {

--- a/src/main/java/team/washer/server/v2/global/util/DateTimeUtil.java
+++ b/src/main/java/team/washer/server/v2/global/util/DateTimeUtil.java
@@ -44,4 +44,20 @@ public final class DateTimeUtil {
         }
         return null;
     }
+
+    public static LocalDateTime getExpectedCompletionTime(DeviceStatusQuerySupport deviceStatusQuerySupport,
+            String deviceId,
+            boolean isWasher) {
+        try {
+            var status = deviceStatusQuerySupport.queryDeviceStatus(deviceId);
+            var completionTimeStr = status.getCompletionTime(isWasher);
+
+            if (completionTimeStr != null && !completionTimeStr.isBlank()) {
+                return parseAndConvertToKoreaTime(completionTimeStr);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to get expected completion time for device: {}", deviceId, e);
+        }
+        return null;
+    }
 }

--- a/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -142,6 +143,46 @@ class QueryAllMachinesStatusServiceTest {
 
             // Then
             assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("건조기 상태 조회 시 건조기 완료 예정 시간을 사용해야 한다")
+        void execute_ShouldUseDryerCompletionTime_WhenDryerStatusContainsWasherAndDryerCapabilities() {
+            // Given
+            givenUserMocked();
+
+            var machine = Machine.builder().name("D-3F-R1").type(MachineType.DRYER).deviceId("device-1").floor(3)
+                    .position(Position.RIGHT).number(1).status(MachineStatus.NORMAL)
+                    .availability(MachineAvailability.AVAILABLE).build();
+
+            var washerCompletionTime = new SmartThingsDeviceStatusResDto.AttributeState("2026-01-26T15:30:00Z",
+                    "2026-01-26T14:30:00Z",
+                    null);
+            var dryerCompletionTime = new SmartThingsDeviceStatusResDto.AttributeState("2026-01-26T16:00:00Z",
+                    "2026-01-26T14:30:00Z",
+                    null);
+            var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(null,
+                    null,
+                    washerCompletionTime);
+            var dryerOpState = new SmartThingsDeviceStatusResDto.DryerOperatingState(null, null, dryerCompletionTime);
+            var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState,
+                    dryerOpState,
+                    null,
+                    null);
+            var deviceStatus = new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
+
+            when(machineRepository.findAll(any(Sort.class))).thenReturn(List.of(machine));
+            when(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1")))
+                    .thenReturn(Map.of("device-1", deviceStatus));
+            when(reservationRepository.findActiveReservationByMachineId(any())).thenReturn(Optional.of(reservation));
+            when(reservation.getStatus()).thenReturn(ReservationStatus.RUNNING);
+            when(reservation.getUser()).thenReturn(user);
+
+            // When
+            var result = queryAllMachinesStatusService.execute(USER_ID, true);
+
+            // Then
+            assertThat(result.getFirst().expectedCompletionTime()).isEqualTo(LocalDateTime.of(2026, 1, 27, 1, 0));
         }
     }
 

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/OverdueReservationProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/OverdueReservationProcessorTest.java
@@ -69,7 +69,28 @@ class OverdueReservationProcessorTest {
     private SmartThingsDeviceStatusResDto buildDeviceStatus(String completionTime) {
         var completionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState(completionTime, null, null);
         var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(null, null, completionTimeAttr);
-        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null, null);
+        var dryerOpState = new SmartThingsDeviceStatusResDto.DryerOperatingState(null, null, completionTimeAttr);
+        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState,
+                dryerOpState,
+                null,
+                null);
+        return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
+    }
+
+    private SmartThingsDeviceStatusResDto buildStatusWithMixedCompletionTime(String washerCompletionTime,
+            String dryerCompletionTime) {
+        var washerCompletionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState(washerCompletionTime,
+                null,
+                null);
+        var dryerCompletionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState(dryerCompletionTime, null, null);
+        var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(null,
+                null,
+                washerCompletionTimeAttr);
+        var dryerOpState = new SmartThingsDeviceStatusResDto.DryerOperatingState(null, null, dryerCompletionTimeAttr);
+        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState,
+                dryerOpState,
+                null,
+                null);
         return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
     }
 
@@ -104,6 +125,27 @@ class OverdueReservationProcessorTest {
                     .sendStarted(eq(user), eq(machine), any(LocalDateTime.class));
             verify(reservation, never()).cancel();
             verify(penaltyRedisUtil, never()).applyCooldown(any(), any());
+        }
+
+        @Test
+        @DisplayName("건조기 자동 시작 시 건조기 완료 예정 시간을 저장해야 한다")
+        void shouldAutoStartDryerWithDryerCompletionTime_WhenBothCompletionTimesExist() {
+            // Given
+            var deviceStatus = buildStatusWithMixedCompletionTime("2026-01-26T15:30:00Z", "2026-01-26T16:00:00Z");
+            givenReservedReservation();
+            when(reservation.getUser()).thenReturn(user);
+            when(machine.isWasher()).thenReturn(false);
+            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(true);
+
+            // When
+            var result = overdueReservationProcessor.processOverdue(RESERVATION_ID, deviceStatus);
+
+            // Then
+            assertThat(result).isEqualTo(OverdueResult.AUTO_STARTED);
+            verify(reservation, times(1)).start(LocalDateTime.of(2026, 1, 27, 1, 0));
+            verify(reservationNotificationSupport, times(1))
+                    .sendStarted(user, machine, LocalDateTime.of(2026, 1, 27, 1, 0));
         }
     }
 

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
@@ -65,7 +65,28 @@ class ReservationLifecycleProcessorTest {
     private SmartThingsDeviceStatusResDto buildDeviceStatus(String completionTime) {
         var completionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState(completionTime, null, null);
         var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(null, null, completionTimeAttr);
-        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null, null);
+        var dryerOpState = new SmartThingsDeviceStatusResDto.DryerOperatingState(null, null, completionTimeAttr);
+        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState,
+                dryerOpState,
+                null,
+                null);
+        return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
+    }
+
+    private SmartThingsDeviceStatusResDto buildStatusWithMixedCompletionTime(String washerCompletionTime,
+            String dryerCompletionTime) {
+        var washerCompletionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState(washerCompletionTime,
+                null,
+                null);
+        var dryerCompletionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState(dryerCompletionTime, null, null);
+        var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(null,
+                null,
+                washerCompletionTimeAttr);
+        var dryerOpState = new SmartThingsDeviceStatusResDto.DryerOperatingState(null, null, dryerCompletionTimeAttr);
+        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState,
+                dryerOpState,
+                null,
+                null);
         return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
     }
 
@@ -157,6 +178,28 @@ class ReservationLifecycleProcessorTest {
             // Then
             verify(reservation, never()).start(any());
             verify(reservationRepository, never()).save(reservation);
+        }
+
+        @Test
+        @DisplayName("건조기 예약 시작 시 건조기 완료 예정 시간을 저장해야 한다")
+        void shouldStartDryerReservationWithDryerCompletionTime_WhenBothCompletionTimesExist() {
+            // Given
+            var deviceStatus = buildStatusWithMixedCompletionTime("2026-01-26T15:30:00Z", "2026-01-26T16:00:00Z");
+            when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
+            when(reservation.isReserved()).thenReturn(true);
+            when(reservation.getMachine()).thenReturn(machine);
+            when(reservation.getUser()).thenReturn(user);
+            when(machine.isWasher()).thenReturn(false);
+            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(true);
+
+            // When
+            reservationLifecycleProcessor.processReservedToRunning(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, times(1)).start(LocalDateTime.of(2026, 1, 27, 1, 0));
+            verify(reservationNotificationSupport, times(1))
+                    .sendStarted(user, machine, LocalDateTime.of(2026, 1, 27, 1, 0));
         }
 
         @Test
@@ -345,6 +388,29 @@ class ReservationLifecycleProcessorTest {
             verify(reservation, times(1)).updateExpectedCompletionTime(any(LocalDateTime.class));
             verify(reservationRepository, times(1)).save(reservation);
             verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
+        }
+
+        @Test
+        @DisplayName("건조기 진행 중 상태 갱신 시 건조기 완료 예정 시간을 저장해야 한다")
+        void shouldUpdateDryerExpectedCompletionTime_WhenBothCompletionTimesExist() {
+            // Given
+            var deviceStatus = buildStatusWithMixedCompletionTime("2026-01-26T15:30:00Z", "2026-01-26T16:00:00Z");
+            givenRunningReservation();
+            when(machine.isWasher()).thenReturn(false);
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(Optional.empty());
+            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
+            when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
+            when(reservation.getExpectedCompletionTime()).thenReturn(null);
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, times(1)).updateExpectedCompletionTime(LocalDateTime.of(2026, 1, 27, 1, 0));
+            verify(reservationRepository, times(1)).save(reservation);
         }
 
         @Test


### PR DESCRIPTION
## 개요

  `SmartThings` 기기 상태 응답에서 세탁기/건조기 완료 예정 시간이 함께 내려오는 경우, 기기 유형에 맞는 완료 예정 시간을 조회하도록 수정했습니다.

  ## 본문

  기존에는 `SmartThingsDeviceStatusResDto.getCompletionTime()`이 세탁기 완료 예정 시간을 우선 반환해, 건조기 상태 조회 또는 예약 생명주기 처리에서 세탁기 완료 예정 시간
  이 사용될 수 있었습니다.

  이를 해결하기 위해 `SmartThingsDeviceStatusResDto.getCompletionTime(boolean isWasher)`를 추가하고, `QueryAllMachinesStatusServiceImpl`,
  `ReservationLifecycleProcessor`, `OverdueReservationProcessor`에서 `machine.isWasher()` 기준으로 완료 예정 시간을 선택하도록 변경했습니다.

  또한 `DateTimeUtil`에 기기 유형 기반 완료 예정 시간 조회 오버로드를 추가하고, 세탁기/건조기 완료 예정 시간이 함께 존재할 때 건조기 예약과 상태 조회가 건조기 완료 예정
  시간을 사용하는 테스트를 추가했습니다.

  검증:
  - `./gradlew spotlessApply`
  - `./gradlew test --tests "team.washer.server.v2.domain.machine.service.QueryAllMachinesStatusServiceTest" --tests
  "team.washer.server.v2.domain.reservation.service.ReservationLifecycleProcessorTest" --tests
  "team.washer.server.v2.domain.reservation.service.OverdueReservationProcessorTest"`
  - `./gradlew test`