### PR TITLE
[reservation] 완료 판정 통합 및 완료 디바운스 적용

### DIFF
--- a/docs/analysis-reservation-state-transition.md
+++ b/docs/analysis-reservation-state-transition.md
@@ -21,14 +21,20 @@ PR #102 범위의 항목은 해당 PR에 인라인 코멘트로 남겼다. 이 �
 
 | 브랜치 | 범위 | 상태 |
 |---|---|---|
-| `fix/reservation-completion-detection-unification` | 3장 1~3단계 (2-1 · 2-2 · 2-3 · 2-4) | 진행 중 |
-| 후속 브랜치 (2-5) | `ReservationTimeoutScheduler` 운영시간 체크 | 예정 |
-| 후속 브랜치 (2-6) | 강제정지 `ALREADY_STOPPED` 취소 조건 + 취소 알림 | 예정 |
-| 후속 브랜치 (2-7) | `complete()` 시 잔여 상태 정리 | 예정 |
-| 후속 브랜치 (2-8) | 활성 예약 선택 규칙 통일 | 예정 |
+| `fix/reservation-completion-detection-unification` | 3장 1~3단계 (2-1 · 2-2 · 2-3 · 2-4) | PR #103 |
+| `fix/reservation-lifecycle-residue` | 2-5 + 2-7 | 진행 중 |
+| `fix/force-stop-cancellation-notification` | 2-6 | 예정 |
+| `fix/active-reservation-selection` | 2-8 | 예정 |
 
-2-5 ~ 2-8은 코어 3단계와 서로 독립적이므로 **각각 별도 브랜치·PR로 진행한다.**
-리뷰 단위를 작게 유지하고, 코어 변경의 회귀 여부를 별건과 섞이지 않게 확인하기 위함이다.
+별건은 코어 3단계와 독립적이므로 분리하되, 규모에 맞춰 묶는다.
+
+- **2-5 + 2-7**: 각각 수 줄 규모이고 둘 다 reservation 도메인이라 하나로 묶는다.
+- **2-6**: `NotificationType`을 새로 만들어야 하고 관리자 기능의 동작 자체가 바뀌므로 단독으로 둔다.
+- **2-8**: 활성 예약 선택 규칙을 바꾸면 목록 API 표시가 달라져 회귀 확인 지점이 다르므로 단독으로 둔다.
+
+`fix/reservation-lifecycle-residue`는 2-7이 코어 브랜치에서 재작성한 `completeReservation`을
+건드리므로 `develop`이 아니라 **코어 브랜치 위에 쌓아 올린다.** 코어가 머지되면 base가
+`develop`으로 전환된다.
 
 ---
 

--- a/docs/analysis-reservation-state-transition.md
+++ b/docs/analysis-reservation-state-transition.md
@@ -1,0 +1,240 @@
+# 예약 상태 전이 로직 정합성 분석
+
+작성일: 2026-08-26
+대상 브랜치: `fix/machine-completion-immediate-availability` (PR #102) 기준
+관련 PR: #96, #101, #102
+
+## 요약
+
+PR #102 리뷰 중 발견된 문제를 추적하다가, 그 아래에 누적된 구조적 결함을 확인했다.
+**"기기 사이클이 완료됐는가"를 판정하는 규칙이 코드 네 곳에 서로 다르게 구현되어 있다.**
+
+PR #96 → #101 → #102로 이어지며 각각 다른 지점에 패치를 얹는 사이 이 편차가 벌어졌고,
+그 결과 화면에 보이는 상태와 DB에 저장된 상태가 갈라지는 현상이 발생한다.
+
+PR #102 범위의 항목은 해당 PR에 인라인 코멘트로 남겼다. 이 문서는 **PR #102만 되돌려서는
+해결되지 않는 항목**을 정리한다.
+
+## 작업 분할
+
+`develop` 기준으로 브랜치를 나눠 진행한다.
+
+| 브랜치 | 범위 | 상태 |
+|---|---|---|
+| `fix/reservation-completion-detection-unification` | 3장 1~3단계 (2-1 · 2-2 · 2-3 · 2-4) | 진행 중 |
+| 후속 브랜치 (2-5) | `ReservationTimeoutScheduler` 운영시간 체크 | 예정 |
+| 후속 브랜치 (2-6) | 강제정지 `ALREADY_STOPPED` 취소 조건 + 취소 알림 | 예정 |
+| 후속 브랜치 (2-7) | `complete()` 시 잔여 상태 정리 | 예정 |
+| 후속 브랜치 (2-8) | 활성 예약 선택 규칙 통일 | 예정 |
+
+2-5 ~ 2-8은 코어 3단계와 서로 독립적이므로 **각각 별도 브랜치·PR로 진행한다.**
+리뷰 단위를 작게 유지하고, 코어 변경의 회귀 여부를 별건과 섞이지 않게 확인하기 위함이다.
+
+---
+
+## 1. 근본 원인: 완료 판정 규칙의 분산
+
+| 위치 | 완료 판정 근거 | stale 가드 | 조기완료 가드 | 디바운스 |
+|---|---|---|---|---|
+| `MachineStateDetectionSupport.isCompleted` | jobState + machineState + completionTime | — | — | — |
+| `ReservationLifecycleProcessor` (`isCompleted` 경로) | 위 + 3중 가드 | O | O | X |
+| `ReservationLifecycleProcessor.getStoppedNearCompletionTime` | stop + completionTime ±5분 | **X** | **X** | X |
+| `QueryAllMachinesStatusServiceImpl.getDisplayReservation` | `isCompleted`만 | **X** | **X** | X |
+
+같은 질문에 네 가지 답이 나온다. 특히 아래 두 경로는 라이프사이클이 공들여 쌓아둔 방어를
+전혀 거치지 않는다.
+
+- `getStoppedNearCompletionTime` (PR #101에서 도입)
+- `getDisplayReservation` (PR #101에서 도입)
+
+참고로 중단 판정(`isInterrupted`)에는 이미 `INTERRUPTION_CONFIRM_THRESHOLD` 기반의
+연속 감지(디바운스)가 있으나, **완료 판정에는 어느 경로에도 디바운스가 없다.**
+SmartThings가 단 한 번 순간적으로 보고한 `stop`이 곧바로 확정 처리된다.
+
+---
+
+## 2. 발견 항목
+
+### 2-1. [High] 목록 API와 라이프사이클이 서로 다른 상태를 보고한다
+
+- 위치: `QueryAllMachinesStatusServiceImpl.java:115` (`getDisplayReservation`)
+- 도입: PR #101 (`60e2c53`)
+
+`getDisplayReservation`은 `isCompleted().isPresent()`만 보고 RUNNING 예약을 숨긴다.
+반면 라이프사이클은 같은 신호를 `stale_completion` / `too_early_completion`으로
+**보류**한다 (`ReservationLifecycleProcessor.java:106,115`).
+
+즉 라이프사이클이 완료를 거부하는 동안에도 목록 API는 이미 AVAILABLE을 반환한다.
+`getDisplayReservation`이 null을 반환하면 `computeAvailability`가
+`reservation == null` + `isOperating == false`(stop)로 판단해 AVAILABLE을 내보내기 때문이다.
+
+**증상 (사용자 관점)**
+
+1. 기기 목록에 "사용 가능 / 남은 시간 없음"으로 표시된다.
+2. 예약을 누르면 실패한다.
+   - `CreateReservationServiceImpl.java:82` → `해당 기기를 사용할 수 없습니다` (400)
+     — DB의 `machine.availability`는 여전히 `IN_USE`이기 때문
+   - 또는 `CreateReservationServiceImpl.java:88` → `해당 기기에 이미 진행 중인 예약이 있습니다` (409)
+
+PR #102는 `isCompleted`가 `present`를 반환하는 조건을 넓히므로 이 현상의 발생 빈도를 키운다.
+사이클 도중 순간 정지 한 번에 목록이 "사용 가능"으로 깜빡인다. PR #101이 고치려던 증상
+(완료 후에도 남은 시간이 계속 표시됨)의 정반대 오류다.
+
+### 2-2. [High] `stopped_near_completion` 경로가 가드를 통째로 우회한다
+
+- 위치: `ReservationLifecycleProcessor.java:234` (`getStoppedNearCompletionTime`), `:205` (`processStoppedNearCompletion`)
+- 도입: PR #101 (`60e2c53`)
+
+`getStoppedNearCompletionTime`은 `completionTime.isBefore(startTime)`만 확인한다.
+`isCompleted` 경로에 있는 아래 가드가 **하나도 적용되지 않는다.**
+
+- `isStaleCompletion`의 타임스탬프 검사 (`:293-294` — operatingStateTimestamp / jobStateTimestamp가 startTime 이전인지)
+- `isTooEarlyCompletion` (`:297`)
+
+그리고 `processStoppedNearCompletion`은 completionTime이 과거이기만 하면 곧바로
+`completeReservation`을 호출한다 (`:205-207`).
+
+**시나리오**: 60분 코스 10분 경과 시점에 `stop` + `jobState=wash` + completionTime이
+잠깐 과거 값으로 보고되면 (단 startTime 이후) 즉시 완료가 확정된다.
+
+### 2-3. [Medium] 중단 확정이 영구히 불가능해지는 조합
+
+- 위치: `ReservationLifecycleProcessor.java:131` vs `:137`, `:211-214`
+
+`getStoppedNearCompletionTime`(`:131`)이 `isInterrupted`(`:137`)보다 **먼저** 평가되고,
+`processStoppedNearCompletion`이 `:211-214`에서 `interruptionCount`를 clear한다.
+
+따라서 사용자가 전원을 끈(`switch=off`) 상태여도 completionTime이 ±5분 안이면
+매 폴링(30초)마다 카운터가 0으로 리셋되어 `INTERRUPTION_CONFIRM_THRESHOLD`에
+**절대 도달하지 못한다.**
+
+그리고 completionTime이 지나는 순간 중단이 아니라 **정상 완료**로 처리되어,
+`sendInterruption`이 아닌 `sendCompletion` 알림이 나간다.
+
+### 2-4. [Medium] 가드가 자기 기준선을 스스로 오염시킨다
+
+- 위치: `ReservationLifecycleProcessor.java:216-220`, `:193-200`
+
+두 지점이 SmartThings의 completionTime을 `expectedCompletionTime`에 계속 덮어쓴다.
+그런데 `isTooEarlyCompletion`(`:298`)은 **바로 그 `expectedCompletionTime`을 기준으로**
+조기 완료를 판정한다. 정지 중 기기가 보고한 값이 기준선이 되면 가드가 무의미해진다.
+
+또한 `:193-200`의 갱신에는 상한 검증이 없다. 이상치가 그대로 저장되고,
+나중에 `hasSuspiciousExpectedCompletionTime`(`:331`, 240분 초과)이라는
+**우회로로 그 이상치를 예외 처리**한다. 저장 시점에 상한을 검증하면 이 우회로 자체가 불필요하다.
+
+### 2-5. [Medium] `ReservationTimeoutScheduler`만 운영시간 체크가 없다
+
+- 위치: `ReservationTimeoutScheduler.java:20`
+
+| 스케줄러 | 주기 | `operationTimePolicy` 확인 |
+|---|---|---|
+| `ReservationLifecycleScheduler` | 30초 | O (`:23`) |
+| `IdleMachineShutdownScheduler` | 60초 | O (`:23`) |
+| `ReservationTimeoutScheduler` | 60초 | **X** |
+
+운영시간 외에도 60초마다 돌면서 RESERVED 예약을 취소하고
+**패널티(쿨다운 · 취소횟수 · 48h 블록)를 부여**한다 (`OverdueReservationProcessor.java:94-100`).
+
+라이프사이클 스케줄러는 멈춰 있어 RESERVED → RUNNING 전환이 일어나지 않는 시간대이므로,
+그 시간에 남아 있던 예약은 자동 시작 기회 없이 취소 + 패널티만 받는다.
+
+### 2-6. [Medium] 강제정지가 정상 사이클을 취소할 수 있고, 알림도 가지 않는다
+
+- 위치: `ForceStopMachineServiceImpl.java:119`, `:122`
+
+**(a) `ALREADY_STOPPED`인데 RUNNING이면 취소된다**
+
+```java
+if (forceStopResult != ForceStopResult.STOPPED && !reservation.isRunning()) {
+    return null;
+}
+reservation.cancel();
+```
+
+뒤집으면 `ALREADY_STOPPED` + RUNNING 조합에서 취소가 실행된다.
+`:73`의 stop 판정은 단발 조회라 라이프사이클의 디바운스가 전혀 없어서,
+사이클 단계 전환 중 순간 stop일 때 관리자가 버튼을 누르면 정상 진행 중인 예약이 취소된다.
+
+**(b) 취소 알림이 없다**
+
+| 취소 경로 | 알림 |
+|---|---|
+| 기기 중단 확정 | `sendInterruption` |
+| pause 타임아웃 | `sendPauseTimeout` |
+| RESERVED 타임아웃 | `sendAutoCancellation` |
+| **관리자 강제정지** | **없음** |
+
+진행 중이던 사용자는 목록에서 예약이 사라진 것으로만 알 수 있다.
+
+### 2-7. [Low] `complete()`가 잔여 상태를 정리하지 않는다
+
+- 위치: `ReservationLifecycleProcessor.java:260` (`completeReservation`)
+
+중단 경로(`:143`)와 pause 타임아웃 경로(`:172`)는 `clearInterruptionCount` /
+`clearPausedAt`을 호출하는데, `completeReservation`은 `reservation.complete()`만 부른다.
+`pausedAt` · `interruptionCount`가 COMPLETED 예약에 남아 관리자 이력에 노출된다.
+
+### 2-8. [Low] "활성 예약 하나 고르기" 규칙이 두 가지다
+
+| 위치 | 선택 규칙 |
+|---|---|
+| `ForceStopMachineServiceImpl.java:108` | RUNNING 우선, 없으면 RESERVED |
+| `ReservationRepository.java:55` (`findActiveReservationByMachineId`) | `createdAt DESC` 첫 번째 |
+
+목록 API는 후자를 쓰므로, 상태 드리프트로 RUNNING과 RESERVED가 공존하면
+최신 RESERVED가 RUNNING을 가려 실제로는 IN_USE인 기기가 RESERVED로 표시된다.
+
+---
+
+## 3. 개선 순서 제안
+
+### 1단계 — 완료 판정을 한 곳으로 모은다
+
+가드(stale · 조기완료)까지 포함한 완료 판정을 `ReservationCompletionDecisionSupport`
+하나로 모으고, 라이프사이클만 이것을 호출한다.
+
+- 2-2의 `stopped_near_completion` 우회 경로도 이 통합 판정 안으로 들어간다.
+- **목록 API는 완료를 예측하지 않는다.** `getDisplayReservation`을 제거하고 DB의 예약
+  상태만 그대로 반영한다. 완료 확정은 라이프사이클이 디바운스와 가드를 거쳐 DB에 쓰고,
+  목록은 그 결과만 읽으므로 2-1의 화면/DB 불일치가 구조적으로 불가능해진다.
+  대가는 완료 반영이 라이프사이클 확정 시점까지 지연된다는 것(최대 30초 × 임계값).
+
+### 2단계 — 완료 판정에도 디바운스를 적용한다
+
+`isInterrupted`가 이미 쓰는 `INTERRUPTION_CONFIRM_THRESHOLD` 방식(연속 감지 확인)을
+완료 판정에도 적용한다. 완료는 `COMPLETION_CONFIRM_THRESHOLD`(연속 2회)를 별도로 둔다.
+
+- PR #102가 노린 "완료 직후 즉시 AVAILABLE 전환"은 최대 30초 지연으로 유지된다.
+- 사이클 도중 순간 정지에 의한 오탐이 막힌다.
+- 2-3의 `interruptionCount` 리셋 문제도 함께 해소된다
+  (완료 판정과 중단 판정이 같은 디바운스 체계 위에 놓이므로).
+
+### 3단계 — `expectedCompletionTime` 저장 시 상한을 검증한다
+
+`MAX_REASONABLE_CYCLE_MINUTES`를 저장 시점에 적용하면
+`hasSuspiciousExpectedCompletionTime` 우회로를 삭제할 수 있다 (2-4).
+
+### 별건 (후속 브랜치로 각각 분리)
+
+위 1~3단계와 의존 관계가 없으므로 코어 브랜치에 섞지 않고 개별 브랜치·PR로 처리한다.
+
+- 2-5 `ReservationTimeoutScheduler`에 운영시간 체크 추가
+- 2-6 강제정지의 `ALREADY_STOPPED` 취소 조건 수정 + 취소 알림 추가
+- 2-7 `complete()` 시 잔여 상태 정리
+- 2-8 활성 예약 선택 규칙 통일
+
+---
+
+## 4. PR #102 자체 항목 (참고 — 해당 PR에 코멘트 완료)
+
+| 위치 | 내용 |
+|---|---|
+| `MachineStateDetectionSupport.java:88` | [High] reset-jobState 분기를 미래 completionTime 가드보다 앞으로 옮겨 가드가 무력화됨 |
+| `ReservationLifecycleProcessor.java:317` | [High] `hasFreshStoppedCompletionEvidence`의 두 조건이 항상 통과해 `too_early_completion` 보류가 죽음 |
+| `MachineStateDetectionSupport.java:95` | [Low] 아래로 밀려난 블록이 동작상 죽은 코드가 됨 |
+| `ReservationLifecycleProcessorTest.java:327` | [Medium] `buildDeviceStatus(null)`은 machineState가 null이라 도달 불가능한 상태를 검증 |
+| `ReservationLifecycleProcessor.java:358` | [Low] 두 수용 경로의 로그 reason이 합쳐져 구분 불가 |
+
+제거된 가드는 `3ef60b2`(조기 완료 표시 수정)에서 "실제 종료 2~4분 전 완료 오인"을 막으려고
+의도적으로 넣은 것이고, `1f5e786`(조기 완료 방어 보강)이 그 위에 쌓은 것이다.

--- a/src/main/java/team/washer/server/v2/domain/machine/dto/response/ForceStopMachineResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/dto/response/ForceStopMachineResDto.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import team.washer.server.v2.domain.machine.enums.ForceStopResult;
 import team.washer.server.v2.domain.machine.enums.MachineAvailability;
 import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 
 @Schema(description = "기기 강제 정지 응답 DTO")
 public record ForceStopMachineResDto(@Schema(description = "기기 ID", example = "1") Long machineId,
@@ -11,7 +12,7 @@ public record ForceStopMachineResDto(@Schema(description = "기기 ID", example 
         @Schema(description = "기기 타입", example = "WASHER") MachineType machineType,
         @Schema(description = "SmartThings Device ID", example = "device-abc") String deviceId,
         @Schema(description = "SmartThings 강제 정지 처리 결과", example = "STOPPED") ForceStopResult forceStopResult,
-        @Schema(description = "처리 전 기기 동작 상태", example = "run") String previousMachineState,
+        @Schema(description = "처리 전 기기 동작 상태", example = "run") MachineOperatingState previousMachineState,
         @Schema(description = "취소된 활성 예약 ID", example = "1") Long cancelledReservationId,
         @Schema(description = "활성 예약 취소 여부", example = "true") boolean reservationCancelled,
         @Schema(description = "변경된 기기 사용 가능 상태", example = "AVAILABLE") MachineAvailability availability) {

--- a/src/main/java/team/washer/server/v2/domain/machine/dto/response/MachineStatusResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/dto/response/MachineStatusResDto.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import team.washer.server.v2.domain.machine.enums.MachineAvailability;
 import team.washer.server.v2.domain.machine.enums.MachineStatus;
 import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 
 @Schema(description = "기기 상태 응답")
 public record MachineStatusResDto(@Schema(description = "기기 ID", example = "1") Long machineId,
@@ -18,7 +19,7 @@ public record MachineStatusResDto(@Schema(description = "기기 ID", example = "
 
         @Schema(description = "사용 가능 여부", example = "AVAILABLE") MachineAvailability availability,
 
-        @Schema(description = "작동 상태", example = "running") String operatingState,
+        @Schema(description = "작동 상태", example = "run") MachineOperatingState operatingState,
 
         @Schema(description = "작업 상태", example = "washing") String jobState,
 

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/ForceStopMachineServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/ForceStopMachineServiceImpl.java
@@ -23,6 +23,7 @@ import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.smartthings.dto.request.SmartThingsCommandReqDto;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 import team.washer.server.v2.domain.smartthings.service.SendDeviceCommandService;
 import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
 
@@ -42,7 +43,9 @@ public class ForceStopMachineServiceImpl implements ForceStopMachineService {
         final var machine = machineRepository.findById(machineId)
                 .orElseThrow(() -> new ExpectedException("기기를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
         final var status = deviceStatusQuerySupport.queryDeviceStatus(machine.getDeviceId());
-        final var previousMachineState = extractMachineState(machine, status);
+        final var previousMachineState = status == null
+                ? MachineOperatingState.UNKNOWN
+                : status.getOperatingState(machine.isWasher());
         final var forceStopResult = forceStop(machine, status, previousMachineState);
         final var updateResult = updateMachineAndReservation(machineId, forceStopResult);
 
@@ -63,17 +66,19 @@ public class ForceStopMachineServiceImpl implements ForceStopMachineService {
                 updateResult.availability());
     }
 
-    private ForceStopResult forceStop(Machine machine, SmartThingsDeviceStatusResDto status, String machineState) {
+    private ForceStopResult forceStop(Machine machine,
+            SmartThingsDeviceStatusResDto status,
+            MachineOperatingState machineState) {
         if (status == null) {
             throw new ExpectedException("기기 상태를 확인할 수 없습니다", HttpStatus.BAD_GATEWAY);
         }
         if (!machine.isWasher() && !machine.isDryer()) {
             throw new ExpectedException("지원하지 않는 기기 유형입니다", HttpStatus.BAD_REQUEST);
         }
-        if ("off".equalsIgnoreCase(status.getSwitchStatus()) || "stop".equalsIgnoreCase(machineState)) {
+        if (status.isSwitchOff() || machineState == MachineOperatingState.STOP) {
             return ForceStopResult.ALREADY_STOPPED;
         }
-        if (!"run".equalsIgnoreCase(machineState) && !"pause".equalsIgnoreCase(machineState)) {
+        if (!machineState.isOperating()) {
             throw new ExpectedException("기기 동작 상태를 확인할 수 없습니다", HttpStatus.BAD_GATEWAY);
         }
 
@@ -140,19 +145,6 @@ public class ForceStopMachineServiceImpl implements ForceStopMachineService {
             }
         }
         machine.markAsAvailable();
-    }
-
-    private String extractMachineState(Machine machine, SmartThingsDeviceStatusResDto status) {
-        if (status == null) {
-            return null;
-        }
-        if (machine.isWasher()) {
-            return status.getWasherOperatingState();
-        }
-        if (machine.isDryer()) {
-            return status.getDryerOperatingState();
-        }
-        return null;
     }
 
     private record UpdateResult(Long machineId, String machineName, MachineType machineType, String deviceId,

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
@@ -21,6 +21,7 @@ import team.washer.server.v2.domain.machine.service.QueryAllMachinesStatusServic
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.global.util.DateTimeUtil;
@@ -66,15 +67,15 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
     private MachineStatusResDto mapToStatusDto(Machine machine,
             SmartThingsDeviceStatusResDto deviceStatus,
             Reservation reservation) {
-        String operatingState = null;
+        MachineOperatingState operatingState = MachineOperatingState.UNKNOWN;
         String jobState = null;
         String switchStatus = null;
         LocalDateTime expectedCompletionTime = null;
         Long remainingMinutes = null;
 
         if (deviceStatus != null) {
-            operatingState = getOperatingState(machine, deviceStatus);
-            jobState = getJobState(machine, deviceStatus);
+            operatingState = deviceStatus.getOperatingState(machine.isWasher());
+            jobState = deviceStatus.getJobState(machine.isWasher());
             switchStatus = deviceStatus.getSwitchStatus();
 
             if (reservation != null) {
@@ -131,34 +132,7 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
      * 기기가 물리적으로 작동 중(run 또는 pause)인지 판정한다. 세탁기/건조기는 타입에 맞는 machineState를 본다.
      */
     private boolean isOperating(Machine machine, SmartThingsDeviceStatusResDto deviceStatus) {
-        if (deviceStatus == null) {
-            return false;
-        }
-        String machineState = null;
-        if (machine.isWasher()) {
-            machineState = deviceStatus.getWasherOperatingState();
-        } else if (machine.isDryer()) {
-            machineState = deviceStatus.getDryerOperatingState();
-        }
-        return "run".equalsIgnoreCase(machineState) || "pause".equalsIgnoreCase(machineState);
-    }
-
-    private String getOperatingState(Machine machine, SmartThingsDeviceStatusResDto deviceStatus) {
-        if (machine.isWasher()) {
-            return deviceStatus.getWasherOperatingState();
-        } else if (machine.isDryer()) {
-            return deviceStatus.getDryerOperatingState();
-        }
-        return null;
-    }
-
-    private String getJobState(Machine machine, SmartThingsDeviceStatusResDto deviceStatus) {
-        if (machine.isWasher()) {
-            return deviceStatus.getWasherJobState();
-        } else if (machine.isDryer()) {
-            return deviceStatus.getDryerJobState();
-        }
-        return null;
+        return deviceStatus != null && deviceStatus.getOperatingState(machine.isWasher()).isOperating();
     }
 
     private Long calculateRemainingMinutes(LocalDateTime completionTime) {

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
@@ -22,7 +22,6 @@ import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
-import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.global.util.DateTimeUtil;
 
@@ -37,7 +36,6 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
     private final MachineRepository machineRepository;
     private final ReservationRepository reservationRepository;
     private final DeviceStatusQuerySupport deviceStatusQuerySupport;
-    private final MachineStateDetectionSupport machineStateDetectionSupport;
     private final UserRepository userRepository;
 
     @Override
@@ -78,7 +76,6 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
             operatingState = getOperatingState(machine, deviceStatus);
             jobState = getJobState(machine, deviceStatus);
             switchStatus = deviceStatus.getSwitchStatus();
-            reservation = getDisplayReservation(machine, deviceStatus, reservation);
 
             if (reservation != null) {
                 var completionTimeStr = deviceStatus.getCompletionTime(machine.isWasher());
@@ -106,20 +103,13 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
                 reservation != null ? reservation.getUser().getRoomNumber() : null);
     }
 
-    private Reservation getDisplayReservation(Machine machine,
-            SmartThingsDeviceStatusResDto deviceStatus,
-            Reservation reservation) {
-        if (reservation == null || !reservation.isRunning()) {
-            return reservation;
-        }
-        return machineStateDetectionSupport.isCompleted(deviceStatus, machine.isWasher()).isPresent()
-                ? null
-                : reservation;
-    }
-
     /**
-     * 예약 정보와 실제 기기 작동 상태를 기반으로 가용성을 동적으로 계산한다. 예약 상태를 우선 source of truth로 사용하되, 예약이
-     * 없어도 SmartThings에서 실제 작동 중(무단 사용)이면 IN_USE로 표시해 중복 예약을 차단한다.
+     * 예약 정보와 실제 기기 작동 상태를 기반으로 가용성을 동적으로 계산한다. 예약 상태를 유일한 source of truth로 사용하되,
+     * 예약이 없어도 SmartThings에서 실제 작동 중(무단 사용)이면 IN_USE로 표시해 중복 예약을 차단한다.
+     *
+     * <p>
+     * 완료 여부를 이 API에서 따로 예측하지 않는다. 완료 확정은 라이프사이클 스케줄러가 디바운스와 가드를 거쳐 DB에 반영하며, 목록은 그
+     * 결과만 그대로 보여준다. 화면에 표시된 상태와 DB에 저장된 상태가 갈라지지 않게 하기 위함이다.
      */
     private MachineAvailability computeAvailability(Machine machine,
             Reservation reservation,

--- a/src/main/java/team/washer/server/v2/domain/reservation/entity/Reservation.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/entity/Reservation.java
@@ -13,6 +13,7 @@ import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.global.common.constants.ReservationConstants;
 import team.washer.server.v2.global.common.entity.BaseEntity;
 import team.washer.server.v2.global.util.DateTimeUtil;
 
@@ -73,6 +74,10 @@ public class Reservation extends BaseEntity {
     @Builder.Default
     private int interruptionCount = 0;
 
+    @Column(name = "completion_count", nullable = false)
+    @Builder.Default
+    private int completionCount = 0;
+
     /**
      * 기기 일시정지 시각을 기록합니다.
      */
@@ -100,6 +105,20 @@ public class Reservation extends BaseEntity {
      */
     public void clearInterruptionCount() {
         this.interruptionCount = 0;
+    }
+
+    /**
+     * 사이클 완료 감지 횟수를 1 증가시킵니다. 기기가 순간적으로 보고한 완료 신호를 진짜 완료와 구분하기 위한 디바운스 카운터입니다.
+     */
+    public void incrementCompletionCount() {
+        this.completionCount++;
+    }
+
+    /**
+     * 사이클 완료 감지 추적을 초기화합니다. 완료 신호가 사라지거나 가드에 의해 보류되면 호출합니다.
+     */
+    public void clearCompletionCount() {
+        this.completionCount = 0;
     }
 
     /**
@@ -147,20 +166,50 @@ public class Reservation extends BaseEntity {
         }
         this.status = ReservationStatus.RUNNING;
         this.startTime = DateTimeUtil.nowInKorea();
-        this.expectedCompletionTime = expectedCompletionTime;
+        this.expectedCompletionTime = isReasonableCompletionTime(expectedCompletionTime)
+                ? expectedCompletionTime
+                : null;
     }
 
     /**
      * 실행 중인 예약의 예상 완료 시각을 갱신합니다. RUNNING 상태가 아니면 예외를 발생시킵니다.
      *
+     * <p>
+     * 기기가 보고한 값이 합리적인 사이클 길이를 벗어나면 이상치로 보고 갱신하지 않습니다. 조기 완료 판정의 기준선이 오염되는 것을 막기
+     * 위함입니다.
+     *
      * @param expectedCompletionTime
      *            갱신할 예상 완료 시각
+     * @return 갱신 여부. 이상치로 판단되어 무시되면 {@code false}
      */
-    public void updateExpectedCompletionTime(LocalDateTime expectedCompletionTime) {
+    public boolean updateExpectedCompletionTime(LocalDateTime expectedCompletionTime) {
         if (this.status != ReservationStatus.RUNNING) {
             throw new ExpectedException("실행 중인 예약만 완료 시각을 갱신할 수 있습니다", HttpStatus.BAD_REQUEST);
         }
+        if (!isReasonableCompletionTime(expectedCompletionTime)) {
+            return false;
+        }
         this.expectedCompletionTime = expectedCompletionTime;
+        return true;
+    }
+
+    /**
+     * 예상 완료 시각 후보가 합리적인 사이클 길이(최대 {@code MAX_REASONABLE_CYCLE_MINUTES}분) 안에 있는지
+     * 판정합니다. 시작 시각이 아직 없으면 현재 시각을 기준으로 삼습니다.
+     *
+     * @param candidate
+     *            검증할 예상 완료 시각
+     * @return 합리적인 범위 안에 있으면 {@code true}
+     */
+    private boolean isReasonableCompletionTime(LocalDateTime candidate) {
+        if (candidate == null) {
+            return false;
+        }
+        var baseTime = this.startTime != null ? this.startTime : DateTimeUtil.nowInKorea();
+        if (candidate.isBefore(baseTime)) {
+            return false;
+        }
+        return Duration.between(baseTime, candidate).toMinutes() <= ReservationConstants.MAX_REASONABLE_CYCLE_MINUTES;
     }
 
     /**

--- a/src/main/java/team/washer/server/v2/domain/reservation/scheduler/ReservationTimeoutScheduler.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/scheduler/ReservationTimeoutScheduler.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.reservation.service.CancelOverdueReservationService;
+import team.washer.server.v2.global.thirdparty.smartthings.SmartThingsOperationTimePolicy;
 
 @Slf4j
 @Component
@@ -15,9 +16,21 @@ public class ReservationTimeoutScheduler {
     private static final long TIMEOUT_CHECK_INTERVAL = 60000;
 
     private final CancelOverdueReservationService cancelOverdueReservationService;
+    private final SmartThingsOperationTimePolicy operationTimePolicy;
 
+    /**
+     * RESERVED 예약의 타임아웃을 확인한다.
+     *
+     * <p>
+     * 운영 시간 외에는 라이프사이클 스케줄러가 멈춰 있어 RESERVED → RUNNING 전환이 일어나지 않는다. 그 시간대에 타임아웃만 계속
+     * 돌면 예약이 자동 시작 기회 없이 취소되고 패널티까지 부과되므로, 다른 스케줄러와 동일하게 운영 시간을 확인한다.
+     */
     @Scheduled(fixedDelay = TIMEOUT_CHECK_INTERVAL)
     public void checkReservationTimeouts() {
+        if (!operationTimePolicy.isOperationAllowed()) {
+            log.debug("reservation timeout check skipped outside operation hours");
+            return;
+        }
         try {
             cancelOverdueReservationService.execute();
         } catch (Exception e) {

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
@@ -3,7 +3,6 @@ package team.washer.server.v2.domain.reservation.service.impl;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
@@ -17,6 +16,8 @@ import team.washer.server.v2.domain.notification.support.ReservationNotification
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.reservation.support.CompletionDecision;
+import team.washer.server.v2.domain.reservation.support.ReservationCompletionDecisionSupport;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 import team.washer.server.v2.global.common.constants.ReservationConstants;
@@ -30,19 +31,20 @@ import team.washer.server.v2.global.util.DateTimeUtil;
  * 트랜잭션 밖에서 수행하고, 이 컴포넌트는 조회된 상태를 바탕으로 개별 예약의 DB 갱신만 짧은 독립 트랜잭션
  * ({@link Propagation#REQUIRES_NEW})으로 처리한다. 외부 API 호출이 DB 커넥션을 점유하지 않도록 하여 커넥션
  * 풀 고갈을 방지한다.
+ *
+ * <p>
+ * 완료 여부 판정 자체는 {@link ReservationCompletionDecisionSupport}가 전담하고, 이 컴포넌트는 그
+ * 결과에 디바운스를 적용하여 상태 전이를 확정한다.
  */
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class ReservationLifecycleProcessor {
 
-    private static final long COMPLETION_EARLY_LOG_TOLERANCE_MINUTES = 2;
-    private static final long COMPLETION_BOUNDARY_GRACE_MINUTES = 5;
-    private static final long MAX_REASONABLE_CYCLE_MINUTES = 240;
-
     private final ReservationRepository reservationRepository;
     private final MachineRepository machineRepository;
     private final MachineStateDetectionSupport machineStateDetectionSupport;
+    private final ReservationCompletionDecisionSupport completionDecisionSupport;
     private final ReservationNotificationSupport reservationNotificationSupport;
 
     /**
@@ -76,12 +78,22 @@ public class ReservationLifecycleProcessor {
             return;
         }
 
-        var expectedCompletionTime = DateTimeUtil
+        var reportedCompletionTime = DateTimeUtil
                 .parseAndConvertToKoreaTime(status.getCompletionTime(machine.isWasher()));
-        reservation.start(expectedCompletionTime);
+        reservation.start(reportedCompletionTime);
         machine.markAsInUse();
         reservationRepository.save(reservation);
         machineRepository.save(machine);
+
+        var expectedCompletionTime = reservation.getExpectedCompletionTime();
+        if (reportedCompletionTime != null && expectedCompletionTime == null) {
+            log.warn(
+                    "expected completion time rejected on start reservationId={} startTime={} reported={} maxCycleMinutes={}",
+                    reservation.getId(),
+                    reservation.getStartTime(),
+                    reportedCompletionTime,
+                    ReservationConstants.MAX_REASONABLE_CYCLE_MINUTES);
+        }
 
         reservationNotificationSupport.sendStarted(reservation.getUser(), machine, expectedCompletionTime);
 
@@ -91,6 +103,10 @@ public class ReservationLifecycleProcessor {
     /**
      * RUNNING 예약을 기기 상태에 따라 완료·중단·일시정지·진행으로 처리한다. 외부 API 호출 이후의 DB 갱신만 독립 트랜잭션으로
      * 처리한다.
+     *
+     * <p>
+     * 판정 순서는 완료 → 전원 차단 → 완료 예정 시각 근처 정지 → 비정상 중단 → 일시정지 → 진행이다. 전원 차단은 사이클 종료 직전의
+     * 정지 보류보다 앞에 두어, 유예 범위 안에서 중단이 영영 확정되지 않는 상황을 막는다.
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void processRunningToCompleted(Long reservationId, SmartThingsDeviceStatusResDto status) {
@@ -100,161 +116,149 @@ public class ReservationLifecycleProcessor {
         }
         var machine = reservation.getMachine();
         var isWasher = machine.isWasher();
-        var completionTime = machineStateDetectionSupport.isCompleted(status, isWasher);
 
-        if (completionTime.isPresent()) {
-            if (isStaleCompletion(reservation, status, isWasher, completionTime.get())) {
-                log.info(
-                        "completion deferred reason=stale_completion reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
-                        reservation.getId(),
-                        reservation.getStartTime(),
-                        reservation.getExpectedCompletionTime(),
-                        completionTime.get());
-                return;
-            }
-            if (isTooEarlyCompletion(reservation, completionTime.get())) {
-                if (!canAcceptEarlyCompletion(reservation, status, isWasher, completionTime.get())) {
-                    log.info(
-                            "completion deferred reason=too_early_completion reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
-                            reservation.getId(),
-                            reservation.getStartTime(),
-                            reservation.getExpectedCompletionTime(),
-                            completionTime.get());
-                    return;
-                }
-                logEarlyCompletionAccepted(reservation, completionTime.get());
-            }
-            completeReservation(reservation, machine, completionTime.get(), "smartthings_completed");
+        var decision = completionDecisionSupport.decide(reservation, status, isWasher);
+        if (decision.isCompleted()) {
+            processCompletionCandidate(reservation, machine, decision);
             return;
         }
 
-        var stoppedNearCompletionTime = getStoppedNearCompletionTime(reservation, status, isWasher);
-        if (stoppedNearCompletionTime.isPresent()) {
-            processStoppedNearCompletion(reservation, machine, stoppedNearCompletionTime.get());
+        clearCompletionCount(reservation);
+        if (decision.isDeferred()) {
+            logCompletionDeferred(reservation, decision.reason(), decision.completionTime());
             return;
         }
 
+        if (machineStateDetectionSupport.isPoweredOff(status)) {
+            processInterruption(reservation, machine);
+            return;
+        }
+        if (completionDecisionSupport.isStoppedNearCompletion(reservation, status, isWasher)) {
+            logCompletionDeferred(reservation, "stopped_near_completion", reservation.getExpectedCompletionTime());
+            return;
+        }
         if (machineStateDetectionSupport.isInterrupted(status, isWasher)) {
-            // 사이클 단계 전환 중 순간적으로 보고되는 정지를 진짜 중단으로 오판하지 않도록, 연속으로 중단이
-            // 감지될 때만 취소를 확정한다.
-            reservation.incrementInterruptionCount();
-            if (reservation.getInterruptionCount() >= ReservationConstants.INTERRUPTION_CONFIRM_THRESHOLD) {
-                reservation.cancel();
-                reservation.clearInterruptionCount();
-                machine.markAsAvailable();
-                reservationRepository.save(reservation);
-                machineRepository.save(machine);
-
-                reservationNotificationSupport.sendInterruption(reservation.getUser(), machine);
-
-                log.warn(
-                        "Reservation {} cancelled due to confirmed machine interruption, no penalty applied (RUNNING → CANCELLED)",
-                        reservation.getId());
-            } else {
-                reservationRepository.save(reservation);
-                log.warn("Reservation {} interruption suspected count={} threshold={} deferring cancellation",
-                        reservation.getId(),
-                        reservation.getInterruptionCount(),
-                        ReservationConstants.INTERRUPTION_CONFIRM_THRESHOLD);
-            }
-        } else if (machineStateDetectionSupport.isPaused(status, isWasher)) {
-            if (reservation.getInterruptionCount() > 0) {
-                reservation.clearInterruptionCount();
-                reservationRepository.save(reservation);
-            }
-            if (reservation.getPausedAt() == null) {
-                reservation.markAsPaused();
-                reservationRepository.save(reservation);
-                log.info("Reservation {} pause started, tracking pause time", reservation.getId());
-            } else if (Duration.between(reservation.getPausedAt(), DateTimeUtil.nowInKorea())
-                    .toMinutes() >= ReservationConstants.PAUSE_TIMEOUT_MINUTES) {
-                reservation.cancel();
-                reservation.clearPausedAt();
-                machine.markAsAvailable();
-                reservationRepository.save(reservation);
-                machineRepository.save(machine);
-
-                reservationNotificationSupport.sendPauseTimeout(reservation.getUser(), machine);
-
-                log.warn(
-                        "Reservation {} cancelled due to prolonged pause ({}min+), no penalty applied (RUNNING → CANCELLED)",
-                        reservation.getId(),
-                        ReservationConstants.PAUSE_TIMEOUT_MINUTES);
-            }
-        } else {
-            if (reservation.getInterruptionCount() > 0) {
-                reservation.clearInterruptionCount();
-                reservationRepository.save(reservation);
-            }
-            if (reservation.getPausedAt() != null) {
-                reservation.clearPausedAt();
-                log.info("Reservation {} resumed from pause, clearing pause tracking", reservation.getId());
-            }
-            var updatedExpectedCompletionTime = DateTimeUtil
-                    .parseAndConvertToKoreaTime(getCompletionTime(status, isWasher));
-            var current = reservation.getExpectedCompletionTime();
-            if (updatedExpectedCompletionTime != null && (current == null
-                    || Math.abs(Duration.between(current, updatedExpectedCompletionTime).toSeconds()) >= 60)) {
-                reservation.updateExpectedCompletionTime(updatedExpectedCompletionTime);
-                reservationRepository.save(reservation);
-            }
+            processInterruption(reservation, machine);
+            return;
         }
+        if (machineStateDetectionSupport.isPaused(status, isWasher)) {
+            processPaused(reservation, machine);
+            return;
+        }
+        processRunning(reservation, status, isWasher);
     }
 
-    private void processStoppedNearCompletion(Reservation reservation, Machine machine, LocalDateTime completionTime) {
-        if (!completionTime.isAfter(DateTimeUtil.nowInKorea())) {
-            completeReservation(reservation, machine, completionTime, "stopped_near_completion");
+    /**
+     * 완료 후보를 디바운스한다. 연속으로 {@code COMPLETION_CONFIRM_THRESHOLD}회 완료로 판정된 경우에만 완료를
+     * 확정하여, 사이클 도중 한 번 보고된 순간 정지가 곧바로 완료로 굳어지는 것을 막는다.
+     */
+    private void processCompletionCandidate(Reservation reservation, Machine machine, CompletionDecision decision) {
+        reservation.incrementCompletionCount();
+        if (reservation.getCompletionCount() < ReservationConstants.COMPLETION_CONFIRM_THRESHOLD) {
+            reservationRepository.save(reservation);
+            log.info("completion suspected reservationId={} reason={} count={} threshold={} completionTime={}",
+                    reservation.getId(),
+                    decision.reason(),
+                    reservation.getCompletionCount(),
+                    ReservationConstants.COMPLETION_CONFIRM_THRESHOLD,
+                    decision.completionTime());
+            return;
+        }
+        completeReservation(reservation, machine, decision.completionTime(), decision.reason());
+    }
+
+    private void processInterruption(Reservation reservation, Machine machine) {
+        // 사이클 단계 전환 중 순간적으로 보고되는 정지를 진짜 중단으로 오판하지 않도록, 연속으로 중단이
+        // 감지될 때만 취소를 확정한다.
+        reservation.incrementInterruptionCount();
+        if (reservation.getInterruptionCount() < ReservationConstants.INTERRUPTION_CONFIRM_THRESHOLD) {
+            reservationRepository.save(reservation);
+            log.warn("Reservation {} interruption suspected count={} threshold={} deferring cancellation",
+                    reservation.getId(),
+                    reservation.getInterruptionCount(),
+                    ReservationConstants.INTERRUPTION_CONFIRM_THRESHOLD);
             return;
         }
 
+        reservation.cancel();
+        reservation.clearInterruptionCount();
+        machine.markAsAvailable();
+        reservationRepository.save(reservation);
+        machineRepository.save(machine);
+
+        reservationNotificationSupport.sendInterruption(reservation.getUser(), machine);
+
+        log.warn(
+                "Reservation {} cancelled due to confirmed machine interruption, no penalty applied (RUNNING → CANCELLED)",
+                reservation.getId());
+    }
+
+    private void processPaused(Reservation reservation, Machine machine) {
+        if (reservation.getInterruptionCount() > 0) {
+            reservation.clearInterruptionCount();
+            reservationRepository.save(reservation);
+        }
+        if (reservation.getPausedAt() == null) {
+            reservation.markAsPaused();
+            reservationRepository.save(reservation);
+            log.info("Reservation {} pause started, tracking pause time", reservation.getId());
+            return;
+        }
+        if (Duration.between(reservation.getPausedAt(), DateTimeUtil.nowInKorea())
+                .toMinutes() < ReservationConstants.PAUSE_TIMEOUT_MINUTES) {
+            return;
+        }
+
+        reservation.cancel();
+        reservation.clearPausedAt();
+        machine.markAsAvailable();
+        reservationRepository.save(reservation);
+        machineRepository.save(machine);
+
+        reservationNotificationSupport.sendPauseTimeout(reservation.getUser(), machine);
+
+        log.warn("Reservation {} cancelled due to prolonged pause ({}min+), no penalty applied (RUNNING → CANCELLED)",
+                reservation.getId(),
+                ReservationConstants.PAUSE_TIMEOUT_MINUTES);
+    }
+
+    /**
+     * 기기가 정상 진행 중일 때 디바운스 카운터와 일시정지 추적을 정리하고, 기기가 보고한 완료 예정 시각을 반영한다. 상한을 벗어난 이상치는
+     * 엔티티가 거부하므로 조기 완료 판정의 기준선이 오염되지 않는다.
+     */
+    private void processRunning(Reservation reservation, SmartThingsDeviceStatusResDto status, boolean isWasher) {
         var changed = false;
         if (reservation.getInterruptionCount() > 0) {
             reservation.clearInterruptionCount();
             changed = true;
         }
-
-        var current = reservation.getExpectedCompletionTime();
-        if (current == null || Math.abs(Duration.between(current, completionTime).toSeconds()) >= 60) {
-            reservation.updateExpectedCompletionTime(completionTime);
+        if (reservation.getPausedAt() != null) {
+            reservation.clearPausedAt();
             changed = true;
+            log.info("Reservation {} resumed from pause, clearing pause tracking", reservation.getId());
+        }
+
+        var reportedCompletionTime = DateTimeUtil.parseAndConvertToKoreaTime(getCompletionTime(status, isWasher));
+        var current = reservation.getExpectedCompletionTime();
+        if (reportedCompletionTime != null
+                && (current == null || Math.abs(Duration.between(current, reportedCompletionTime).toSeconds()) >= 60)) {
+            if (reservation.updateExpectedCompletionTime(reportedCompletionTime)) {
+                changed = true;
+            } else {
+                log.warn(
+                        "expected completion time rejected reservationId={} startTime={} reported={} current={} "
+                                + "maxCycleMinutes={}",
+                        reservation.getId(),
+                        reservation.getStartTime(),
+                        reportedCompletionTime,
+                        current,
+                        ReservationConstants.MAX_REASONABLE_CYCLE_MINUTES);
+            }
         }
 
         if (changed) {
             reservationRepository.save(reservation);
         }
-
-        log.info(
-                "completion deferred reason=stopped_near_completion reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
-                reservation.getId(),
-                reservation.getStartTime(),
-                reservation.getExpectedCompletionTime(),
-                completionTime);
-    }
-
-    private Optional<LocalDateTime> getStoppedNearCompletionTime(Reservation reservation,
-            SmartThingsDeviceStatusResDto status,
-            boolean isWasher) {
-        var machineState = getOperatingState(status, isWasher);
-        if (!"stop".equalsIgnoreCase(machineState)) {
-            return Optional.empty();
-        }
-
-        var completionTime = DateTimeUtil.parseAndConvertToKoreaTime(getCompletionTime(status, isWasher));
-        if (completionTime == null) {
-            return Optional.empty();
-        }
-
-        var startTime = reservation.getStartTime();
-        if (startTime != null && completionTime.isBefore(startTime)) {
-            return Optional.empty();
-        }
-
-        var secondsFromNow = Math.abs(Duration.between(DateTimeUtil.nowInKorea(), completionTime).toSeconds());
-        if (secondsFromNow > Duration.ofMinutes(COMPLETION_BOUNDARY_GRACE_MINUTES).toSeconds()) {
-            return Optional.empty();
-        }
-
-        return Optional.of(completionTime);
     }
 
     private void completeReservation(Reservation reservation,
@@ -262,6 +266,7 @@ public class ReservationLifecycleProcessor {
             LocalDateTime completionTime,
             String reason) {
         reservation.complete();
+        reservation.clearCompletionCount();
         machine.markAsAvailable();
         reservationRepository.save(reservation);
         machineRepository.save(machine);
@@ -279,86 +284,21 @@ public class ReservationLifecycleProcessor {
                 reservation.getExpectedCompletionTime());
     }
 
-    private boolean isStaleCompletion(Reservation reservation,
-            SmartThingsDeviceStatusResDto status,
-            boolean isWasher,
-            LocalDateTime completionTime) {
-        var startTime = reservation.getStartTime();
-        if (startTime == null) {
-            return false;
+    private void clearCompletionCount(Reservation reservation) {
+        if (reservation.getCompletionCount() > 0) {
+            reservation.clearCompletionCount();
+            reservationRepository.save(reservation);
         }
-        if (completionTime.isBefore(startTime)) {
-            return true;
-        }
-        return isTimestampBeforeStart(getOperatingStateTimestamp(status, isWasher), startTime)
-                || isTimestampBeforeStart(getJobStateTimestamp(status, isWasher), startTime);
     }
 
-    private boolean isTooEarlyCompletion(Reservation reservation, LocalDateTime completionTime) {
-        var expectedCompletionTime = reservation.getExpectedCompletionTime();
-        if (expectedCompletionTime == null) {
-            return false;
-        }
-        var earliestCompletionTime = expectedCompletionTime.minusMinutes(COMPLETION_EARLY_LOG_TOLERANCE_MINUTES);
-        return completionTime.isBefore(earliestCompletionTime);
-    }
-
-    private boolean canAcceptEarlyCompletion(Reservation reservation,
-            SmartThingsDeviceStatusResDto status,
-            boolean isWasher,
-            LocalDateTime completionTime) {
-        return hasSuspiciousExpectedCompletionTime(reservation)
-                && hasFreshCompletionEvidence(reservation, status, isWasher, completionTime);
-    }
-
-    private boolean hasSuspiciousExpectedCompletionTime(Reservation reservation) {
-        var startTime = reservation.getStartTime();
-        var expectedCompletionTime = reservation.getExpectedCompletionTime();
-        if (startTime == null || expectedCompletionTime == null) {
-            return false;
-        }
-        return Duration.between(startTime, expectedCompletionTime).toMinutes() > MAX_REASONABLE_CYCLE_MINUTES;
-    }
-
-    private boolean hasFreshCompletionEvidence(Reservation reservation,
-            SmartThingsDeviceStatusResDto status,
-            boolean isWasher,
-            LocalDateTime completionTime) {
-        var startTime = reservation.getStartTime();
-        if (startTime == null) {
-            return false;
-        }
-        var completionTimeStr = getCompletionTime(status, isWasher);
-        if (completionTimeStr != null && !completionTimeStr.isBlank() && !completionTime.isBefore(startTime)) {
-            return true;
-        }
-        return isTimestampAtOrAfterStart(getOperatingStateTimestamp(status, isWasher), startTime)
-                || isTimestampAtOrAfterStart(getJobStateTimestamp(status, isWasher), startTime);
-    }
-
-    private void logEarlyCompletionAccepted(Reservation reservation, LocalDateTime completionTime) {
+    private void logCompletionDeferred(Reservation reservation, String reason, LocalDateTime completionTime) {
         log.info(
-                "completion accepted reason=suspicious_expected_completion_time reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
+                "completion deferred reason={} reservationId={} startTime={} expectedCompletionTime={} completionTime={}",
+                reason,
                 reservation.getId(),
                 reservation.getStartTime(),
                 reservation.getExpectedCompletionTime(),
                 completionTime);
-    }
-
-    private boolean isTimestampBeforeStart(String timestamp, LocalDateTime startTime) {
-        if (timestamp == null || timestamp.isBlank()) {
-            return false;
-        }
-        var updatedAt = DateTimeUtil.parseAndConvertToKoreaTime(timestamp);
-        return updatedAt != null && updatedAt.isBefore(startTime);
-    }
-
-    private boolean isTimestampAtOrAfterStart(String timestamp, LocalDateTime startTime) {
-        if (timestamp == null || timestamp.isBlank()) {
-            return false;
-        }
-        var updatedAt = DateTimeUtil.parseAndConvertToKoreaTime(timestamp);
-        return updatedAt != null && !updatedAt.isBefore(startTime);
     }
 
     private String getCompletionTime(SmartThingsDeviceStatusResDto status, boolean isWasher) {
@@ -366,26 +306,5 @@ public class ReservationLifecycleProcessor {
             return null;
         }
         return isWasher ? status.getWasherCompletionTime() : status.getDryerCompletionTime();
-    }
-
-    private String getOperatingState(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        if (status == null) {
-            return null;
-        }
-        return isWasher ? status.getWasherOperatingState() : status.getDryerOperatingState();
-    }
-
-    private String getOperatingStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        if (status == null) {
-            return null;
-        }
-        return isWasher ? status.getWasherOperatingStateTimestamp() : status.getDryerOperatingStateTimestamp();
-    }
-
-    private String getJobStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        if (status == null) {
-            return null;
-        }
-        return isWasher ? status.getWasherJobStateTimestamp() : status.getDryerJobStateTimestamp();
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
@@ -261,12 +261,18 @@ public class ReservationLifecycleProcessor {
         }
     }
 
+    /**
+     * 예약을 완료 처리한다. 중단·일시정지 경로와 마찬가지로 디바운스 카운터와 일시정지 추적을 함께 정리하여, 완료된 예약에 진행 중에만 의미가
+     * 있는 값이 남지 않도록 한다.
+     */
     private void completeReservation(Reservation reservation,
             Machine machine,
             LocalDateTime completionTime,
             String reason) {
         reservation.complete();
         reservation.clearCompletionCount();
+        reservation.clearInterruptionCount();
+        reservation.clearPausedAt();
         machine.markAsAvailable();
         reservationRepository.save(reservation);
         machineRepository.save(machine);

--- a/src/main/java/team/washer/server/v2/domain/reservation/support/CompletionDecision.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/support/CompletionDecision.java
@@ -1,0 +1,48 @@
+package team.washer.server.v2.domain.reservation.support;
+
+import java.time.LocalDateTime;
+
+/**
+ * RUNNING 예약에 대한 사이클 완료 판정 결과.
+ *
+ * @param outcome
+ *            판정 결과
+ * @param completionTime
+ *            완료 후보 시각. {@link Outcome#NOT_COMPLETED}이면 {@code null}
+ * @param reason
+ *            판정 근거. 로그의 {@code reason} 필드로 그대로 사용된다
+ */
+public record CompletionDecision(Outcome outcome, LocalDateTime completionTime, String reason) {
+
+    /**
+     * 완료 판정 결과의 종류.
+     */
+    public enum Outcome {
+        /** 완료 후보가 모든 가드를 통과했다. */
+        COMPLETED,
+        /** 완료 후보는 있으나 가드에 걸려 판정을 보류한다. */
+        DEFERRED,
+        /** 완료 후보 자체가 없다. */
+        NOT_COMPLETED
+    }
+
+    public static CompletionDecision completed(LocalDateTime completionTime, String reason) {
+        return new CompletionDecision(Outcome.COMPLETED, completionTime, reason);
+    }
+
+    public static CompletionDecision deferred(LocalDateTime completionTime, String reason) {
+        return new CompletionDecision(Outcome.DEFERRED, completionTime, reason);
+    }
+
+    public static CompletionDecision notCompleted() {
+        return new CompletionDecision(Outcome.NOT_COMPLETED, null, "not_completed");
+    }
+
+    public boolean isCompleted() {
+        return this.outcome == Outcome.COMPLETED;
+    }
+
+    public boolean isDeferred() {
+        return this.outcome == Outcome.DEFERRED;
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationCompletionDecisionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationCompletionDecisionSupport.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 import team.washer.server.v2.global.util.DateTimeUtil;
 
@@ -124,8 +125,7 @@ public class ReservationCompletionDecisionSupport {
         if (status == null || machineStateDetectionSupport.isPoweredOff(status)) {
             return Optional.empty();
         }
-        if (!"stop".equalsIgnoreCase(getOperatingState(status, isWasher))
-                || !isResetJobState(getJobState(status, isWasher))) {
+        if (!isStopped(status, isWasher) || !status.isJobStateReset(isWasher)) {
             return Optional.empty();
         }
 
@@ -140,8 +140,8 @@ public class ReservationCompletionDecisionSupport {
             return Optional.empty();
         }
         // 이번 사이클에서 실제로 상태가 갱신됐다는 근거가 없으면 이전 사이클의 잔재로 본다.
-        if (!isTimestampAtOrAfterStart(getOperatingStateTimestamp(status, isWasher), startTime)
-                && !isTimestampAtOrAfterStart(getJobStateTimestamp(status, isWasher), startTime)) {
+        if (!isTimestampAtOrAfterStart(resolveOperatingStateTimestamp(status, isWasher), startTime)
+                && !isTimestampAtOrAfterStart(resolveJobStateTimestamp(status, isWasher), startTime)) {
             return Optional.empty();
         }
 
@@ -149,10 +149,6 @@ public class ReservationCompletionDecisionSupport {
                 completionTime,
                 startTime);
         return Optional.of(now);
-    }
-
-    private boolean isResetJobState(String jobState) {
-        return jobState == null || jobState.isBlank() || "none".equalsIgnoreCase(jobState);
     }
 
     private boolean isTimestampAtOrAfterStart(String timestamp, LocalDateTime startTime) {
@@ -169,7 +165,7 @@ public class ReservationCompletionDecisionSupport {
     private Optional<LocalDateTime> findNearCompletionStopTime(Reservation reservation,
             SmartThingsDeviceStatusResDto status,
             boolean isWasher) {
-        if (!"stop".equalsIgnoreCase(getOperatingState(status, isWasher))) {
+        if (!isStopped(status, isWasher)) {
             return Optional.empty();
         }
 
@@ -206,8 +202,8 @@ public class ReservationCompletionDecisionSupport {
         if (completionTime.isBefore(startTime)) {
             return true;
         }
-        return isTimestampBeforeStart(getOperatingStateTimestamp(status, isWasher), startTime)
-                || isTimestampBeforeStart(getJobStateTimestamp(status, isWasher), startTime);
+        return isTimestampBeforeStart(resolveOperatingStateTimestamp(status, isWasher), startTime)
+                || isTimestampBeforeStart(resolveJobStateTimestamp(status, isWasher), startTime);
     }
 
     /**
@@ -230,39 +226,23 @@ public class ReservationCompletionDecisionSupport {
         return updatedAt != null && updatedAt.isBefore(startTime);
     }
 
+    /**
+     * 기기가 물리적으로 정지(machineState=stop) 상태인지 판정한다.
+     */
+    private boolean isStopped(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        return status != null && status.getOperatingState(isWasher) == MachineOperatingState.STOP;
+    }
+
     private String getCompletionTime(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        if (status == null) {
-            return null;
-        }
-        return isWasher ? status.getWasherCompletionTime() : status.getDryerCompletionTime();
+        return status == null ? null : status.getCompletionTime(isWasher);
     }
 
-    private String getOperatingState(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        if (status == null) {
-            return null;
-        }
-        return isWasher ? status.getWasherOperatingState() : status.getDryerOperatingState();
+    private String resolveOperatingStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        return status == null ? null : status.getOperatingStateTimestamp(isWasher);
     }
 
-    private String getJobState(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        if (status == null) {
-            return null;
-        }
-        return isWasher ? status.getWasherJobState() : status.getDryerJobState();
-    }
-
-    private String getOperatingStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        if (status == null) {
-            return null;
-        }
-        return isWasher ? status.getWasherOperatingStateTimestamp() : status.getDryerOperatingStateTimestamp();
-    }
-
-    private String getJobStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        if (status == null) {
-            return null;
-        }
-        return isWasher ? status.getWasherJobStateTimestamp() : status.getDryerJobStateTimestamp();
+    private String resolveJobStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        return status == null ? null : status.getJobStateTimestamp(isWasher);
     }
 
     private record CompletionCandidate(LocalDateTime completionTime, String reason) {

--- a/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationCompletionDecisionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationCompletionDecisionSupport.java
@@ -1,0 +1,197 @@
+package team.washer.server.v2.domain.reservation.support;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
+import team.washer.server.v2.global.util.DateTimeUtil;
+
+/**
+ * 기기 사이클의 완료 여부를 판정하는 단일 진입점.
+ *
+ * <p>
+ * 완료 후보를 찾는 경로는 두 가지다. SmartThings가 jobState·machineState로 완료를 보고한 경우
+ * ({@code smartthings_completed})와, 완료 예정 시각 근처에서 기기가 정지한 채 그 시각이 지난 경우
+ * ({@code stopped_near_completion}). 두 경로 모두 동일한 가드(이전 사이클 신호 검사·조기 완료 검사)를
+ * 거치므로, 어느 경로로 들어오든 같은 질문에 같은 답이 나온다.
+ *
+ * <p>
+ * 이 컴포넌트는 판정만 하고 상태를 바꾸지 않는다. 디바운스와 DB 갱신은 호출 측
+ * ({@code ReservationLifecycleProcessor})의 책임이다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ReservationCompletionDecisionSupport {
+
+    private static final String REASON_SMARTTHINGS_COMPLETED = "smartthings_completed";
+    private static final String REASON_STOPPED_NEAR_COMPLETION = "stopped_near_completion";
+    private static final String REASON_STALE_COMPLETION = "stale_completion";
+    private static final String REASON_TOO_EARLY_COMPLETION = "too_early_completion";
+
+    private static final long COMPLETION_EARLY_TOLERANCE_MINUTES = 2;
+    private static final long COMPLETION_BOUNDARY_GRACE_MINUTES = 5;
+
+    private final MachineStateDetectionSupport machineStateDetectionSupport;
+
+    /**
+     * 예약과 기기 상태를 바탕으로 사이클 완료 여부를 판정한다.
+     *
+     * @param reservation
+     *            판정 대상 RUNNING 예약
+     * @param status
+     *            SmartThings에서 조회한 기기 상태
+     * @param isWasher
+     *            세탁기 여부
+     * @return 완료 판정 결과
+     */
+    public CompletionDecision decide(Reservation reservation, SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        var candidate = findCompletionCandidate(reservation, status, isWasher);
+        if (candidate.isEmpty()) {
+            return CompletionDecision.notCompleted();
+        }
+
+        var completionTime = candidate.get().completionTime();
+        if (isStaleCompletion(reservation, status, isWasher, completionTime)) {
+            return CompletionDecision.deferred(completionTime, REASON_STALE_COMPLETION);
+        }
+        if (isTooEarlyCompletion(reservation, completionTime)) {
+            return CompletionDecision.deferred(completionTime, REASON_TOO_EARLY_COMPLETION);
+        }
+        return CompletionDecision.completed(completionTime, candidate.get().reason());
+    }
+
+    /**
+     * 완료 예정 시각 근처에서 기기가 정지한 상태인지 판정한다. 사이클 종료 직전의 정지를 비정상 중단으로 오판하지 않기 위해 사용한다.
+     *
+     * @param reservation
+     *            판정 대상 RUNNING 예약
+     * @param status
+     *            SmartThings에서 조회한 기기 상태
+     * @param isWasher
+     *            세탁기 여부
+     * @return 완료 예정 시각 근처의 정지이면 {@code true}
+     */
+    public boolean isStoppedNearCompletion(Reservation reservation,
+            SmartThingsDeviceStatusResDto status,
+            boolean isWasher) {
+        return findNearCompletionStopTime(reservation, status, isWasher).isPresent();
+    }
+
+    private Optional<CompletionCandidate> findCompletionCandidate(Reservation reservation,
+            SmartThingsDeviceStatusResDto status,
+            boolean isWasher) {
+        var detected = machineStateDetectionSupport.isCompleted(status, isWasher);
+        if (detected.isPresent()) {
+            return Optional.of(new CompletionCandidate(detected.get(), REASON_SMARTTHINGS_COMPLETED));
+        }
+        return findNearCompletionStopTime(reservation, status, isWasher)
+                .filter(completionTime -> !completionTime.isAfter(DateTimeUtil.nowInKorea()))
+                .map(completionTime -> new CompletionCandidate(completionTime, REASON_STOPPED_NEAR_COMPLETION));
+    }
+
+    /**
+     * 기기가 정지한 상태이고 보고된 완료 예정 시각이 현재 시각과 유예 범위 안에 있으면 그 시각을 반환한다.
+     */
+    private Optional<LocalDateTime> findNearCompletionStopTime(Reservation reservation,
+            SmartThingsDeviceStatusResDto status,
+            boolean isWasher) {
+        if (!"stop".equalsIgnoreCase(getOperatingState(status, isWasher))) {
+            return Optional.empty();
+        }
+
+        var completionTime = DateTimeUtil.parseAndConvertToKoreaTime(getCompletionTime(status, isWasher));
+        if (completionTime == null) {
+            return Optional.empty();
+        }
+
+        var startTime = reservation.getStartTime();
+        if (startTime != null && completionTime.isBefore(startTime)) {
+            return Optional.empty();
+        }
+
+        var secondsFromNow = Math.abs(Duration.between(DateTimeUtil.nowInKorea(), completionTime).toSeconds());
+        if (secondsFromNow > Duration.ofMinutes(COMPLETION_BOUNDARY_GRACE_MINUTES).toSeconds()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(completionTime);
+    }
+
+    /**
+     * 완료 신호가 이전 사이클에서 남은 값인지 판정한다. 완료 시각이나 상태 갱신 시각이 이번 예약의 시작 시각보다 앞서면 이전 사이클의 잔재로
+     * 본다.
+     */
+    private boolean isStaleCompletion(Reservation reservation,
+            SmartThingsDeviceStatusResDto status,
+            boolean isWasher,
+            LocalDateTime completionTime) {
+        var startTime = reservation.getStartTime();
+        if (startTime == null) {
+            return false;
+        }
+        if (completionTime.isBefore(startTime)) {
+            return true;
+        }
+        return isTimestampBeforeStart(getOperatingStateTimestamp(status, isWasher), startTime)
+                || isTimestampBeforeStart(getJobStateTimestamp(status, isWasher), startTime);
+    }
+
+    /**
+     * 예상 완료 시각보다 지나치게 이른 완료 신호인지 판정한다. 예상 완료 시각은 저장 시점에 상한 검증을 거치므로
+     * ({@code Reservation.updateExpectedCompletionTime}) 여기서 별도의 이상치 예외 처리는 하지 않는다.
+     */
+    private boolean isTooEarlyCompletion(Reservation reservation, LocalDateTime completionTime) {
+        var expectedCompletionTime = reservation.getExpectedCompletionTime();
+        if (expectedCompletionTime == null) {
+            return false;
+        }
+        return completionTime.isBefore(expectedCompletionTime.minusMinutes(COMPLETION_EARLY_TOLERANCE_MINUTES));
+    }
+
+    private boolean isTimestampBeforeStart(String timestamp, LocalDateTime startTime) {
+        if (timestamp == null || timestamp.isBlank()) {
+            return false;
+        }
+        var updatedAt = DateTimeUtil.parseAndConvertToKoreaTime(timestamp);
+        return updatedAt != null && updatedAt.isBefore(startTime);
+    }
+
+    private String getCompletionTime(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        if (status == null) {
+            return null;
+        }
+        return isWasher ? status.getWasherCompletionTime() : status.getDryerCompletionTime();
+    }
+
+    private String getOperatingState(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        if (status == null) {
+            return null;
+        }
+        return isWasher ? status.getWasherOperatingState() : status.getDryerOperatingState();
+    }
+
+    private String getOperatingStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        if (status == null) {
+            return null;
+        }
+        return isWasher ? status.getWasherOperatingStateTimestamp() : status.getDryerOperatingStateTimestamp();
+    }
+
+    private String getJobStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        if (status == null) {
+            return null;
+        }
+        return isWasher ? status.getWasherJobStateTimestamp() : status.getDryerJobStateTimestamp();
+    }
+
+    private record CompletionCandidate(LocalDateTime completionTime, String reason) {
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsDeviceStatusResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsDeviceStatusResDto.java
@@ -6,11 +6,17 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 
 @Schema(description = "SmartThings 기기 상태 응답")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record SmartThingsDeviceStatusResDto(
         @Schema(description = "컴포넌트 목록") @JsonProperty("components") Map<String, ComponentStatus> components) {
+
+    private static final String WASHER_FINISHED_JOB_STATE = "finish";
+    private static final String DRYER_FINISHED_JOB_STATE = "finished";
+    private static final String IDLE_JOB_STATE = "none";
+    private static final String SWITCH_OFF = "off";
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record ComponentStatus(@JsonProperty("washerOperatingState") WasherOperatingState washerOperatingState,
@@ -172,11 +178,54 @@ public record SmartThingsDeviceStatusResDto(
         return null;
     }
 
-    /** 스위치 상태 값 반환: "on" | "off" */
+    /** 기기 타입에 해당하는 완료 예정 시간 반환 */
     public String getCompletionTime(boolean isWasher) {
         return isWasher ? getWasherCompletionTime() : getDryerCompletionTime();
     }
 
+    /**
+     * 기기 타입에 해당하는 machineState를 {@link MachineOperatingState}로 반환한다. 세탁기·건조기
+     * capability를 동시에 노출하는 기기에서 반대쪽 값을 읽지 않도록, 분기는 이 메서드로 일원화한다.
+     */
+    public MachineOperatingState getOperatingState(boolean isWasher) {
+        return MachineOperatingState.from(isWasher ? getWasherOperatingState() : getDryerOperatingState());
+    }
+
+    /** 기기 타입에 해당하는 machineState 갱신 시각 반환 */
+    public String getOperatingStateTimestamp(boolean isWasher) {
+        return isWasher ? getWasherOperatingStateTimestamp() : getDryerOperatingStateTimestamp();
+    }
+
+    /** 기기 타입에 해당하는 jobState 반환 */
+    public String getJobState(boolean isWasher) {
+        return isWasher ? getWasherJobState() : getDryerJobState();
+    }
+
+    /** 기기 타입에 해당하는 jobState 갱신 시각 반환 */
+    public String getJobStateTimestamp(boolean isWasher) {
+        return isWasher ? getWasherJobStateTimestamp() : getDryerJobStateTimestamp();
+    }
+
+    /** jobState가 사이클 종료 직후 리셋된 값(none·공백·null)인지 여부 반환 */
+    public boolean isJobStateReset(boolean isWasher) {
+        var jobState = getJobState(isWasher);
+        return jobState == null || jobState.isBlank() || IDLE_JOB_STATE.equalsIgnoreCase(jobState);
+    }
+
+    /**
+     * jobState가 정상 완료를 뜻하는 값인지 여부 반환. 세탁기는 finish, 건조기는 finished로 보고한다.
+     */
+    public boolean isJobStateFinished(boolean isWasher) {
+        return (isWasher ? WASHER_FINISHED_JOB_STATE : DRYER_FINISHED_JOB_STATE)
+                .equalsIgnoreCase(getJobState(isWasher));
+    }
+
+    /** 기기 전원이 꺼진 상태(switch=off)인지 여부 반환 */
+    public boolean isSwitchOff() {
+        return SWITCH_OFF.equalsIgnoreCase(getSwitchStatus());
+    }
+
+    /** 스위치 상태 값 반환: "on" | "off" */
     public String getSwitchStatus() {
         var main = getMainComponent();
         if (main == null || main.switchCapability() == null) {

--- a/src/main/java/team/washer/server/v2/domain/smartthings/enums/MachineOperatingState.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/enums/MachineOperatingState.java
@@ -1,0 +1,50 @@
+package team.washer.server.v2.domain.smartthings.enums;
+
+import java.util.Arrays;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * SmartThings의 washerOperatingState/dryerOperatingState capability가 보고하는
+ * machineState 값.
+ *
+ * <p>
+ * SmartThings는 이 값을 소문자 문자열("run" | "pause" | "stop")로 내려주며, 기기가 해당 capability를
+ * 노출하지 않거나 응답이 비어 있을 수 있다. 그런 경우를 호출 측에서 null 검사로 흩어 처리하지 않도록
+ * {@link #UNKNOWN}으로 흡수한다.
+ *
+ * <p>
+ * API 응답에는 {@link JsonValue}를 통해 SmartThings와 동일한 원시 소문자 값으로 직렬화된다
+ * ({@link #UNKNOWN}은 null). 내부 판정만 enum으로 하고 클라이언트가 보던 계약은 그대로 유지하기 위함이다.
+ */
+@Getter
+@AllArgsConstructor
+public enum MachineOperatingState {
+    RUN("run", "작동 중"), PAUSE("pause", "일시정지"), STOP("stop", "정지"), UNKNOWN(null, "확인 불가");
+
+    @JsonValue
+    private final String value;
+    private final String description;
+
+    /**
+     * SmartThings가 내려준 원시 machineState 문자열을 enum으로 변환한다. 값이 없거나 알 수 없는 값이면
+     * {@link #UNKNOWN}을 반환한다.
+     */
+    public static MachineOperatingState from(final String rawValue) {
+        if (rawValue == null || rawValue.isBlank()) {
+            return UNKNOWN;
+        }
+        return Arrays.stream(values()).filter(state -> rawValue.equalsIgnoreCase(state.value)).findFirst()
+                .orElse(UNKNOWN);
+    }
+
+    /**
+     * 기기가 사이클을 물리적으로 점유 중인 상태(run 또는 pause)인지 여부를 반환한다.
+     */
+    public boolean isOperating() {
+        return this == RUN || this == PAUSE;
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
@@ -107,6 +107,24 @@ public class MachineStateDetectionSupport {
     }
 
     /**
+     * 기기 전원이 꺼졌는지 감지한다.
+     *
+     * <p>
+     * 전원 차단은 사이클 진행 여부와 무관하게 명백한 중단이므로, 완료 예정 시각 근처의 정지를 보류하는 판정보다 먼저 평가되어야 한다. 그렇지
+     * 않으면 완료 예정 시각이 유예 범위 안에 있는 동안 중단이 영영 확정되지 않는다.
+     */
+    public boolean isPoweredOff(SmartThingsDeviceStatusResDto status) {
+        if (status == null) {
+            return false;
+        }
+        var isPoweredOff = "off".equalsIgnoreCase(status.getSwitchStatus());
+        if (isPoweredOff) {
+            log.debug("device power off detected switch=off");
+        }
+        return isPoweredOff;
+    }
+
+    /**
      * 기기가 비정상 중단되었는지 감지한다.
      *
      * <p>
@@ -119,8 +137,7 @@ public class MachineStateDetectionSupport {
         if (status == null) {
             return false;
         }
-        if ("off".equalsIgnoreCase(status.getSwitchStatus())) {
-            log.debug("device power off detected switch=off");
+        if (isPoweredOff(status)) {
             return true;
         }
 

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 import team.washer.server.v2.global.util.DateTimeUtil;
 
 /**
@@ -15,6 +16,11 @@ import team.washer.server.v2.global.util.DateTimeUtil;
  * <p>
  * 모든 판정은 기기 타입(세탁기/건조기)에 해당하는 capability만 검사한다. 하나의 deviceId가 세탁기·건조기
  * capability를 동시에 노출하는 경우, 사용하지 않는 쪽의 유휴 상태를 비정상 중단으로 오판하지 않기 위함이다.
+ *
+ * <p>
+ * 세탁기/건조기 분기와 원시 문자열 해석은 {@link SmartThingsDeviceStatusResDto}의 타입 인자 접근자
+ * ({@code getOperatingState(isWasher)} 등)가 담당한다. 이 컴포넌트는 그 위에서 "작동 중·완료·중단" 같은
+ * 판정만 수행한다.
  */
 @Component
 @Slf4j
@@ -28,8 +34,7 @@ public class MachineStateDetectionSupport {
         if (status == null) {
             return false;
         }
-        var machineState = isWasher ? status.getWasherOperatingState() : status.getDryerOperatingState();
-        var isRunning = "run".equalsIgnoreCase(machineState);
+        var isRunning = status.getOperatingState(isWasher) == MachineOperatingState.RUN;
         if (isRunning) {
             log.debug("device is running isWasher={}", isWasher);
         }
@@ -50,60 +55,41 @@ public class MachineStateDetectionSupport {
             return Optional.empty();
         }
         var now = DateTimeUtil.nowInKorea();
-        if (isWasher) {
-            return evaluateCompletion(status.getWasherJobState(),
-                    "finish",
-                    status.getWasherOperatingState(),
-                    status.getWasherCompletionTime(),
-                    now);
-        }
-        return evaluateCompletion(status
-                .getDryerJobState(), "finished", status.getDryerOperatingState(), status.getDryerCompletionTime(), now);
-    }
-
-    /**
-     * jobState·machineState·completionTime을 종합하여 단일 기기 타입의 완료 여부를 판정한다.
-     */
-    private Optional<LocalDateTime> evaluateCompletion(String jobState,
-            String finishedJobState,
-            String machineState,
-            String completionTimeStr,
-            LocalDateTime now) {
-        if (!"stop".equalsIgnoreCase(machineState)) {
-            if (finishedJobState.equalsIgnoreCase(jobState)) {
+        if (status.getOperatingState(isWasher) != MachineOperatingState.STOP) {
+            if (status.isJobStateFinished(isWasher)) {
                 log.debug("job finished but machine not stopped yet machineState={} jobState={}",
-                        machineState,
-                        jobState);
+                        status.getOperatingState(isWasher),
+                        status.getJobState(isWasher));
             }
             return Optional.empty();
         }
+
+        var completionTimeStr = status.getCompletionTime(isWasher);
         var completionTime = (completionTimeStr != null && !completionTimeStr.isBlank())
                 ? DateTimeUtil.parseAndConvertToKoreaTime(completionTimeStr)
                 : null;
-        if (finishedJobState.equalsIgnoreCase(jobState)) {
-            log.debug("device job is completed jobState={} completionTime={}", jobState, completionTime);
+        if (status.isJobStateFinished(isWasher)) {
+            log.debug("device job is completed jobState={} completionTime={}",
+                    status.getJobState(isWasher),
+                    completionTime);
             return Optional.of(completionTime != null && !completionTime.isAfter(now) ? completionTime : now);
         }
 
         if (completionTime != null && completionTime.isAfter(now)) {
             log.debug("device stopped but completion time still in future completionTime={} jobState={}",
                     completionTime,
-                    jobState);
+                    status.getJobState(isWasher));
             return Optional.empty();
         }
 
-        if (isResetJobState(jobState) && completionTime != null) {
+        if (status.isJobStateReset(isWasher) && completionTime != null) {
             log.debug("device job is completed after job reset jobState={} completionTime={}",
-                    jobState,
+                    status.getJobState(isWasher),
                     completionTime);
             return Optional.of(completionTime);
         }
 
         return Optional.empty();
-    }
-
-    private boolean isResetJobState(String jobState) {
-        return jobState == null || jobState.isBlank() || "none".equalsIgnoreCase(jobState);
     }
 
     /**
@@ -117,7 +103,7 @@ public class MachineStateDetectionSupport {
         if (status == null) {
             return false;
         }
-        var isPoweredOff = "off".equalsIgnoreCase(status.getSwitchStatus());
+        var isPoweredOff = status.isSwitchOff();
         if (isPoweredOff) {
             log.debug("device power off detected switch=off");
         }
@@ -141,22 +127,19 @@ public class MachineStateDetectionSupport {
             return true;
         }
 
-        var machineState = isWasher ? status.getWasherOperatingState() : status.getDryerOperatingState();
-        if (!"stop".equalsIgnoreCase(machineState)) {
+        if (status.getOperatingState(isWasher) != MachineOperatingState.STOP) {
+            return false;
+        }
+        if (status.isJobStateFinished(isWasher)) {
+            return false;
+        }
+        if (status.isJobStateReset(isWasher)) {
+            log.debug("machine stopped with idle jobState, not treated as interruption jobState={}",
+                    status.getJobState(isWasher));
             return false;
         }
 
-        var jobState = isWasher ? status.getWasherJobState() : status.getDryerJobState();
-        var finishedJobState = isWasher ? "finish" : "finished";
-        if (finishedJobState.equalsIgnoreCase(jobState)) {
-            return false;
-        }
-        if (jobState == null || jobState.isBlank() || "none".equalsIgnoreCase(jobState)) {
-            log.debug("machine stopped with idle jobState, not treated as interruption jobState={}", jobState);
-            return false;
-        }
-
-        log.debug("machine interrupted mid-cycle machineState=stop jobState={}", jobState);
+        log.debug("machine interrupted mid-cycle machineState=stop jobState={}", status.getJobState(isWasher));
         return true;
     }
 
@@ -167,8 +150,7 @@ public class MachineStateDetectionSupport {
         if (status == null) {
             return false;
         }
-        var machineState = isWasher ? status.getWasherOperatingState() : status.getDryerOperatingState();
-        var isPaused = "pause".equalsIgnoreCase(machineState);
+        var isPaused = status.getOperatingState(isWasher) == MachineOperatingState.PAUSE;
         if (isPaused) {
             log.debug("device is paused isWasher={}", isWasher);
         }

--- a/src/main/java/team/washer/server/v2/global/common/constants/ReservationConstants.java
+++ b/src/main/java/team/washer/server/v2/global/common/constants/ReservationConstants.java
@@ -12,4 +12,17 @@ public final class ReservationConstants {
      * 오판하지 않도록 디바운스하는 데 사용한다. 라이프사이클 폴링 주기(30초) 기준 약 90초 연속 정지 시 확정된다.
      */
     public static final int INTERRUPTION_CONFIRM_THRESHOLD = 3;
+
+    /**
+     * 사이클 완료를 확정하기 전까지 연속으로 완료가 감지되어야 하는 폴링 횟수. SmartThings가 사이클 도중 단 한 번 순간적으로 보고한
+     * 정지·완료 신호를 곧바로 확정 처리하지 않도록 디바운스하는 데 사용한다. 라이프사이클 폴링 주기(30초) 기준 완료 반영이 최대 30초
+     * 지연된다.
+     */
+    public static final int COMPLETION_CONFIRM_THRESHOLD = 2;
+
+    /**
+     * 하나의 세탁·건조 사이클이 가질 수 있는 최대 길이(분). 기기가 보고한 완료 예정 시각이 이 범위를 벗어나면 이상치로 보고 저장하지
+     * 않는다. 조기 완료 판정({@code isTooEarlyCompletion})이 오염된 기준선 위에서 동작하는 것을 막기 위한 상한이다.
+     */
+    public static final int MAX_REASONABLE_CYCLE_MINUTES = 240;
 }

--- a/src/test/java/team/washer/server/v2/domain/machine/service/ForceStopMachineServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/ForceStopMachineServiceTest.java
@@ -41,6 +41,7 @@ import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceSt
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.DryerOperatingState;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.SwitchCapability;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.WasherOperatingState;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 import team.washer.server.v2.domain.smartthings.service.SendDeviceCommandService;
 import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
 import team.washer.server.v2.domain.user.entity.User;
@@ -155,7 +156,7 @@ class ForceStopMachineServiceTest {
                 // Then
                 assertThat(result.machineId()).isEqualTo(machineId);
                 assertThat(result.forceStopResult()).isEqualTo(ForceStopResult.STOPPED);
-                assertThat(result.previousMachineState()).isEqualTo("run");
+                assertThat(result.previousMachineState()).isEqualTo(MachineOperatingState.RUN);
                 assertThat(result.cancelledReservationId()).isEqualTo(reservationId);
                 assertThat(result.reservationCancelled()).isTrue();
                 assertThat(result.availability()).isEqualTo(MachineAvailability.AVAILABLE);

--- a/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
@@ -32,7 +32,6 @@ import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
-import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 
@@ -50,9 +49,6 @@ class QueryAllMachinesStatusServiceTest {
 
     @Mock
     private DeviceStatusQuerySupport deviceStatusQuerySupport;
-
-    @Mock
-    private MachineStateDetectionSupport machineStateDetectionSupport;
 
     @Mock
     private UserRepository userRepository;
@@ -190,14 +186,14 @@ class QueryAllMachinesStatusServiceTest {
         }
 
         @Test
-        @DisplayName("완료 신호가 확인된 활성 예약은 완료 예정 시각과 예약 정보를 숨긴다")
-        void execute_ShouldHideReservationInfo_WhenActiveReservationIsCompletedOnDeviceStatus() {
+        @DisplayName("기기가 완료 신호를 보고해도 DB의 RUNNING 예약이 남아 있으면 IN_USE와 예약 정보를 그대로 반환한다")
+        void execute_ShouldKeepReservationInfo_WhenDeviceReportsCompletionButReservationStillRunning() {
             // Given
             givenUserMocked();
 
             var machine = Machine.builder().name("W-3F-L1").type(MachineType.WASHER).deviceId("device-1").floor(3)
                     .position(Position.LEFT).number(1).status(MachineStatus.NORMAL)
-                    .availability(MachineAvailability.AVAILABLE).build();
+                    .availability(MachineAvailability.IN_USE).build();
 
             var machineStateAttr = new SmartThingsDeviceStatusResDto.AttributeState("stop",
                     "2026-01-26T15:30:00Z",
@@ -216,20 +212,21 @@ class QueryAllMachinesStatusServiceTest {
             when(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1")))
                     .thenReturn(Map.of("device-1", deviceStatus));
             when(reservationRepository.findActiveReservationByMachineId(any())).thenReturn(Optional.of(reservation));
-            when(reservation.isRunning()).thenReturn(true);
-            when(machineStateDetectionSupport.isCompleted(deviceStatus, true))
-                    .thenReturn(Optional.of(LocalDateTime.of(2026, 1, 27, 0, 30)));
+            when(reservation.getId()).thenReturn(10L);
+            when(reservation.getStatus()).thenReturn(ReservationStatus.RUNNING);
+            when(reservation.getUser()).thenReturn(user);
+            when(user.getId()).thenReturn(USER_ID);
+            when(user.getRoomNumber()).thenReturn("301");
 
             // When
             var result = queryAllMachinesStatusService.execute(USER_ID, true);
 
             // Then
-            assertThat(result.getFirst().availability()).isEqualTo(MachineAvailability.AVAILABLE);
-            assertThat(result.getFirst().expectedCompletionTime()).isNull();
-            assertThat(result.getFirst().remainingMinutes()).isNull();
-            assertThat(result.getFirst().reservationId()).isNull();
-            assertThat(result.getFirst().userId()).isNull();
-            assertThat(result.getFirst().roomNumber()).isNull();
+            assertThat(result.getFirst().availability()).isEqualTo(MachineAvailability.IN_USE);
+            assertThat(result.getFirst().expectedCompletionTime()).isEqualTo(LocalDateTime.of(2026, 1, 27, 0, 31));
+            assertThat(result.getFirst().reservationId()).isEqualTo(10L);
+            assertThat(result.getFirst().userId()).isEqualTo(USER_ID);
+            assertThat(result.getFirst().roomNumber()).isEqualTo("301");
         }
     }
 

--- a/src/test/java/team/washer/server/v2/domain/reservation/entity/ReservationTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/entity/ReservationTest.java
@@ -1,0 +1,171 @@
+package team.washer.server.v2.domain.reservation.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import team.washer.server.v2.global.common.constants.ReservationConstants;
+
+@DisplayName("Reservation 예상 완료 시각 상한 검증")
+class ReservationTest {
+
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
+    private Reservation buildReservedReservation() {
+        return Reservation.builder().reservedAt(LocalDateTime.now(KOREA_ZONE)).build();
+    }
+
+    private Reservation buildRunningReservation(LocalDateTime expectedCompletionTime) {
+        var reservation = buildReservedReservation();
+        reservation.start(expectedCompletionTime);
+        return reservation;
+    }
+
+    @Nested
+    @DisplayName("예약 시작 시 상한 검증")
+    class StartTest {
+
+        @Test
+        @DisplayName("합리적인 범위의 완료 예정 시각은 그대로 저장한다")
+        void shouldStoreExpectedCompletionTime_WhenWithinReasonableCycle() {
+            // Given
+            var expectedCompletionTime = LocalDateTime.now(KOREA_ZONE)
+                    .plusMinutes(ReservationConstants.DEFAULT_RESERVATION_DURATION_MINUTES);
+            var reservation = buildReservedReservation();
+
+            // When
+            reservation.start(expectedCompletionTime);
+
+            // Then
+            assertThat(reservation.getExpectedCompletionTime()).isEqualTo(expectedCompletionTime);
+        }
+
+        @Test
+        @DisplayName("사이클 상한을 넘는 완료 예정 시각은 저장하지 않는다")
+        void shouldNotStoreExpectedCompletionTime_WhenExceedingMaxCycle() {
+            // Given
+            var outlier = LocalDateTime.now(KOREA_ZONE)
+                    .plusMinutes(ReservationConstants.MAX_REASONABLE_CYCLE_MINUTES + 10);
+            var reservation = buildReservedReservation();
+
+            // When
+            reservation.start(outlier);
+
+            // Then
+            assertThat(reservation.getExpectedCompletionTime()).isNull();
+        }
+
+        @Test
+        @DisplayName("시작 시각보다 이른 완료 예정 시각은 저장하지 않는다")
+        void shouldNotStoreExpectedCompletionTime_WhenBeforeStartTime() {
+            // Given
+            var pastTime = LocalDateTime.now(KOREA_ZONE).minusMinutes(10);
+            var reservation = buildReservedReservation();
+
+            // When
+            reservation.start(pastTime);
+
+            // Then
+            assertThat(reservation.getExpectedCompletionTime()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("진행 중 완료 예정 시각 갱신")
+    class UpdateExpectedCompletionTimeTest {
+
+        @Test
+        @DisplayName("합리적인 범위의 값이면 갱신하고 true를 반환한다")
+        void shouldUpdateAndReturnTrue_WhenWithinReasonableCycle() {
+            // Given
+            var initial = LocalDateTime.now(KOREA_ZONE).plusMinutes(60);
+            var reservation = buildRunningReservation(initial);
+            var updated = initial.plusMinutes(5);
+
+            // When
+            var result = reservation.updateExpectedCompletionTime(updated);
+
+            // Then
+            assertThat(result).isTrue();
+            assertThat(reservation.getExpectedCompletionTime()).isEqualTo(updated);
+        }
+
+        @Test
+        @DisplayName("사이클 상한을 넘는 값이면 갱신하지 않고 false를 반환한다")
+        void shouldNotUpdateAndReturnFalse_WhenExceedingMaxCycle() {
+            // Given
+            var initial = LocalDateTime.now(KOREA_ZONE).plusMinutes(60);
+            var reservation = buildRunningReservation(initial);
+            var outlier = LocalDateTime.now(KOREA_ZONE)
+                    .plusMinutes(ReservationConstants.MAX_REASONABLE_CYCLE_MINUTES + 10);
+
+            // When
+            var result = reservation.updateExpectedCompletionTime(outlier);
+
+            // Then
+            assertThat(result).isFalse();
+            assertThat(reservation.getExpectedCompletionTime()).isEqualTo(initial);
+        }
+
+        @Test
+        @DisplayName("시작 시각보다 이른 값이면 갱신하지 않고 false를 반환한다")
+        void shouldNotUpdateAndReturnFalse_WhenBeforeStartTime() {
+            // Given
+            var initial = LocalDateTime.now(KOREA_ZONE).plusMinutes(60);
+            var reservation = buildRunningReservation(initial);
+            var pastTime = LocalDateTime.now(KOREA_ZONE).minusMinutes(10);
+
+            // When
+            var result = reservation.updateExpectedCompletionTime(pastTime);
+
+            // Then
+            assertThat(result).isFalse();
+            assertThat(reservation.getExpectedCompletionTime()).isEqualTo(initial);
+        }
+
+        @Test
+        @DisplayName("null이면 갱신하지 않고 false를 반환한다")
+        void shouldNotUpdateAndReturnFalse_WhenNull() {
+            // Given
+            var initial = LocalDateTime.now(KOREA_ZONE).plusMinutes(60);
+            var reservation = buildRunningReservation(initial);
+
+            // When
+            var result = reservation.updateExpectedCompletionTime(null);
+
+            // Then
+            assertThat(result).isFalse();
+            assertThat(reservation.getExpectedCompletionTime()).isEqualTo(initial);
+        }
+    }
+
+    @Nested
+    @DisplayName("완료 디바운스 카운터")
+    class CompletionCountTest {
+
+        @Test
+        @DisplayName("감지될 때마다 1씩 증가하고 초기화하면 0으로 돌아간다")
+        void shouldIncrementAndClear() {
+            // Given
+            var reservation = buildReservedReservation();
+
+            // When
+            reservation.incrementCompletionCount();
+            reservation.incrementCompletionCount();
+
+            // Then
+            assertThat(reservation.getCompletionCount()).isEqualTo(2);
+
+            // When
+            reservation.clearCompletionCount();
+
+            // Then
+            assertThat(reservation.getCompletionCount()).isZero();
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/reservation/scheduler/ReservationTimeoutSchedulerTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/scheduler/ReservationTimeoutSchedulerTest.java
@@ -1,0 +1,80 @@
+package team.washer.server.v2.domain.reservation.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import team.washer.server.v2.domain.reservation.service.CancelOverdueReservationService;
+import team.washer.server.v2.global.thirdparty.smartthings.SmartThingsOperationTimePolicy;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReservationTimeoutScheduler 예약 타임아웃 스케줄러")
+class ReservationTimeoutSchedulerTest {
+
+    @InjectMocks
+    private ReservationTimeoutScheduler reservationTimeoutScheduler;
+
+    @Mock
+    private CancelOverdueReservationService cancelOverdueReservationService;
+
+    @Mock
+    private SmartThingsOperationTimePolicy operationTimePolicy;
+
+    @Nested
+    @DisplayName("운영 시간 확인")
+    class OperationTimeTest {
+
+        @Test
+        @DisplayName("운영 시간 내이면 타임아웃 취소를 수행한다")
+        void shouldExecute_WhenWithinOperationHours() {
+            // Given
+            when(operationTimePolicy.isOperationAllowed()).thenReturn(true);
+
+            // When
+            reservationTimeoutScheduler.checkReservationTimeouts();
+
+            // Then
+            verify(cancelOverdueReservationService, times(1)).execute();
+        }
+
+        @Test
+        @DisplayName("운영 시간 외이면 타임아웃 취소를 수행하지 않는다")
+        void shouldSkip_WhenOutsideOperationHours() {
+            // Given
+            when(operationTimePolicy.isOperationAllowed()).thenReturn(false);
+
+            // When
+            reservationTimeoutScheduler.checkReservationTimeouts();
+
+            // Then
+            verify(cancelOverdueReservationService, never()).execute();
+        }
+    }
+
+    @Nested
+    @DisplayName("예외 처리")
+    class ExceptionHandlingTest {
+
+        @Test
+        @DisplayName("타임아웃 취소가 실패해도 예외를 전파하지 않는다")
+        void shouldNotPropagate_WhenExecutionFails() {
+            // Given
+            when(operationTimePolicy.isOperationAllowed()).thenReturn(true);
+            doThrow(new IllegalStateException("타임아웃 취소 실패")).when(cancelOverdueReservationService).execute();
+
+            // When & Then
+            assertThatCode(() -> reservationTimeoutScheduler.checkReservationTimeouts()).doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
@@ -26,6 +26,8 @@ import team.washer.server.v2.domain.notification.support.ReservationNotification
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.reservation.service.impl.ReservationLifecycleProcessor;
+import team.washer.server.v2.domain.reservation.support.CompletionDecision;
+import team.washer.server.v2.domain.reservation.support.ReservationCompletionDecisionSupport;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 import team.washer.server.v2.domain.user.entity.User;
@@ -49,6 +51,9 @@ class ReservationLifecycleProcessorTest {
 
     @Mock
     private MachineStateDetectionSupport machineStateDetectionSupport;
+
+    @Mock
+    private ReservationCompletionDecisionSupport completionDecisionSupport;
 
     @Mock
     private ReservationNotificationSupport reservationNotificationSupport;
@@ -90,52 +95,6 @@ class ReservationLifecycleProcessorTest {
         return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
     }
 
-    private SmartThingsDeviceStatusResDto buildWasherStatusWithTimestamp(String machineStateTimestamp,
-            String jobStateTimestamp) {
-        var machineStateAttr = new SmartThingsDeviceStatusResDto.AttributeState("stop", machineStateTimestamp, null);
-        var jobStateAttr = new SmartThingsDeviceStatusResDto.AttributeState("finish", jobStateTimestamp, null);
-        var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(machineStateAttr,
-                jobStateAttr,
-                null);
-        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null, null);
-        return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
-    }
-
-    private SmartThingsDeviceStatusResDto buildDryerStatusWithTimestamp(String machineStateTimestamp,
-            String jobStateTimestamp) {
-        var machineStateAttr = new SmartThingsDeviceStatusResDto.AttributeState("stop", machineStateTimestamp, null);
-        var jobStateAttr = new SmartThingsDeviceStatusResDto.AttributeState("finished", jobStateTimestamp, null);
-        var dryerOpState = new SmartThingsDeviceStatusResDto.DryerOperatingState(machineStateAttr, jobStateAttr, null);
-        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(null, dryerOpState, null, null);
-        return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
-    }
-
-    private SmartThingsDeviceStatusResDto buildWasherStoppedStatus(String jobState, String completionTime) {
-        var machineStateAttr = new SmartThingsDeviceStatusResDto.AttributeState("stop", null, null);
-        var jobStateAttr = new SmartThingsDeviceStatusResDto.AttributeState(jobState, null, null);
-        var completionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState(completionTime, null, null);
-        var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(machineStateAttr,
-                jobStateAttr,
-                completionTimeAttr);
-        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null, null);
-        return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
-    }
-
-    private SmartThingsDeviceStatusResDto buildDryerStoppedStatus(String jobState, String completionTime) {
-        var machineStateAttr = new SmartThingsDeviceStatusResDto.AttributeState("stop", null, null);
-        var jobStateAttr = new SmartThingsDeviceStatusResDto.AttributeState(jobState, null, null);
-        var completionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState(completionTime, null, null);
-        var dryerOpState = new SmartThingsDeviceStatusResDto.DryerOperatingState(machineStateAttr,
-                jobStateAttr,
-                completionTimeAttr);
-        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(null, dryerOpState, null, null);
-        return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
-    }
-
-    private String isoUtc(LocalDateTime koreaTime) {
-        return koreaTime.atZone(KOREA_ZONE).withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime().toString() + "Z";
-    }
-
     @Nested
     @DisplayName("RESERVED -> RUNNING 전환 처리")
     class ProcessReservedToRunningTest {
@@ -144,11 +103,13 @@ class ReservationLifecycleProcessorTest {
         @DisplayName("RESERVED 상태이고 기기가 작동 중이면 RUNNING으로 전환하고 시작 알림을 전송한다")
         void shouldStartReservation_WhenReservedAndMachineRunning() {
             // Given
+            var expectedCompletionTime = LocalDateTime.of(2026, 1, 27, 0, 30);
             var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
             when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
             when(reservation.isReserved()).thenReturn(true);
             when(reservation.getMachine()).thenReturn(machine);
             when(reservation.getUser()).thenReturn(user);
+            when(reservation.getExpectedCompletionTime()).thenReturn(expectedCompletionTime);
             when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(true);
 
@@ -158,7 +119,7 @@ class ReservationLifecycleProcessorTest {
             // Then
             verify(reservation, times(1)).start(any(LocalDateTime.class));
             verify(reservationRepository, times(1)).save(reservation);
-            verify(reservationNotificationSupport, times(1)).sendStarted(any(), any(), any(LocalDateTime.class));
+            verify(reservationNotificationSupport, times(1)).sendStarted(user, machine, expectedCompletionTime);
         }
 
         @Test
@@ -184,11 +145,13 @@ class ReservationLifecycleProcessorTest {
         @DisplayName("건조기 예약 시작 시 건조기 완료 예정 시간을 저장해야 한다")
         void shouldStartDryerReservationWithDryerCompletionTime_WhenBothCompletionTimesExist() {
             // Given
+            var dryerCompletionTime = LocalDateTime.of(2026, 1, 27, 1, 0);
             var deviceStatus = buildStatusWithMixedCompletionTime("2026-01-26T15:30:00Z", "2026-01-26T16:00:00Z");
             when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
             when(reservation.isReserved()).thenReturn(true);
             when(reservation.getMachine()).thenReturn(machine);
             when(reservation.getUser()).thenReturn(user);
+            when(reservation.getExpectedCompletionTime()).thenReturn(dryerCompletionTime);
             when(machine.isWasher()).thenReturn(false);
             when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(true);
@@ -197,9 +160,29 @@ class ReservationLifecycleProcessorTest {
             reservationLifecycleProcessor.processReservedToRunning(RESERVATION_ID, deviceStatus);
 
             // Then
-            verify(reservation, times(1)).start(LocalDateTime.of(2026, 1, 27, 1, 0));
-            verify(reservationNotificationSupport, times(1))
-                    .sendStarted(user, machine, LocalDateTime.of(2026, 1, 27, 1, 0));
+            verify(reservation, times(1)).start(dryerCompletionTime);
+            verify(reservationNotificationSupport, times(1)).sendStarted(user, machine, dryerCompletionTime);
+        }
+
+        @Test
+        @DisplayName("기기가 보고한 완료 예정 시각이 상한을 벗어나 저장되지 않으면 예상 완료 시각 없이 시작 알림을 전송한다")
+        void shouldSendStartedWithoutExpectedTime_WhenReportedCompletionTimeRejected() {
+            // Given
+            var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
+            when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
+            when(reservation.isReserved()).thenReturn(true);
+            when(reservation.getMachine()).thenReturn(machine);
+            when(reservation.getUser()).thenReturn(user);
+            when(reservation.getExpectedCompletionTime()).thenReturn(null);
+            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(true);
+
+            // When
+            reservationLifecycleProcessor.processReservedToRunning(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, times(1)).start(any(LocalDateTime.class));
+            verify(reservationNotificationSupport, times(1)).sendStarted(user, machine, null);
         }
 
         @Test
@@ -229,113 +212,28 @@ class ReservationLifecycleProcessorTest {
             when(reservation.getMachine()).thenReturn(machine);
         }
 
+        private void givenCompletionDecision(CompletionDecision decision) {
+            when(completionDecisionSupport.decide(any(), any(), anyBoolean())).thenReturn(decision);
+        }
+
         @Test
-        @DisplayName("RUNNING 상태이고 기기 작업이 완료되면 COMPLETED로 전환하고 알림을 전송한다")
-        void shouldCompleteReservation_WhenRunningAndMachineCompleted() {
+        @DisplayName("완료 판정이 확정 임계치까지 연속되면 COMPLETED로 전환하고 완료 알림을 전송한다")
+        void shouldCompleteReservation_WhenCompletionConfirmed() {
             // Given
             var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
             givenRunningReservation();
+            givenCompletionDecision(
+                    CompletionDecision.completed(LocalDateTime.now(KOREA_ZONE), "smartthings_completed"));
+            when(reservation.getCompletionCount()).thenReturn(ReservationConstants.COMPLETION_CONFIRM_THRESHOLD);
             when(reservation.getUser()).thenReturn(user);
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.of(LocalDateTime.now(KOREA_ZONE)));
 
             // When
             reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
 
             // Then
+            verify(reservation, times(1)).incrementCompletionCount();
             verify(reservation, times(1)).complete();
-            verify(reservationRepository, times(1)).save(reservation);
-            verify(reservationNotificationSupport, times(1)).sendCompletion(user, machine);
-        }
-
-        @Test
-        @DisplayName("완료 시각이 현재 예약 시작 시각보다 이전이면 이전 상태로 보고 완료 처리하지 않는다")
-        void shouldNotCompleteReservation_WhenCompletionTimeBeforeReservationStartTime() {
-            // Given
-            var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
-            var startTime = LocalDateTime.now(KOREA_ZONE);
-            var staleCompletionTime = startTime.minusMinutes(5);
-            givenRunningReservation();
-            when(reservation.getStartTime()).thenReturn(startTime);
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.of(staleCompletionTime));
-
-            // When
-            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
-
-            // Then
-            verify(reservation, never()).complete();
-            verify(machine, never()).markAsAvailable();
-            verify(reservationRepository, never()).save(reservation);
-            verify(machineRepository, never()).save(machine);
-            verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
-        }
-
-        @Test
-        @DisplayName("완료 신호의 갱신 시각이 예약 시작 전이면 이전 상태로 보고 완료 처리하지 않는다")
-        void shouldNotCompleteReservation_WhenCompletionSignalTimestampBeforeReservationStartTime() {
-            // Given
-            var startTime = LocalDateTime.now(KOREA_ZONE);
-            var staleTimestamp = isoUtc(startTime.minusMinutes(1));
-            var deviceStatus = buildWasherStatusWithTimestamp(staleTimestamp, staleTimestamp);
-            givenRunningReservation();
-            when(machine.isWasher()).thenReturn(true);
-            when(reservation.getStartTime()).thenReturn(startTime);
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.of(startTime.plusMinutes(1)));
-
-            // When
-            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
-
-            // Then
-            verify(reservation, never()).complete();
-            verify(machine, never()).markAsAvailable();
-            verify(reservationRepository, never()).save(reservation);
-            verify(machineRepository, never()).save(machine);
-            verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
-        }
-
-        @Test
-        @DisplayName("예상 완료 시간이 정상 범위이면 너무 이른 완료 신호를 보류한다")
-        void shouldNotCompleteReservation_WhenCompletionDetectedTooEarlyWithNormalExpectedTime() {
-            // Given
-            var nowKst = LocalDateTime.now(KOREA_ZONE);
-            var deviceStatus = buildDryerStatusWithTimestamp(isoUtc(nowKst), isoUtc(nowKst));
-            givenRunningReservation();
-            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(1));
-            when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.plusMinutes(10));
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.of(nowKst));
-
-            // When
-            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
-
-            // Then
-            verify(reservation, never()).complete();
-            verify(machine, never()).markAsAvailable();
-            verify(reservationRepository, never()).save(reservation);
-            verify(machineRepository, never()).save(machine);
-            verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
-        }
-
-        @Test
-        @DisplayName("예상 완료 시간이 비정상적으로 길고 최신 완료 증거가 있으면 완료 처리한다")
-        void shouldCompleteReservation_WhenExpectedCompletionTimeIsSuspiciousAndCompletionEvidenceIsFresh() {
-            // Given
-            var nowKst = LocalDateTime.now(KOREA_ZONE);
-            var deviceStatus = buildDryerStatusWithTimestamp(isoUtc(nowKst), isoUtc(nowKst));
-            givenRunningReservation();
-            when(reservation.getUser()).thenReturn(user);
-            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(10));
-            when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.plusHours(10));
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.of(nowKst));
-
-            // When
-            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
-
-            // Then
-            verify(reservation, times(1)).complete();
+            verify(reservation, times(1)).clearCompletionCount();
             verify(machine, times(1)).markAsAvailable();
             verify(reservationRepository, times(1)).save(reservation);
             verify(machineRepository, times(1)).save(machine);
@@ -343,156 +241,88 @@ class ReservationLifecycleProcessorTest {
         }
 
         @Test
-        @DisplayName("예상 완료 시간이 비정상적으로 길어도 최신 완료 증거가 없으면 완료 신호를 보류한다")
-        void shouldNotCompleteReservation_WhenExpectedCompletionTimeIsSuspiciousButCompletionEvidenceIsMissing() {
+        @DisplayName("완료가 처음 감지되면 카운트만 증가시키고 완료 처리하지 않는다")
+        void shouldOnlyIncrementCount_WhenCompletionBelowThreshold() {
+            // Given
+            var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
+            givenRunningReservation();
+            givenCompletionDecision(
+                    CompletionDecision.completed(LocalDateTime.now(KOREA_ZONE), "stopped_near_completion"));
+            when(reservation.getCompletionCount()).thenReturn(ReservationConstants.COMPLETION_CONFIRM_THRESHOLD - 1);
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, times(1)).incrementCompletionCount();
+            verify(reservation, never()).complete();
+            verify(machine, never()).markAsAvailable();
+            verify(reservationRepository, times(1)).save(reservation);
+            verify(machineRepository, never()).save(machine);
+            verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
+        }
+
+        @Test
+        @DisplayName("완료 신호가 가드에 걸려 보류되면 완료 카운트를 초기화하고 중단 판정으로 넘어가지 않는다")
+        void shouldClearCompletionCountAndDefer_WhenCompletionDeferredByGuard() {
+            // Given
+            var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
+            givenRunningReservation();
+            givenCompletionDecision(CompletionDecision.deferred(LocalDateTime.now(KOREA_ZONE), "too_early_completion"));
+            when(reservation.getCompletionCount()).thenReturn(1);
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, times(1)).clearCompletionCount();
+            verify(reservation, never()).complete();
+            verify(reservation, never()).incrementCompletionCount();
+            verify(reservationRepository, times(1)).save(reservation);
+            verify(machineStateDetectionSupport, never()).isInterrupted(any(), anyBoolean());
+            verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
+        }
+
+        @Test
+        @DisplayName("전원이 꺼지면 완료 예정 시각 근처여도 중단 카운트를 증가시킨다")
+        void shouldCountInterruption_WhenPoweredOffEvenNearCompletionTime() {
             // Given
             var deviceStatus = buildDeviceStatus(null);
-            var nowKst = LocalDateTime.now(KOREA_ZONE);
             givenRunningReservation();
-            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(10));
-            when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.plusHours(10));
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.of(nowKst));
-
-            // When
-            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
-
-            // Then
-            verify(reservation, never()).complete();
-            verify(machine, never()).markAsAvailable();
-            verify(reservationRepository, never()).save(reservation);
-            verify(machineRepository, never()).save(machine);
-            verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
-        }
-
-        @Test
-        @DisplayName("RUNNING 상태이고 기기 작업이 완료되지 않으면 예상 완료 시각을 갱신한다")
-        void shouldUpdateExpectedCompletionTime_WhenRunningAndMachineNotCompleted() {
-            // Given
-            var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
-            givenRunningReservation();
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.empty());
-            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(false);
-            when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(false);
-            when(reservation.getExpectedCompletionTime()).thenReturn(null);
-
-            // When
-            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
-
-            // Then
-            verify(reservation, never()).complete();
-            verify(reservation, never()).cancel();
-            verify(reservation, times(1)).updateExpectedCompletionTime(any(LocalDateTime.class));
-            verify(reservationRepository, times(1)).save(reservation);
-            verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
-        }
-
-        @Test
-        @DisplayName("건조기 진행 중 상태 갱신 시 건조기 완료 예정 시간을 저장해야 한다")
-        void shouldUpdateDryerExpectedCompletionTime_WhenBothCompletionTimesExist() {
-            // Given
-            var deviceStatus = buildStatusWithMixedCompletionTime("2026-01-26T15:30:00Z", "2026-01-26T16:00:00Z");
-            givenRunningReservation();
-            when(machine.isWasher()).thenReturn(false);
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.empty());
-            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(false);
-            when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(false);
-            when(reservation.getExpectedCompletionTime()).thenReturn(null);
-
-            // When
-            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
-
-            // Then
-            verify(reservation, times(1)).updateExpectedCompletionTime(LocalDateTime.of(2026, 1, 27, 1, 0));
-            verify(reservationRepository, times(1)).save(reservation);
-        }
-
-        @Test
-        @DisplayName("완료 예정 시각 근처에서 정지 상태가 감지되면 중단 취소를 보류한다")
-        void shouldDeferInterruption_WhenStoppedNearFutureCompletionTime() {
-            // Given
-            var nowKst = LocalDateTime.now(KOREA_ZONE);
-            var completionTime = nowKst.plusMinutes(3);
-            var deviceStatus = buildWasherStoppedStatus("spin", isoUtc(completionTime));
-            givenRunningReservation();
-            when(machine.isWasher()).thenReturn(true);
-            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(40));
-            when(reservation.getExpectedCompletionTime()).thenReturn(completionTime);
+            givenCompletionDecision(CompletionDecision.notCompleted());
+            when(machineStateDetectionSupport.isPoweredOff(any(SmartThingsDeviceStatusResDto.class))).thenReturn(true);
             when(reservation.getInterruptionCount()).thenReturn(1);
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.empty());
 
             // When
             reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
 
             // Then
-            verify(reservation, times(1)).clearInterruptionCount();
+            verify(reservation, times(1)).incrementInterruptionCount();
+            verify(reservation, never()).clearInterruptionCount();
+            verify(reservation, never()).cancel();
             verify(reservationRepository, times(1)).save(reservation);
+            verify(completionDecisionSupport, never()).isStoppedNearCompletion(any(), any(), anyBoolean());
+        }
+
+        @Test
+        @DisplayName("완료 예정 시각 근처 정지는 중단 카운트를 건드리지 않고 판정을 보류한다")
+        void shouldHoldWithoutTouchingInterruptionCount_WhenStoppedNearCompletionTime() {
+            // Given
+            var deviceStatus = buildDeviceStatus(null);
+            givenRunningReservation();
+            givenCompletionDecision(CompletionDecision.notCompleted());
+            when(machineStateDetectionSupport.isPoweredOff(any(SmartThingsDeviceStatusResDto.class))).thenReturn(false);
+            when(completionDecisionSupport.isStoppedNearCompletion(any(), any(), anyBoolean())).thenReturn(true);
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
             verify(reservation, never()).incrementInterruptionCount();
+            verify(reservation, never()).clearInterruptionCount();
             verify(reservation, never()).cancel();
-            verify(reservationNotificationSupport, never()).sendInterruption(any(), any());
-            verify(machineStateDetectionSupport, never()).isInterrupted(any(), anyBoolean());
-        }
-
-        @Test
-        @DisplayName("완료 예정 시각 근처 정지 상태에서 완료 시각이 지나면 완료 처리한다")
-        void shouldComplete_WhenStoppedNearCompletionTimeAndTimePassed() {
-            // Given
-            var nowKst = LocalDateTime.now(KOREA_ZONE);
-            var completionTime = nowKst.minusMinutes(1);
-            var deviceStatus = buildWasherStoppedStatus("spin", isoUtc(completionTime));
-            givenRunningReservation();
-            when(machine.isWasher()).thenReturn(true);
-            when(reservation.getUser()).thenReturn(user);
-            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(40));
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.empty());
-
-            // When
-            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
-
-            // Then
-            verify(reservation, times(1)).complete();
-            verify(machine, times(1)).markAsAvailable();
-            verify(reservationRepository, times(1)).save(reservation);
-            verify(machineRepository, times(1)).save(machine);
-            verify(reservationNotificationSupport, times(1)).sendCompletion(user, machine);
-            verify(reservation, never()).cancel();
-            verify(reservationNotificationSupport, never()).sendInterruption(any(), any());
-            verify(machineStateDetectionSupport, never()).isInterrupted(any(), anyBoolean());
-        }
-
-        @Test
-        @DisplayName("건조기도 완료 예정 시각 근처 정지 상태에서 완료 시각이 지나면 완료 처리한다")
-        void shouldCompleteDryer_WhenStoppedNearCompletionTimeAndTimePassed() {
-            // Given
-            var nowKst = LocalDateTime.now(KOREA_ZONE);
-            var completionTime = nowKst.minusMinutes(1);
-            var deviceStatus = buildDryerStoppedStatus("drying", isoUtc(completionTime));
-            givenRunningReservation();
-            when(machine.isWasher()).thenReturn(false);
-            when(reservation.getUser()).thenReturn(user);
-            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(40));
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.empty());
-
-            // When
-            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
-
-            // Then
-            verify(reservation, times(1)).complete();
-            verify(machine, times(1)).markAsAvailable();
-            verify(reservationRepository, times(1)).save(reservation);
-            verify(machineRepository, times(1)).save(machine);
-            verify(reservationNotificationSupport, times(1)).sendCompletion(user, machine);
-            verify(reservation, never()).cancel();
-            verify(reservationNotificationSupport, never()).sendInterruption(any(), any());
+            verify(reservation, never()).complete();
+            verify(reservationRepository, never()).save(reservation);
             verify(machineStateDetectionSupport, never()).isInterrupted(any(), anyBoolean());
         }
 
@@ -502,8 +332,9 @@ class ReservationLifecycleProcessorTest {
             // Given
             var deviceStatus = buildDeviceStatus(null);
             givenRunningReservation();
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.empty());
+            givenCompletionDecision(CompletionDecision.notCompleted());
+            when(machineStateDetectionSupport.isPoweredOff(any(SmartThingsDeviceStatusResDto.class))).thenReturn(false);
+            when(completionDecisionSupport.isStoppedNearCompletion(any(), any(), anyBoolean())).thenReturn(false);
             when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(true);
             when(reservation.getInterruptionCount()).thenReturn(1);
@@ -526,9 +357,10 @@ class ReservationLifecycleProcessorTest {
             // Given
             var deviceStatus = buildDeviceStatus(null);
             givenRunningReservation();
+            givenCompletionDecision(CompletionDecision.notCompleted());
             when(reservation.getUser()).thenReturn(user);
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.empty());
+            when(machineStateDetectionSupport.isPoweredOff(any(SmartThingsDeviceStatusResDto.class))).thenReturn(false);
+            when(completionDecisionSupport.isStoppedNearCompletion(any(), any(), anyBoolean())).thenReturn(false);
             when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(true);
             when(reservation.getInterruptionCount()).thenReturn(ReservationConstants.INTERRUPTION_CONFIRM_THRESHOLD);
@@ -554,8 +386,9 @@ class ReservationLifecycleProcessorTest {
             // Given
             var deviceStatus = buildDeviceStatus(null);
             givenRunningReservation();
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.empty());
+            givenCompletionDecision(CompletionDecision.notCompleted());
+            when(machineStateDetectionSupport.isPoweredOff(any(SmartThingsDeviceStatusResDto.class))).thenReturn(false);
+            when(completionDecisionSupport.isStoppedNearCompletion(any(), any(), anyBoolean())).thenReturn(false);
             when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(false);
             when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
@@ -578,14 +411,15 @@ class ReservationLifecycleProcessorTest {
             // Given
             var deviceStatus = buildDeviceStatus(null);
             givenRunningReservation();
+            givenCompletionDecision(CompletionDecision.notCompleted());
             when(reservation.getUser()).thenReturn(user);
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.empty());
+            when(machineStateDetectionSupport.isPoweredOff(any(SmartThingsDeviceStatusResDto.class))).thenReturn(false);
+            when(completionDecisionSupport.isStoppedNearCompletion(any(), any(), anyBoolean())).thenReturn(false);
             when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(false);
             when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(true);
-            when(reservation.getPausedAt()).thenReturn(LocalDateTime.now().minusMinutes(11));
+            when(reservation.getPausedAt()).thenReturn(LocalDateTime.now(KOREA_ZONE).minusMinutes(11));
 
             // When
             reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
@@ -602,19 +436,97 @@ class ReservationLifecycleProcessorTest {
         }
 
         @Test
+        @DisplayName("RUNNING 상태이고 기기 작업이 완료되지 않으면 예상 완료 시각을 갱신한다")
+        void shouldUpdateExpectedCompletionTime_WhenRunningAndMachineNotCompleted() {
+            // Given
+            var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
+            givenRunningReservation();
+            givenCompletionDecision(CompletionDecision.notCompleted());
+            when(machineStateDetectionSupport.isPoweredOff(any(SmartThingsDeviceStatusResDto.class))).thenReturn(false);
+            when(completionDecisionSupport.isStoppedNearCompletion(any(), any(), anyBoolean())).thenReturn(false);
+            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
+            when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
+            when(reservation.getExpectedCompletionTime()).thenReturn(null);
+            when(reservation.updateExpectedCompletionTime(any(LocalDateTime.class))).thenReturn(true);
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, never()).complete();
+            verify(reservation, never()).cancel();
+            verify(reservation, times(1)).updateExpectedCompletionTime(any(LocalDateTime.class));
+            verify(reservationRepository, times(1)).save(reservation);
+            verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
+        }
+
+        @Test
+        @DisplayName("건조기 진행 중 상태 갱신 시 건조기 완료 예정 시간을 저장해야 한다")
+        void shouldUpdateDryerExpectedCompletionTime_WhenBothCompletionTimesExist() {
+            // Given
+            var deviceStatus = buildStatusWithMixedCompletionTime("2026-01-26T15:30:00Z", "2026-01-26T16:00:00Z");
+            givenRunningReservation();
+            givenCompletionDecision(CompletionDecision.notCompleted());
+            when(machine.isWasher()).thenReturn(false);
+            when(machineStateDetectionSupport.isPoweredOff(any(SmartThingsDeviceStatusResDto.class))).thenReturn(false);
+            when(completionDecisionSupport.isStoppedNearCompletion(any(), any(), anyBoolean())).thenReturn(false);
+            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
+            when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
+            when(reservation.getExpectedCompletionTime()).thenReturn(null);
+            when(reservation.updateExpectedCompletionTime(any(LocalDateTime.class))).thenReturn(true);
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, times(1)).updateExpectedCompletionTime(LocalDateTime.of(2026, 1, 27, 1, 0));
+            verify(reservationRepository, times(1)).save(reservation);
+        }
+
+        @Test
+        @DisplayName("기기가 보고한 완료 예정 시각이 상한을 벗어나 거부되면 저장하지 않는다")
+        void shouldNotSave_WhenReportedExpectedCompletionTimeRejected() {
+            // Given
+            var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
+            givenRunningReservation();
+            givenCompletionDecision(CompletionDecision.notCompleted());
+            when(machineStateDetectionSupport.isPoweredOff(any(SmartThingsDeviceStatusResDto.class))).thenReturn(false);
+            when(completionDecisionSupport.isStoppedNearCompletion(any(), any(), anyBoolean())).thenReturn(false);
+            when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
+            when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(false);
+            when(reservation.getExpectedCompletionTime()).thenReturn(null);
+            when(reservation.updateExpectedCompletionTime(any(LocalDateTime.class))).thenReturn(false);
+
+            // When
+            reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, times(1)).updateExpectedCompletionTime(any(LocalDateTime.class));
+            verify(reservationRepository, never()).save(reservation);
+        }
+
+        @Test
         @DisplayName("일시정지 후 재개되면 pausedAt을 초기화하고 예상 완료 시각을 갱신한다")
         void shouldClearPausedAtAndUpdateExpectedTime_WhenMachineResumed() {
             // Given
             var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
             givenRunningReservation();
-            when(machineStateDetectionSupport.isCompleted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(Optional.empty());
+            givenCompletionDecision(CompletionDecision.notCompleted());
+            when(machineStateDetectionSupport.isPoweredOff(any(SmartThingsDeviceStatusResDto.class))).thenReturn(false);
+            when(completionDecisionSupport.isStoppedNearCompletion(any(), any(), anyBoolean())).thenReturn(false);
             when(machineStateDetectionSupport.isInterrupted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(false);
             when(machineStateDetectionSupport.isPaused(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(false);
-            when(reservation.getPausedAt()).thenReturn(LocalDateTime.now().minusMinutes(3));
+            when(reservation.getPausedAt()).thenReturn(LocalDateTime.now(KOREA_ZONE).minusMinutes(3));
             when(reservation.getExpectedCompletionTime()).thenReturn(null);
+            when(reservation.updateExpectedCompletionTime(any(LocalDateTime.class))).thenReturn(true);
 
             // When
             reservationLifecycleProcessor.processRunningToCompleted(RESERVATION_ID, deviceStatus);

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
@@ -234,6 +234,8 @@ class ReservationLifecycleProcessorTest {
             verify(reservation, times(1)).incrementCompletionCount();
             verify(reservation, times(1)).complete();
             verify(reservation, times(1)).clearCompletionCount();
+            verify(reservation, times(1)).clearInterruptionCount();
+            verify(reservation, times(1)).clearPausedAt();
             verify(machine, times(1)).markAsAvailable();
             verify(reservationRepository, times(1)).save(reservation);
             verify(machineRepository, times(1)).save(machine);

--- a/src/test/java/team/washer/server/v2/domain/reservation/support/ReservationCompletionDecisionSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/support/ReservationCompletionDecisionSupportTest.java
@@ -1,0 +1,327 @@
+package team.washer.server.v2.domain.reservation.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReservationCompletionDecisionSupport 완료 판정")
+class ReservationCompletionDecisionSupportTest {
+
+    private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+
+    @InjectMocks
+    private ReservationCompletionDecisionSupport completionDecisionSupport;
+
+    @Mock
+    private MachineStateDetectionSupport machineStateDetectionSupport;
+
+    @Mock
+    private Reservation reservation;
+
+    private SmartThingsDeviceStatusResDto buildWasherStatus(String machineState,
+            String jobState,
+            String completionTime) {
+        return buildWasherStatus(machineState, null, jobState, null, completionTime);
+    }
+
+    private SmartThingsDeviceStatusResDto buildWasherStatus(String machineState,
+            String machineStateTimestamp,
+            String jobState,
+            String jobStateTimestamp,
+            String completionTime) {
+        var machineStateAttr = new SmartThingsDeviceStatusResDto.AttributeState(machineState,
+                machineStateTimestamp,
+                null);
+        var jobStateAttr = new SmartThingsDeviceStatusResDto.AttributeState(jobState, jobStateTimestamp, null);
+        var completionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState(completionTime, null, null);
+        var washerOpState = new SmartThingsDeviceStatusResDto.WasherOperatingState(machineStateAttr,
+                jobStateAttr,
+                completionTimeAttr);
+        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(washerOpState, null, null, null);
+        return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
+    }
+
+    private SmartThingsDeviceStatusResDto buildDryerStatus(String machineState,
+            String jobState,
+            String completionTime) {
+        var machineStateAttr = new SmartThingsDeviceStatusResDto.AttributeState(machineState, null, null);
+        var jobStateAttr = new SmartThingsDeviceStatusResDto.AttributeState(jobState, null, null);
+        var completionTimeAttr = new SmartThingsDeviceStatusResDto.AttributeState(completionTime, null, null);
+        var dryerOpState = new SmartThingsDeviceStatusResDto.DryerOperatingState(machineStateAttr,
+                jobStateAttr,
+                completionTimeAttr);
+        var componentStatus = new SmartThingsDeviceStatusResDto.ComponentStatus(null, dryerOpState, null, null);
+        return new SmartThingsDeviceStatusResDto(Map.of("main", componentStatus));
+    }
+
+    private String isoUtc(LocalDateTime koreaTime) {
+        return koreaTime.atZone(KOREA_ZONE).withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime().toString() + "Z";
+    }
+
+    private void givenDetectedCompletion(LocalDateTime completionTime) {
+        when(machineStateDetectionSupport.isCompleted(any(), anyBoolean())).thenReturn(Optional.of(completionTime));
+    }
+
+    private void givenNoDetectedCompletion() {
+        when(machineStateDetectionSupport.isCompleted(any(), anyBoolean())).thenReturn(Optional.empty());
+    }
+
+    @Nested
+    @DisplayName("SmartThings 완료 보고 경로")
+    class SmartThingsCompletedPathTest {
+
+        @Test
+        @DisplayName("가드를 모두 통과하면 완료로 판정한다")
+        void shouldReturnCompleted_WhenAllGuardsPassed() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var status = buildWasherStatus("stop", "finish", isoUtc(nowKst));
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(60));
+            when(reservation.getExpectedCompletionTime()).thenReturn(nowKst);
+            givenDetectedCompletion(nowKst);
+
+            // When
+            var decision = completionDecisionSupport.decide(reservation, status, true);
+
+            // Then
+            assertThat(decision.isCompleted()).isTrue();
+            assertThat(decision.reason()).isEqualTo("smartthings_completed");
+            assertThat(decision.completionTime()).isEqualTo(nowKst);
+        }
+
+        @Test
+        @DisplayName("완료 시각이 예약 시작 시각보다 이전이면 이전 사이클의 잔재로 보고 보류한다")
+        void shouldDefer_WhenCompletionTimeBeforeStartTime() {
+            // Given
+            var startTime = LocalDateTime.now(KOREA_ZONE);
+            var staleCompletionTime = startTime.minusMinutes(5);
+            var status = buildWasherStatus("stop", "finish", isoUtc(staleCompletionTime));
+            when(reservation.getStartTime()).thenReturn(startTime);
+            givenDetectedCompletion(staleCompletionTime);
+
+            // When
+            var decision = completionDecisionSupport.decide(reservation, status, true);
+
+            // Then
+            assertThat(decision.isDeferred()).isTrue();
+            assertThat(decision.reason()).isEqualTo("stale_completion");
+        }
+
+        @Test
+        @DisplayName("완료 신호의 갱신 시각이 예약 시작 전이면 이전 사이클의 잔재로 보고 보류한다")
+        void shouldDefer_WhenCompletionSignalTimestampBeforeStartTime() {
+            // Given
+            var startTime = LocalDateTime.now(KOREA_ZONE);
+            var staleTimestamp = isoUtc(startTime.minusMinutes(1));
+            var status = buildWasherStatus("stop", staleTimestamp, "finish", staleTimestamp, isoUtc(startTime));
+            when(reservation.getStartTime()).thenReturn(startTime);
+            givenDetectedCompletion(startTime.plusMinutes(1));
+
+            // When
+            var decision = completionDecisionSupport.decide(reservation, status, true);
+
+            // Then
+            assertThat(decision.isDeferred()).isTrue();
+            assertThat(decision.reason()).isEqualTo("stale_completion");
+        }
+
+        @Test
+        @DisplayName("예상 완료 시각보다 지나치게 이른 완료 신호는 보류한다")
+        void shouldDefer_WhenCompletionDetectedTooEarly() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var status = buildWasherStatus("stop", "finish", isoUtc(nowKst));
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(1));
+            when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.plusMinutes(10));
+            givenDetectedCompletion(nowKst);
+
+            // When
+            var decision = completionDecisionSupport.decide(reservation, status, true);
+
+            // Then
+            assertThat(decision.isDeferred()).isTrue();
+            assertThat(decision.reason()).isEqualTo("too_early_completion");
+        }
+
+        @Test
+        @DisplayName("예상 완료 시각이 없으면 조기 완료 판정을 적용하지 않는다")
+        void shouldReturnCompleted_WhenExpectedCompletionTimeIsNull() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var status = buildWasherStatus("stop", "finish", isoUtc(nowKst));
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(30));
+            when(reservation.getExpectedCompletionTime()).thenReturn(null);
+            givenDetectedCompletion(nowKst);
+
+            // When
+            var decision = completionDecisionSupport.decide(reservation, status, true);
+
+            // Then
+            assertThat(decision.isCompleted()).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("완료 예정 시각 근처 정지 경로")
+    class StoppedNearCompletionPathTest {
+
+        @Test
+        @DisplayName("완료 예정 시각이 지난 정지 상태는 완료로 판정한다")
+        void shouldReturnCompleted_WhenStoppedAndCompletionTimePassed() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var completionTime = nowKst.minusMinutes(1);
+            var status = buildWasherStatus("stop", "spin", isoUtc(completionTime));
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(40));
+            when(reservation.getExpectedCompletionTime()).thenReturn(completionTime);
+            givenNoDetectedCompletion();
+
+            // When
+            var decision = completionDecisionSupport.decide(reservation, status, true);
+
+            // Then
+            assertThat(decision.isCompleted()).isTrue();
+            assertThat(decision.reason()).isEqualTo("stopped_near_completion");
+        }
+
+        @Test
+        @DisplayName("건조기도 완료 예정 시각이 지난 정지 상태는 완료로 판정한다")
+        void shouldReturnCompletedForDryer_WhenStoppedAndCompletionTimePassed() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var completionTime = nowKst.minusMinutes(1);
+            var status = buildDryerStatus("stop", "drying", isoUtc(completionTime));
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(40));
+            when(reservation.getExpectedCompletionTime()).thenReturn(completionTime);
+            givenNoDetectedCompletion();
+
+            // When
+            var decision = completionDecisionSupport.decide(reservation, status, false);
+
+            // Then
+            assertThat(decision.isCompleted()).isTrue();
+            assertThat(decision.reason()).isEqualTo("stopped_near_completion");
+        }
+
+        @Test
+        @DisplayName("사이클 도중 잠깐 과거로 보고된 완료 시각은 조기 완료 가드에 걸려 보류한다")
+        void shouldDefer_WhenStoppedMidCycleWithPastCompletionTime() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var reportedCompletionTime = nowKst.minusMinutes(1);
+            var status = buildWasherStatus("stop", "wash", isoUtc(reportedCompletionTime));
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(10));
+            when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.plusMinutes(50));
+            givenNoDetectedCompletion();
+
+            // When
+            var decision = completionDecisionSupport.decide(reservation, status, true);
+
+            // Then
+            assertThat(decision.isDeferred()).isTrue();
+            assertThat(decision.reason()).isEqualTo("too_early_completion");
+        }
+
+        @Test
+        @DisplayName("완료 예정 시각이 아직 오지 않았으면 완료 후보로 보지 않는다")
+        void shouldReturnNotCompleted_WhenCompletionTimeStillInFuture() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var status = buildWasherStatus("stop", "spin", isoUtc(nowKst.plusMinutes(3)));
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(40));
+            givenNoDetectedCompletion();
+
+            // When
+            var decision = completionDecisionSupport.decide(reservation, status, true);
+
+            // Then
+            assertThat(decision.isCompleted()).isFalse();
+            assertThat(decision.isDeferred()).isFalse();
+        }
+
+        @Test
+        @DisplayName("완료 예정 시각이 유예 범위를 벗어난 정지는 완료 후보로 보지 않는다")
+        void shouldReturnNotCompleted_WhenCompletionTimeOutsideGracePeriod() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var status = buildWasherStatus("stop", "wash", isoUtc(nowKst.plusMinutes(30)));
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(10));
+            givenNoDetectedCompletion();
+
+            // When
+            var decision = completionDecisionSupport.decide(reservation, status, true);
+
+            // Then
+            assertThat(decision.isCompleted()).isFalse();
+            assertThat(decision.isDeferred()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("완료 예정 시각 근처 정지 여부 판정")
+    class IsStoppedNearCompletionTest {
+
+        @Test
+        @DisplayName("완료 예정 시각이 유예 범위 안이면 근처 정지로 판정한다")
+        void shouldReturnTrue_WhenCompletionTimeWithinGracePeriod() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var status = buildWasherStatus("stop", "spin", isoUtc(nowKst.plusMinutes(3)));
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(40));
+
+            // When
+            var result = completionDecisionSupport.isStoppedNearCompletion(reservation, status, true);
+
+            // Then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("기기가 정지 상태가 아니면 근처 정지가 아니다")
+        void shouldReturnFalse_WhenMachineNotStopped() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var status = buildWasherStatus("run", "spin", isoUtc(nowKst.plusMinutes(3)));
+
+            // When
+            var result = completionDecisionSupport.isStoppedNearCompletion(reservation, status, true);
+
+            // Then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("완료 예정 시각이 유예 범위를 벗어나면 근처 정지가 아니다")
+        void shouldReturnFalse_WhenCompletionTimeOutsideGracePeriod() {
+            // Given
+            var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var status = buildWasherStatus("stop", "wash", isoUtc(nowKst.plusMinutes(30)));
+            when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(10));
+
+            // When
+            var result = completionDecisionSupport.isStoppedNearCompletion(reservation, status, true);
+
+            // Then
+            assertThat(result).isFalse();
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/smartthings/enums/MachineOperatingStateTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/enums/MachineOperatingStateTest.java
@@ -1,0 +1,102 @@
+package team.washer.server.v2.domain.smartthings.enums;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@DisplayName("MachineOperatingState 변환 및 판정")
+class MachineOperatingStateTest {
+
+    @Nested
+    @DisplayName("from 원시 문자열 변환")
+    class From {
+
+        @Test
+        @DisplayName("SmartThings가 내려주는 소문자 값을 대응하는 상수로 변환한다")
+        void 소문자_값을_변환한다() {
+            // Given & When & Then
+            assertThat(MachineOperatingState.from("run")).isEqualTo(MachineOperatingState.RUN);
+            assertThat(MachineOperatingState.from("pause")).isEqualTo(MachineOperatingState.PAUSE);
+            assertThat(MachineOperatingState.from("stop")).isEqualTo(MachineOperatingState.STOP);
+        }
+
+        @Test
+        @DisplayName("대소문자를 구분하지 않고 변환한다")
+        void 대소문자를_구분하지_않는다() {
+            // Given
+            final var rawValue = "RuN";
+
+            // When
+            final var result = MachineOperatingState.from(rawValue);
+
+            // Then
+            assertThat(result).isEqualTo(MachineOperatingState.RUN);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   ", "running", "unknownState"})
+        @DisplayName("값이 없거나 알 수 없는 값이면 UNKNOWN을 반환한다")
+        void 알_수_없는_값은_UNKNOWN이다(final String rawValue) {
+            // Given & When
+            final var result = MachineOperatingState.from(rawValue);
+
+            // Then
+            assertThat(result).isEqualTo(MachineOperatingState.UNKNOWN);
+        }
+    }
+
+    @Nested
+    @DisplayName("JSON 직렬화")
+    class Serialization {
+
+        private final ObjectMapper objectMapper = new ObjectMapper();
+
+        @Test
+        @DisplayName("SmartThings와 동일한 원시 소문자 값으로 직렬화한다")
+        void 소문자_값으로_직렬화한다() throws Exception {
+            // Given & When & Then
+            assertThat(objectMapper.writeValueAsString(MachineOperatingState.RUN)).isEqualTo("\"run\"");
+            assertThat(objectMapper.writeValueAsString(MachineOperatingState.PAUSE)).isEqualTo("\"pause\"");
+            assertThat(objectMapper.writeValueAsString(MachineOperatingState.STOP)).isEqualTo("\"stop\"");
+        }
+
+        @Test
+        @DisplayName("UNKNOWN은 상태를 알 수 없다는 뜻이므로 null로 직렬화한다")
+        void UNKNOWN은_null로_직렬화한다() throws Exception {
+            // Given & When
+            final var result = objectMapper.writeValueAsString(MachineOperatingState.UNKNOWN);
+
+            // Then
+            assertThat(result).isEqualTo("null");
+        }
+    }
+
+    @Nested
+    @DisplayName("isOperating 사이클 점유 판정")
+    class IsOperating {
+
+        @Test
+        @DisplayName("run과 pause는 사이클을 점유 중인 상태로 판정한다")
+        void run과_pause는_점유_중이다() {
+            // Given & When & Then
+            assertThat(MachineOperatingState.RUN.isOperating()).isTrue();
+            assertThat(MachineOperatingState.PAUSE.isOperating()).isTrue();
+        }
+
+        @Test
+        @DisplayName("stop과 UNKNOWN은 사이클을 점유하지 않은 상태로 판정한다")
+        void stop과_UNKNOWN은_점유_중이_아니다() {
+            // Given & When & Then
+            assertThat(MachineOperatingState.STOP.isOperating()).isFalse();
+            assertThat(MachineOperatingState.UNKNOWN.isOperating()).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
## 개요

"기기 사이클이 완료됐는가"를 판정하는 규칙이 코드 네 곳에 서로 다르게 구현되어 있어, 화면에 표시된 상태와 DB에 저장된 상태가 갈라지는 문제가 있었습니다. 완료 판정을 `ReservationCompletionDecisionSupport` 하나로 모으고, 완료 판정에도 디바운스를 적용하였습니다. 상세 분석은 `docs/analysis-reservation-state-transition.md`에 정리하였습니다.

## 본문

### 1. 완료 판정 통합

`ReservationCompletionDecisionSupport`를 추가하여 완료 판정의 단일 진입점으로 삼았습니다. `smartthings_completed`와 `stopped_near_completion` 두 경로가 이제 **같은 가드**(이전 사이클 신호 검사 · 조기 완료 검사)를 통과합니다. 기존에는 `stopped_near_completion` 경로가 가드를 통째로 우회하여, 사이클 도중 완료 시각이 잠깐 과거로 보고되면 즉시 완료가 확정되었습니다.

`QueryAllMachinesStatusServiceImpl`의 `getDisplayReservation`은 제거하였습니다. 목록 API는 완료를 따로 예측하지 않고 DB의 예약 상태만 반영합니다. 라이프사이클이 완료를 보류하는 동안 목록만 `AVAILABLE`로 바뀌어 예약 시도가 실패하던 현상이 구조적으로 불가능해집니다.

### 2. 완료 디바운스

`ReservationConstants.COMPLETION_CONFIRM_THRESHOLD`(연속 2회)를 추가하고 `Reservation.completionCount` 컬럼으로 추적합니다. SmartThings가 단 한 번 순간적으로 보고한 정지가 곧바로 완료로 굳어지지 않습니다.

`processRunningToCompleted`의 판정 순서를 **완료 → 전원 차단 → 완료 근처 정지 → 중단 → 일시정지 → 진행**으로 재배치하였습니다. 기존에는 완료 예정 시각이 유예 범위 안이면 매 폴링마다 `interruptionCount`가 0으로 리셋되어, 사용자가 전원을 꺼도 중단이 영영 확정되지 않았습니다. 이제 전원 차단(`isPoweredOff`)을 근처 정지 보류보다 먼저 평가하고, 근처 정지는 중단 카운터를 건드리지 않습니다.

### 3. 완료 예정 시각 상한 검증

`MAX_REASONABLE_CYCLE_MINUTES`(240분)를 `Reservation.start()`와 `updateExpectedCompletionTime()`의 **저장 시점**에 적용하였습니다. `updateExpectedCompletionTime()`은 갱신 여부를 `boolean`으로 반환하며, 거부 시 호출 측이 경고 로그를 남깁니다. 이로써 이상치를 저장해 두고 나중에 예외 처리하던 `hasSuspiciousExpectedCompletionTime` 우회로를 삭제하였습니다.

### 참고 사항

- `reservations` 테이블에 `completion_count` 컬럼이 추가됩니다. `ddl-auto: update`로 자동 반영되며 `interruption_count`와 동일한 패턴입니다.
- 목록 API가 완료를 예측하지 않으므로, 완료 직후 최대 60초간 남은 시간이 0분으로 표시됩니다. 화면과 DB의 불일치를 없애기 위해 감수한 지연입니다.
- 문서의 `2-5`~`2-8` 항목은 이번 변경과 독립적이므로 각각 후속 브랜치로 분리하여 진행합니다.

### 테스트

`ReservationCompletionDecisionSupportTest`와 `ReservationTest`를 신규 작성하였고, `ReservationLifecycleProcessorTest`를 판정 순서 중심으로 재작성하였습니다. 전원 차단과 근처 정지에 대한 회귀 테스트를 추가하였습니다. 전체 375개 테스트가 통과합니다.
