### PR TITLE
[machine] 완료 직후 상태 표시 지연 수정

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
@@ -22,6 +22,7 @@ import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
+import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.global.util.DateTimeUtil;
 
@@ -36,6 +37,7 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
     private final MachineRepository machineRepository;
     private final ReservationRepository reservationRepository;
     private final DeviceStatusQuerySupport deviceStatusQuerySupport;
+    private final MachineStateDetectionSupport machineStateDetectionSupport;
     private final UserRepository userRepository;
 
     @Override
@@ -76,6 +78,7 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
             operatingState = getOperatingState(machine, deviceStatus);
             jobState = getJobState(machine, deviceStatus);
             switchStatus = deviceStatus.getSwitchStatus();
+            reservation = getDisplayReservation(machine, deviceStatus, reservation);
 
             if (reservation != null) {
                 var completionTimeStr = deviceStatus.getCompletionTime(machine.isWasher());
@@ -101,6 +104,17 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
                 reservation != null ? reservation.getId() : null,
                 reservation != null ? reservation.getUser().getId() : null,
                 reservation != null ? reservation.getUser().getRoomNumber() : null);
+    }
+
+    private Reservation getDisplayReservation(Machine machine,
+            SmartThingsDeviceStatusResDto deviceStatus,
+            Reservation reservation) {
+        if (reservation == null || !reservation.isRunning()) {
+            return reservation;
+        }
+        return machineStateDetectionSupport.isCompleted(deviceStatus, machine.isWasher()).isPresent()
+                ? null
+                : reservation;
     }
 
     /**

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
@@ -80,25 +80,26 @@ public class MachineStateDetectionSupport {
         var completionTime = (completionTimeStr != null && !completionTimeStr.isBlank())
                 ? DateTimeUtil.parseAndConvertToKoreaTime(completionTimeStr)
                 : null;
+        if (finishedJobState.equalsIgnoreCase(jobState)) {
+            log.debug("device job is completed jobState={} completionTime={}", jobState, completionTime);
+            return Optional.of(completionTime != null && !completionTime.isAfter(now) ? completionTime : now);
+        }
+
         if (completionTime != null && completionTime.isAfter(now)) {
-            log.debug("job finished but completion time still in future completionTime={} jobState={}",
+            log.debug("device stopped but completion time still in future completionTime={} jobState={}",
                     completionTime,
                     jobState);
             return Optional.empty();
         }
 
-        if (!finishedJobState.equalsIgnoreCase(jobState)) {
-            if (isResetJobState(jobState) && completionTime != null) {
-                log.debug("device job is completed after job reset jobState={} completionTime={}",
-                        jobState,
-                        completionTime);
-                return Optional.of(completionTime);
-            }
-            return Optional.empty();
+        if (isResetJobState(jobState) && completionTime != null) {
+            log.debug("device job is completed after job reset jobState={} completionTime={}",
+                    jobState,
+                    completionTime);
+            return Optional.of(completionTime);
         }
 
-        log.debug("device job is completed jobState={} completionTime={}", jobState, completionTime);
-        return Optional.of(completionTime != null ? completionTime : now);
+        return Optional.empty();
     }
 
     private boolean isResetJobState(String jobState) {

--- a/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
@@ -32,6 +32,7 @@ import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
+import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 
@@ -49,6 +50,9 @@ class QueryAllMachinesStatusServiceTest {
 
     @Mock
     private DeviceStatusQuerySupport deviceStatusQuerySupport;
+
+    @Mock
+    private MachineStateDetectionSupport machineStateDetectionSupport;
 
     @Mock
     private UserRepository userRepository;
@@ -183,6 +187,49 @@ class QueryAllMachinesStatusServiceTest {
 
             // Then
             assertThat(result.getFirst().expectedCompletionTime()).isEqualTo(LocalDateTime.of(2026, 1, 27, 1, 0));
+        }
+
+        @Test
+        @DisplayName("완료 신호가 확인된 활성 예약은 완료 예정 시각과 예약 정보를 숨긴다")
+        void execute_ShouldHideReservationInfo_WhenActiveReservationIsCompletedOnDeviceStatus() {
+            // Given
+            givenUserMocked();
+
+            var machine = Machine.builder().name("W-3F-L1").type(MachineType.WASHER).deviceId("device-1").floor(3)
+                    .position(Position.LEFT).number(1).status(MachineStatus.NORMAL)
+                    .availability(MachineAvailability.AVAILABLE).build();
+
+            var machineStateAttr = new SmartThingsDeviceStatusResDto.AttributeState("stop",
+                    "2026-01-26T15:30:00Z",
+                    null);
+            var jobStateAttr = new SmartThingsDeviceStatusResDto.AttributeState("finish", "2026-01-26T15:30:00Z", null);
+            var completionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState("2026-01-26T15:31:00Z",
+                    "2026-01-26T15:30:00Z",
+                    null);
+            var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(machineStateAttr,
+                    jobStateAttr,
+                    completionTimeAttr);
+            var deviceStatus = new SmartThingsDeviceStatusResDto(
+                    Map.of("main", new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null, null)));
+
+            when(machineRepository.findAll(any(Sort.class))).thenReturn(List.of(machine));
+            when(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1")))
+                    .thenReturn(Map.of("device-1", deviceStatus));
+            when(reservationRepository.findActiveReservationByMachineId(any())).thenReturn(Optional.of(reservation));
+            when(reservation.isRunning()).thenReturn(true);
+            when(machineStateDetectionSupport.isCompleted(deviceStatus, true))
+                    .thenReturn(Optional.of(LocalDateTime.of(2026, 1, 27, 0, 30)));
+
+            // When
+            var result = queryAllMachinesStatusService.execute(USER_ID, true);
+
+            // Then
+            assertThat(result.getFirst().availability()).isEqualTo(MachineAvailability.AVAILABLE);
+            assertThat(result.getFirst().expectedCompletionTime()).isNull();
+            assertThat(result.getFirst().remainingMinutes()).isNull();
+            assertThat(result.getFirst().reservationId()).isNull();
+            assertThat(result.getFirst().userId()).isNull();
+            assertThat(result.getFirst().roomNumber()).isNull();
         }
     }
 

--- a/src/test/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupportTest.java
@@ -83,14 +83,14 @@ class MachineStateDetectionSupportTest {
         }
 
         @Test
-        @DisplayName("jobState=finish, machineState=stop 이지만 완료 시각이 미래(잔여시간 남음)면 미완료로 판정한다")
-        void shouldNotComplete_WhenFinishedButCompletionTimeInFuture() {
+        @DisplayName("jobState=finish, machineState=stop 이면 완료 시각이 미래여도 완료로 판정한다")
+        void shouldComplete_WhenFinishedStoppedAndCompletionTimeInFuture() {
             var future = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(3);
             var status = washerStatus("stop", "finish", isoUtc(future));
 
             var result = machineStateDetectionSupport.isCompleted(status, WASHER);
 
-            assertThat(result).isEmpty();
+            assertThat(result).isPresent();
         }
 
         @Test
@@ -144,6 +144,17 @@ class MachineStateDetectionSupportTest {
         void shouldComplete_WhenFinishedStoppedAndTimePassed() {
             var past = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(1);
             var status = dryerStatus("stop", "finished", isoUtc(past));
+
+            var result = machineStateDetectionSupport.isCompleted(status, DRYER);
+
+            assertThat(result).isPresent();
+        }
+
+        @Test
+        @DisplayName("jobState=finished, machineState=stop 이면 완료 시각이 미래여도 완료로 판정한다")
+        void shouldComplete_WhenDryerFinishedStoppedAndCompletionTimeInFuture() {
+            var future = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(3);
+            var status = dryerStatus("stop", "finished", isoUtc(future));
 
             var result = machineStateDetectionSupport.isCompleted(status, DRYER);
 


### PR DESCRIPTION
## 개요

`SmartThings` 완료 직후에도 완료 예정 시각과 예약 정보가 잠시 노출되던 문제를 수정했습니다.
`machineState=stop`이고 작업 상태가 완료이면 `completionTime`이 약간 미래로 남아 있어도 완료로 판정하도록 조정했습니다.

## 본문

- `MachineStateDetectionSupport`에서 세탁기 `finish`, 건조기 `finished` 상태와 `machineState=stop` 조합을 즉시 완료 신호로 처리했습니다.
- `QueryAllMachinesStatusServiceImpl`에서 완료 신호가 확인된 `RUNNING` 예약은 표시 응답에서 제외해 `expectedCompletionTime`, `remainingMinutes`, 예약자 정보가 다시 내려가지 않도록 했습니다.
- 세탁기와 건조기 완료 판정, 기기 상태 조회 응답 회귀 테스트를 추가했습니다.

테스트:
- `./gradlew test`
