### PR TITLE
[datagsm] 학생 이벤트가 학번으로 사용자를 조회하도록 수정

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/datagsm/service/impl/HandleDataGsmEventServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/datagsm/service/impl/HandleDataGsmEventServiceImpl.java
@@ -68,9 +68,9 @@ public class HandleDataGsmEventServiceImpl implements HandleDataGsmEventService 
                 return;
             }
 
-            final var studentId = extractText(student, "student_id", "studentId", "student_number", "studentNumber");
+            final var studentId = extractText(student, "student_number", "studentNumber");
             if (studentId == null) {
-                log.warn("DataGSM student event ignored because student id is missing");
+                log.warn("DataGSM student event ignored because student number is missing");
                 return;
             }
 

--- a/src/test/java/team/washer/server/v2/domain/datagsm/service/HandleDataGsmEventServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/datagsm/service/HandleDataGsmEventServiceTest.java
@@ -51,7 +51,7 @@ class HandleDataGsmEventServiceTest {
             final var user = createUser();
             final byte[] rawBody = eventPayload("""
                     {
-                      "student_id": "20210001",
+                      "student_number": 3404,
                       "name": "김세탁",
                       "dormitory_room": 401,
                       "grade": 3.0,
@@ -60,7 +60,7 @@ class HandleDataGsmEventServiceTest {
                     }
                     """);
             given(idempotencySupport.isProcessed("evt_student_1")).willReturn(false);
-            given(userRepository.findByStudentId("20210001")).willReturn(Optional.of(user));
+            given(userRepository.findByStudentId("3404")).willReturn(Optional.of(user));
 
             // When
             handleDataGsmEventService.execute(rawBody);
@@ -83,7 +83,7 @@ class HandleDataGsmEventServiceTest {
                     idempotencySupport);
             final byte[] rawBody = eventPayload("""
                     {
-                      "student_id": "20210001",
+                      "student_number": 3404,
                       "name": "김세탁"
                     }
                     """);
@@ -106,12 +106,12 @@ class HandleDataGsmEventServiceTest {
                     idempotencySupport);
             final byte[] rawBody = eventPayload("""
                     {
-                      "student_id": "20210001",
+                      "student_number": 3404,
                       "name": "김세탁"
                     }
                     """);
             given(idempotencySupport.isProcessed("evt_student_1")).willReturn(false);
-            given(userRepository.findByStudentId("20210001")).willReturn(Optional.empty());
+            given(userRepository.findByStudentId("3404")).willReturn(Optional.empty());
 
             // When
             handleDataGsmEventService.execute(rawBody);
@@ -119,6 +119,32 @@ class HandleDataGsmEventServiceTest {
             // Then
             then(userRepository).should(never()).save(any(User.class));
             then(idempotencySupport).should(times(1)).markProcessed("evt_student_1");
+        }
+    }
+
+    @Nested
+    @DisplayName("student_id와 student_number가 함께 들어오면")
+    class Describe_both_student_id_and_student_number {
+
+        @Test
+        @DisplayName("DataGSM 내부 PK가 아닌 학번으로 사용자를 조회한다")
+        void it_looks_up_user_by_student_number() {
+            // Given
+            handleDataGsmEventService = new HandleDataGsmEventServiceImpl(objectMapper,
+                    userRepository,
+                    idempotencySupport);
+            final var user = createUser();
+            final byte[] rawBody = realWorldPayload();
+            given(idempotencySupport.isProcessed("evt_8d60e4c4208644d382c51fa014149324")).willReturn(false);
+            given(userRepository.findByStudentId("3404")).willReturn(Optional.of(user));
+
+            // When
+            handleDataGsmEventService.execute(rawBody);
+
+            // Then
+            then(userRepository).should(times(1)).findByStudentId("3404");
+            then(userRepository).should(never()).findByStudentId("127");
+            assertThat(user.getRoomNumber()).isEqualTo("412");
         }
     }
 
@@ -190,8 +216,42 @@ class HandleDataGsmEventServiceTest {
                 """.formatted(studentObject).getBytes(StandardCharsets.UTF_8);
     }
 
+    /**
+     * DataGSM이 실제로 전송하는 형태의 페이로드. student_id(127)는 DataGSM 내부 PK이고 실제 학번은
+     * student_number(3404)이므로, 학번 조회에는 student_number를 사용해야 한다.
+     */
+    private byte[] realWorldPayload() {
+        return """
+                {
+                  "data": {
+                    "new": [{
+                      "index": 0,
+                      "object": {
+                        "class_num": 4, "dormitory_floor": 4, "dormitory_room": 412,
+                        "email": "s24058@gsm.hs.kr", "grade": 3, "name": "김태은",
+                        "number": 4, "role": "GENERAL_STUDENT", "sex": "MAN",
+                        "student_id": 127, "student_number": 3404
+                      }
+                    }],
+                    "old": [{
+                      "index": 0,
+                      "object": {
+                        "class_num": 4, "dormitory_floor": 4, "dormitory_room": 411,
+                        "email": "s24058@gsm.hs.kr", "grade": 3, "name": "김태은",
+                        "number": 4, "role": "GENERAL_STUDENT", "sex": "MAN",
+                        "student_id": 127, "student_number": 3404
+                      }
+                    }]
+                  },
+                  "event": "student.updated",
+                  "id": "evt_8d60e4c4208644d382c51fa014149324",
+                  "timestamp": "2026-07-14T11:47:16.205061420Z"
+                }
+                """.getBytes(StandardCharsets.UTF_8);
+    }
+
     private User createUser() {
-        return User.builder().name("김기존").studentId("20210001").roomNumber("301").grade(2).floor(3).role(UserRole.USER)
+        return User.builder().name("김기존").studentId("3404").roomNumber("301").grade(2).floor(3).role(UserRole.USER)
                 .build();
     }
 }


### PR DESCRIPTION
## 문제

`student.updated` 이벤트를 수신해도 사용자 정보가 갱신되지 않고 조용히 유실됩니다.
예외가 발생하지 않고 200을 반환하기 때문에 DataGSM 쪽에서는 성공으로 보입니다.

DataGSM 페이로드에는 `student_id`(내부 PK)와 `student_number`(학번)가 함께 전달됩니다.

```json
{ "student_id": 127, "student_number": 3404, "dormitory_room": 412 }
```

그런데 기존 코드는 후보 필드를 순서대로 조회해 `student_id`(127)를 먼저 선택했습니다.

```java
final var studentId = extractText(student, "student_id", "studentId", "student_number", "studentNumber");
```

반면 `users.student_id` 컬럼에는 회원가입 시점부터 **학번**이 저장됩니다
(`UserRegistrationSupport`가 `student.getStudentNumber()`를 사용). 따라서
`findByStudentId("127")`은 매번 빗나가고, `ifPresentOrElse`의 else 분기로 빠져
로그만 남긴 채 변경 사항이 사라집니다.

참고로 DataGSM SDK의 `Student` 모델에는 `studentId` 필드 자체가 없습니다.
내부 PK는 `id`, 학번은 `studentNumber`입니다.

## 변경 사항

조회 후보에서 `student_id`와 `studentId`를 제거하고 `student_number`만 사용합니다.
폴백으로 남겨두면 동일하게 잘못된 값을 우선 선택하므로 후보에서 완전히 제외했습니다.

`extractText`에 이미 숫자 처리 분기가 있어 `3404`(숫자)도 `"3404"`로 변환됩니다.

## 테스트

기존 테스트는 `student_id`를 학번으로 가정한 픽스처를 사용해 이 버그를 통과시켰습니다.
픽스처를 실제 페이로드 형태로 정정하고 회귀 테스트를 추가했습니다.

- `student_id`(127)와 `student_number`(3404)가 함께 오는 실제 페이로드로
  `findByStudentId("3404")` 호출 및 호실 갱신(411 → 412) 검증

회귀 테스트가 수정 전 코드에서 실패하는 것을 먼저 확인했습니다
(`PotentialStubbingProblem`: 코드가 `"127"`로 조회). 전체 354개 테스트 통과.