### PR TITLE
[machine] 완료 직후 예약 가능 상태 전환 수정

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
@@ -134,6 +134,12 @@ public class ReservationLifecycleProcessor {
             return;
         }
 
+        var stoppedResetCompletionTime = getStoppedResetCompletionTime(reservation, status, isWasher);
+        if (stoppedResetCompletionTime.isPresent()) {
+            processStoppedResetCompletion(reservation, machine, stoppedResetCompletionTime.get());
+            return;
+        }
+
         if (machineStateDetectionSupport.isInterrupted(status, isWasher)) {
             // 사이클 단계 전환 중 순간적으로 보고되는 정지를 진짜 중단으로 오판하지 않도록, 연속으로 중단이
             // 감지될 때만 취소를 확정한다.
@@ -231,6 +237,25 @@ public class ReservationLifecycleProcessor {
                 completionTime);
     }
 
+    private void processStoppedResetCompletion(Reservation reservation, Machine machine, LocalDateTime completionTime) {
+        reservation.incrementInterruptionCount();
+        if (reservation.getInterruptionCount() >= ReservationConstants.INTERRUPTION_CONFIRM_THRESHOLD) {
+            reservation.clearInterruptionCount();
+            completeReservation(reservation, machine, completionTime, "stopped_reset_completion_confirmed");
+            return;
+        }
+
+        reservationRepository.save(reservation);
+        log.info(
+                "completion deferred reason=stopped_reset_completion_confirmation reservationId={} count={} threshold={} startTime={} expectedCompletionTime={} completionTime={}",
+                reservation.getId(),
+                reservation.getInterruptionCount(),
+                ReservationConstants.INTERRUPTION_CONFIRM_THRESHOLD,
+                reservation.getStartTime(),
+                reservation.getExpectedCompletionTime(),
+                completionTime);
+    }
+
     private Optional<LocalDateTime> getStoppedNearCompletionTime(Reservation reservation,
             SmartThingsDeviceStatusResDto status,
             boolean isWasher) {
@@ -255,6 +280,38 @@ public class ReservationLifecycleProcessor {
         }
 
         return Optional.of(completionTime);
+    }
+
+    private Optional<LocalDateTime> getStoppedResetCompletionTime(Reservation reservation,
+            SmartThingsDeviceStatusResDto status,
+            boolean isWasher) {
+        if (status == null) {
+            return Optional.empty();
+        }
+        if ("off".equalsIgnoreCase(status.getSwitchStatus())) {
+            return Optional.empty();
+        }
+
+        var machineState = getOperatingState(status, isWasher);
+        if (!"stop".equalsIgnoreCase(machineState) || !isResetJobState(getJobState(status, isWasher))) {
+            return Optional.empty();
+        }
+
+        var completionTime = DateTimeUtil.parseAndConvertToKoreaTime(getCompletionTime(status, isWasher));
+        if (completionTime == null || !completionTime.isAfter(DateTimeUtil.nowInKorea())) {
+            return Optional.empty();
+        }
+
+        var startTime = reservation.getStartTime();
+        if (startTime == null || completionTime.isBefore(startTime)) {
+            return Optional.empty();
+        }
+        if (!isTimestampAtOrAfterStart(getOperatingStateTimestamp(status, isWasher), startTime)
+                && !isTimestampAtOrAfterStart(getJobStateTimestamp(status, isWasher), startTime)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(DateTimeUtil.nowInKorea());
     }
 
     private void completeReservation(Reservation reservation,
@@ -307,25 +364,8 @@ public class ReservationLifecycleProcessor {
             SmartThingsDeviceStatusResDto status,
             boolean isWasher,
             LocalDateTime completionTime) {
-        if (hasFreshStoppedCompletionEvidence(reservation, status, isWasher, completionTime)) {
-            return true;
-        }
         return hasSuspiciousExpectedCompletionTime(reservation)
                 && hasFreshCompletionEvidence(reservation, status, isWasher, completionTime);
-    }
-
-    private boolean hasFreshStoppedCompletionEvidence(Reservation reservation,
-            SmartThingsDeviceStatusResDto status,
-            boolean isWasher,
-            LocalDateTime completionTime) {
-        var startTime = reservation.getStartTime();
-        if (startTime == null || completionTime.isBefore(startTime)) {
-            return false;
-        }
-        if (!"stop".equalsIgnoreCase(getOperatingState(status, isWasher))) {
-            return false;
-        }
-        return hasFreshCompletionEvidence(reservation, status, isWasher, completionTime);
     }
 
     private boolean hasSuspiciousExpectedCompletionTime(Reservation reservation) {
@@ -355,7 +395,7 @@ public class ReservationLifecycleProcessor {
 
     private void logEarlyCompletionAccepted(Reservation reservation, LocalDateTime completionTime) {
         log.info(
-                "completion accepted reason=fresh_completion_evidence reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
+                "completion accepted reason=suspicious_expected_completion_time reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
                 reservation.getId(),
                 reservation.getStartTime(),
                 reservation.getExpectedCompletionTime(),
@@ -392,6 +432,13 @@ public class ReservationLifecycleProcessor {
         return isWasher ? status.getWasherOperatingState() : status.getDryerOperatingState();
     }
 
+    private String getJobState(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        if (status == null) {
+            return null;
+        }
+        return isWasher ? status.getWasherJobState() : status.getDryerJobState();
+    }
+
     private String getOperatingStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
         if (status == null) {
             return null;
@@ -404,5 +451,9 @@ public class ReservationLifecycleProcessor {
             return null;
         }
         return isWasher ? status.getWasherJobStateTimestamp() : status.getDryerJobStateTimestamp();
+    }
+
+    private boolean isResetJobState(String jobState) {
+        return jobState == null || jobState.isBlank() || "none".equalsIgnoreCase(jobState);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
@@ -307,8 +307,25 @@ public class ReservationLifecycleProcessor {
             SmartThingsDeviceStatusResDto status,
             boolean isWasher,
             LocalDateTime completionTime) {
+        if (hasFreshStoppedCompletionEvidence(reservation, status, isWasher, completionTime)) {
+            return true;
+        }
         return hasSuspiciousExpectedCompletionTime(reservation)
                 && hasFreshCompletionEvidence(reservation, status, isWasher, completionTime);
+    }
+
+    private boolean hasFreshStoppedCompletionEvidence(Reservation reservation,
+            SmartThingsDeviceStatusResDto status,
+            boolean isWasher,
+            LocalDateTime completionTime) {
+        var startTime = reservation.getStartTime();
+        if (startTime == null || completionTime.isBefore(startTime)) {
+            return false;
+        }
+        if (!"stop".equalsIgnoreCase(getOperatingState(status, isWasher))) {
+            return false;
+        }
+        return hasFreshCompletionEvidence(reservation, status, isWasher, completionTime);
     }
 
     private boolean hasSuspiciousExpectedCompletionTime(Reservation reservation) {
@@ -338,7 +355,7 @@ public class ReservationLifecycleProcessor {
 
     private void logEarlyCompletionAccepted(Reservation reservation, LocalDateTime completionTime) {
         log.info(
-                "completion accepted reason=suspicious_expected_completion_time reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
+                "completion accepted reason=fresh_completion_evidence reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
                 reservation.getId(),
                 reservation.getStartTime(),
                 reservation.getExpectedCompletionTime(),

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
@@ -85,18 +85,18 @@ public class MachineStateDetectionSupport {
             return Optional.of(completionTime != null && !completionTime.isAfter(now) ? completionTime : now);
         }
 
+        if (isResetJobState(jobState) && completionTime != null) {
+            log.debug("device job is completed after job reset jobState={} completionTime={}",
+                    jobState,
+                    completionTime);
+            return Optional.of(completionTime.isAfter(now) ? now : completionTime);
+        }
+
         if (completionTime != null && completionTime.isAfter(now)) {
             log.debug("device stopped but completion time still in future completionTime={} jobState={}",
                     completionTime,
                     jobState);
             return Optional.empty();
-        }
-
-        if (isResetJobState(jobState) && completionTime != null) {
-            log.debug("device job is completed after job reset jobState={} completionTime={}",
-                    jobState,
-                    completionTime);
-            return Optional.of(completionTime);
         }
 
         return Optional.empty();

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
@@ -85,18 +85,18 @@ public class MachineStateDetectionSupport {
             return Optional.of(completionTime != null && !completionTime.isAfter(now) ? completionTime : now);
         }
 
-        if (isResetJobState(jobState) && completionTime != null) {
-            log.debug("device job is completed after job reset jobState={} completionTime={}",
-                    jobState,
-                    completionTime);
-            return Optional.of(completionTime.isAfter(now) ? now : completionTime);
-        }
-
         if (completionTime != null && completionTime.isAfter(now)) {
             log.debug("device stopped but completion time still in future completionTime={} jobState={}",
                     completionTime,
                     jobState);
             return Optional.empty();
+        }
+
+        if (isResetJobState(jobState) && completionTime != null) {
+            log.debug("device job is completed after job reset jobState={} completionTime={}",
+                    jobState,
+                    completionTime);
+            return Optional.of(completionTime);
         }
 
         return Optional.empty();

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
@@ -132,6 +132,36 @@ class ReservationLifecycleProcessorTest {
         return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
     }
 
+    private SmartThingsDeviceStatusResDto buildDryerStoppedStatusWithTimestamp(String jobState,
+            String completionTime,
+            String machineStateTimestamp,
+            String jobStateTimestamp) {
+        return buildDryerStoppedStatusWithTimestamp(jobState,
+                completionTime,
+                machineStateTimestamp,
+                jobStateTimestamp,
+                null);
+    }
+
+    private SmartThingsDeviceStatusResDto buildDryerStoppedStatusWithTimestamp(String jobState,
+            String completionTime,
+            String machineStateTimestamp,
+            String jobStateTimestamp,
+            String switchStatus) {
+        var machineStateAttr = new SmartThingsDeviceStatusResDto.AttributeState("stop", machineStateTimestamp, null);
+        var jobStateAttr = new SmartThingsDeviceStatusResDto.AttributeState(jobState, jobStateTimestamp, null);
+        var completionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState(completionTime, null, null);
+        var switchAttr = switchStatus == null
+                ? null
+                : new SmartThingsDeviceStatusResDto.SwitchCapability(
+                        new SmartThingsDeviceStatusResDto.AttributeState(switchStatus, null, null));
+        var dryerOpState = new SmartThingsDeviceStatusResDto.DryerOperatingState(machineStateAttr,
+                jobStateAttr,
+                completionTimeAttr);
+        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(null, dryerOpState, switchAttr, null);
+        return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
+    }
+
     private String isoUtc(LocalDateTime koreaTime) {
         return koreaTime.atZone(KOREA_ZONE).withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime().toString() + "Z";
     }
@@ -296,35 +326,11 @@ class ReservationLifecycleProcessorTest {
         }
 
         @Test
-        @DisplayName("예상 완료 시각보다 일러도 정지 상태의 최신 완료 증거가 있으면 완료 처리한다")
-        void shouldCompleteReservation_WhenCompletionDetectedTooEarlyWithFreshStoppedEvidence() {
+        @DisplayName("예상 완료 시간이 정상 범위이면 너무 이른 완료 신호를 보류한다")
+        void shouldNotCompleteReservation_WhenCompletionDetectedTooEarlyWithNormalExpectedTime() {
             // Given
             var nowKst = LocalDateTime.now(KOREA_ZONE);
             var deviceStatus = buildDryerStatusWithTimestamp(isoUtc(nowKst), isoUtc(nowKst));
-            givenRunningReservation();
-            when(reservation.getUser()).thenReturn(user);
-            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(1));
-            when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.plusMinutes(10));
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.of(nowKst));
-
-            // When
-            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
-
-            // Then
-            verify(reservation, times(1)).complete();
-            verify(machine, times(1)).markAsAvailable();
-            verify(reservationRepository, times(1)).save(reservation);
-            verify(machineRepository, times(1)).save(machine);
-            verify(reservationNotificationSupport, times(1)).sendCompletion(user, machine);
-        }
-
-        @Test
-        @DisplayName("예상 완료 시각보다 이른 완료 신호에 최신 정지 증거가 없으면 보류한다")
-        void shouldNotCompleteReservation_WhenCompletionDetectedTooEarlyWithoutFreshStoppedEvidence() {
-            // Given
-            var nowKst = LocalDateTime.now(KOREA_ZONE);
-            var deviceStatus = buildDeviceStatus(null);
             givenRunningReservation();
             when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(1));
             when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.plusMinutes(10));
@@ -340,6 +346,96 @@ class ReservationLifecycleProcessorTest {
             verify(reservationRepository, never()).save(reservation);
             verify(machineRepository, never()).save(machine);
             verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
+        }
+
+        @Test
+        @DisplayName("jobState 리셋과 미래 완료 시각이 처음 감지되면 완료 후보로만 기록한다")
+        void shouldDeferCompletion_WhenStoppedResetFutureCompletionBelowThreshold() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var deviceStatus = buildDryerStoppedStatusWithTimestamp("none",
+                    isoUtc(nowKst.plusHours(1)),
+                    isoUtc(nowKst),
+                    isoUtc(nowKst));
+            givenRunningReservation();
+            when(machine.isWasher()).thenReturn(false);
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(10));
+            when(reservation.getInterruptionCount()).thenReturn(1);
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(Optional.empty());
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, times(1)).incrementInterruptionCount();
+            verify(reservation, never()).complete();
+            verify(machine, never()).markAsAvailable();
+            verify(reservationRepository, times(1)).save(reservation);
+            verify(machineRepository, never()).save(machine);
+            verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
+            verify(machineStateDetectionSupport, never()).isInterrupted(any(), anyBoolean());
+        }
+
+        @Test
+        @DisplayName("전원이 꺼진 정지 상태는 완료 후보가 아니라 중단 후보로 처리한다")
+        void shouldTreatPowerOffStoppedResetAsInterruptionCandidate() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var deviceStatus = buildDryerStoppedStatusWithTimestamp("none",
+                    isoUtc(nowKst.plusHours(1)),
+                    isoUtc(nowKst),
+                    isoUtc(nowKst),
+                    "off");
+            givenRunningReservation();
+            when(machine.isWasher()).thenReturn(false);
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(Optional.empty());
+            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(true);
+            when(reservation.getInterruptionCount()).thenReturn(1);
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, times(1)).incrementInterruptionCount();
+            verify(reservation, never()).complete();
+            verify(reservationRepository, times(1)).save(reservation);
+            verify(machineRepository, never()).save(machine);
+            verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
+            verify(machineStateDetectionSupport, times(1)).isInterrupted(deviceStatus, false);
+        }
+
+        @Test
+        @DisplayName("jobState 리셋과 미래 완료 시각이 연속 감지되면 완료 처리한다")
+        void shouldComplete_WhenStoppedResetFutureCompletionConfirmed() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var deviceStatus = buildDryerStoppedStatusWithTimestamp("none",
+                    isoUtc(nowKst.plusHours(1)),
+                    isoUtc(nowKst),
+                    isoUtc(nowKst));
+            givenRunningReservation();
+            when(machine.isWasher()).thenReturn(false);
+            when(reservation.getUser()).thenReturn(user);
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(10));
+            when(reservation.getInterruptionCount()).thenReturn(ReservationConstants.INTERRUPTION_CONFIRM_THRESHOLD);
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(Optional.empty());
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, times(1)).incrementInterruptionCount();
+            verify(reservation, times(1)).clearInterruptionCount();
+            verify(reservation, times(1)).complete();
+            verify(machine, times(1)).markAsAvailable();
+            verify(reservationRepository, times(1)).save(reservation);
+            verify(machineRepository, times(1)).save(machine);
+            verify(reservationNotificationSupport, times(1)).sendCompletion(user, machine);
+            verify(machineStateDetectionSupport, never()).isInterrupted(any(), anyBoolean());
         }
 
         @Test

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
@@ -296,11 +296,35 @@ class ReservationLifecycleProcessorTest {
         }
 
         @Test
-        @DisplayName("예상 완료 시간이 정상 범위이면 너무 이른 완료 신호를 보류한다")
-        void shouldNotCompleteReservation_WhenCompletionDetectedTooEarlyWithNormalExpectedTime() {
+        @DisplayName("예상 완료 시각보다 일러도 정지 상태의 최신 완료 증거가 있으면 완료 처리한다")
+        void shouldCompleteReservation_WhenCompletionDetectedTooEarlyWithFreshStoppedEvidence() {
             // Given
             var nowKst = LocalDateTime.now(KOREA_ZONE);
             var deviceStatus = buildDryerStatusWithTimestamp(isoUtc(nowKst), isoUtc(nowKst));
+            givenRunningReservation();
+            when(reservation.getUser()).thenReturn(user);
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(1));
+            when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.plusMinutes(10));
+            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(Optional.of(nowKst));
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, times(1)).complete();
+            verify(machine, times(1)).markAsAvailable();
+            verify(reservationRepository, times(1)).save(reservation);
+            verify(machineRepository, times(1)).save(machine);
+            verify(reservationNotificationSupport, times(1)).sendCompletion(user, machine);
+        }
+
+        @Test
+        @DisplayName("예상 완료 시각보다 이른 완료 신호에 최신 정지 증거가 없으면 보류한다")
+        void shouldNotCompleteReservation_WhenCompletionDetectedTooEarlyWithoutFreshStoppedEvidence() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var deviceStatus = buildDeviceStatus(null);
             givenRunningReservation();
             when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(1));
             when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.plusMinutes(10));

--- a/src/test/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupportTest.java
@@ -125,6 +125,17 @@ class MachineStateDetectionSupportTest {
         }
 
         @Test
+        @DisplayName("완료 직후 jobState가 none으로 리셋되고 완료 시각이 미래여도 완료로 판정한다")
+        void shouldComplete_WhenJobStateResetAndCompletionTimeInFuture() {
+            var future = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusHours(1);
+            var status = washerStatus("stop", "none", isoUtc(future));
+
+            var result = machineStateDetectionSupport.isCompleted(status, WASHER);
+
+            assertThat(result).isPresent();
+        }
+
+        @Test
         @DisplayName("jobState가 none으로 리셋됐지만 완료 시각이 없으면 완료로 판정하지 않는다")
         void shouldNotComplete_WhenJobStateResetAndCompletionTimeNull() {
             var status = washerStatus("stop", "none", null);
@@ -177,6 +188,17 @@ class MachineStateDetectionSupportTest {
         void shouldComplete_WhenDryerJobStateResetAndCompletionTimePassed() {
             var past = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(1);
             var status = dryerStatus("stop", "none", isoUtc(past));
+
+            var result = machineStateDetectionSupport.isCompleted(status, DRYER);
+
+            assertThat(result).isPresent();
+        }
+
+        @Test
+        @DisplayName("건조 완료 직후 jobState가 none으로 리셋되고 완료 시각이 미래여도 완료로 판정한다")
+        void shouldComplete_WhenDryerJobStateResetAndCompletionTimeInFuture() {
+            var future = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusHours(1);
+            var status = dryerStatus("stop", "none", isoUtc(future));
 
             var result = machineStateDetectionSupport.isCompleted(status, DRYER);
 

--- a/src/test/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupportTest.java
@@ -125,14 +125,14 @@ class MachineStateDetectionSupportTest {
         }
 
         @Test
-        @DisplayName("완료 직후 jobState가 none으로 리셋되고 완료 시각이 미래여도 완료로 판정한다")
-        void shouldComplete_WhenJobStateResetAndCompletionTimeInFuture() {
+        @DisplayName("jobState가 none으로 리셋되어도 완료 시각이 미래이면 완료로 판정하지 않는다")
+        void shouldNotComplete_WhenJobStateResetAndCompletionTimeInFuture() {
             var future = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusHours(1);
             var status = washerStatus("stop", "none", isoUtc(future));
 
             var result = machineStateDetectionSupport.isCompleted(status, WASHER);
 
-            assertThat(result).isPresent();
+            assertThat(result).isEmpty();
         }
 
         @Test
@@ -195,14 +195,14 @@ class MachineStateDetectionSupportTest {
         }
 
         @Test
-        @DisplayName("건조 완료 직후 jobState가 none으로 리셋되고 완료 시각이 미래여도 완료로 판정한다")
-        void shouldComplete_WhenDryerJobStateResetAndCompletionTimeInFuture() {
+        @DisplayName("건조 jobState가 none으로 리셋되어도 완료 시각이 미래이면 완료로 판정하지 않는다")
+        void shouldNotComplete_WhenDryerJobStateResetAndCompletionTimeInFuture() {
             var future = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusHours(1);
             var status = dryerStatus("stop", "none", isoUtc(future));
 
             var result = machineStateDetectionSupport.isCompleted(status, DRYER);
 
-            assertThat(result).isPresent();
+            assertThat(result).isEmpty();
         }
     }
 


### PR DESCRIPTION
## 개요

세탁기·건조기 완료 직후 서버가 기존 예상 완료 시각을 유지해 앱에 남은 시간이 표시되는 문제를 수정했습니다.
기기가 정지했고 최신 완료 증거가 확인되면 `RUNNING` 예약을 즉시 완료 처리해 예약 가능 상태로 전환합니다.

## 본문

`MachineStateDetectionSupport`에서 `machineState=stop`이고 `jobState`가 `none` 등으로 리셋된 직후에도 `completionTime`이 존재하면 완료로 판정하도록 변경했습니다.

`ReservationLifecycleProcessor`의 너무 이른 완료 보류 로직은 유지하되, 예약 시작 이후의 신선한 정지·완료 증거가 있는 경우에는 보류하지 않고 `COMPLETED` 전환과 기기 `AVAILABLE` 전환을 수행하도록 조정했습니다.

세탁기·건조기 모두 `jobState` 리셋 후 미래 `completionTime`이 남아 있는 케이스와, 정상 예상 완료 시각보다 빨리 완료 신호가 들어온 케이스의 회귀 테스트를 추가했습니다.

검증:
- `./gradlew.bat test --tests "team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupportTest" --tests "team.washer.server.v2.domain.reservation.service.ReservationLifecycleProcessorTest" --tests "team.washer.server.v2.domain.machine.service.QueryAllMachinesStatusServiceTest"`
- `./gradlew.bat test`
