### PR TITLE
[reservation] 운영 시간 확인 추가 및 완료 잔여 상태 정리

### DIFF
--- a/docs/analysis-reservation-state-transition.md
+++ b/docs/analysis-reservation-state-transition.md
@@ -21,14 +21,20 @@ PR #102 범위의 항목은 해당 PR에 인라인 코멘트로 남겼다. 이 �
 
 | 브랜치 | 범위 | 상태 |
 |---|---|---|
-| `fix/reservation-completion-detection-unification` | 3장 1~3단계 (2-1 · 2-2 · 2-3 · 2-4) | 진행 중 |
-| 후속 브랜치 (2-5) | `ReservationTimeoutScheduler` 운영시간 체크 | 예정 |
-| 후속 브랜치 (2-6) | 강제정지 `ALREADY_STOPPED` 취소 조건 + 취소 알림 | 예정 |
-| 후속 브랜치 (2-7) | `complete()` 시 잔여 상태 정리 | 예정 |
-| 후속 브랜치 (2-8) | 활성 예약 선택 규칙 통일 | 예정 |
+| `fix/reservation-completion-detection-unification` | 3장 1~3단계 (2-1 · 2-2 · 2-3 · 2-4) | PR #103 |
+| `fix/reservation-lifecycle-residue` | 2-5 + 2-7 | 진행 중 |
+| `fix/force-stop-cancellation-notification` | 2-6 | 예정 |
+| `fix/active-reservation-selection` | 2-8 | 예정 |
 
-2-5 ~ 2-8은 코어 3단계와 서로 독립적이므로 **각각 별도 브랜치·PR로 진행한다.**
-리뷰 단위를 작게 유지하고, 코어 변경의 회귀 여부를 별건과 섞이지 않게 확인하기 위함이다.
+별건은 코어 3단계와 독립적이므로 분리하되, 규모에 맞춰 묶는다.
+
+- **2-5 + 2-7**: 각각 수 줄 규모이고 둘 다 reservation 도메인이라 하나로 묶는다.
+- **2-6**: `NotificationType`을 새로 만들어야 하고 관리자 기능의 동작 자체가 바뀌므로 단독으로 둔다.
+- **2-8**: 활성 예약 선택 규칙을 바꾸면 목록 API 표시가 달라져 회귀 확인 지점이 다르므로 단독으로 둔다.
+
+`fix/reservation-lifecycle-residue`는 2-7이 코어 브랜치에서 재작성한 `completeReservation`을
+건드리므로 `develop`이 아니라 **코어 브랜치 위에 쌓아 올린다.** 코어가 머지되면 base가
+`develop`으로 전환된다.
 
 ---
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/scheduler/ReservationTimeoutScheduler.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/scheduler/ReservationTimeoutScheduler.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.reservation.service.CancelOverdueReservationService;
+import team.washer.server.v2.global.thirdparty.smartthings.SmartThingsOperationTimePolicy;
 
 @Slf4j
 @Component
@@ -15,9 +16,21 @@ public class ReservationTimeoutScheduler {
     private static final long TIMEOUT_CHECK_INTERVAL = 60000;
 
     private final CancelOverdueReservationService cancelOverdueReservationService;
+    private final SmartThingsOperationTimePolicy operationTimePolicy;
 
+    /**
+     * RESERVED 예약의 타임아웃을 확인한다.
+     *
+     * <p>
+     * 운영 시간 외에는 라이프사이클 스케줄러가 멈춰 있어 RESERVED → RUNNING 전환이 일어나지 않는다. 그 시간대에 타임아웃만 계속
+     * 돌면 예약이 자동 시작 기회 없이 취소되고 패널티까지 부과되므로, 다른 스케줄러와 동일하게 운영 시간을 확인한다.
+     */
     @Scheduled(fixedDelay = TIMEOUT_CHECK_INTERVAL)
     public void checkReservationTimeouts() {
+        if (!operationTimePolicy.isOperationAllowed()) {
+            log.debug("reservation timeout check skipped outside operation hours");
+            return;
+        }
         try {
             cancelOverdueReservationService.execute();
         } catch (Exception e) {

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
@@ -261,12 +261,18 @@ public class ReservationLifecycleProcessor {
         }
     }
 
+    /**
+     * 예약을 완료 처리한다. 중단·일시정지 경로와 마찬가지로 디바운스 카운터와 일시정지 추적을 함께 정리하여, 완료된 예약에 진행 중에만 의미가
+     * 있는 값이 남지 않도록 한다.
+     */
     private void completeReservation(Reservation reservation,
             Machine machine,
             LocalDateTime completionTime,
             String reason) {
         reservation.complete();
         reservation.clearCompletionCount();
+        reservation.clearInterruptionCount();
+        reservation.clearPausedAt();
         machine.markAsAvailable();
         reservationRepository.save(reservation);
         machineRepository.save(machine);

--- a/src/test/java/team/washer/server/v2/domain/reservation/scheduler/ReservationTimeoutSchedulerTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/scheduler/ReservationTimeoutSchedulerTest.java
@@ -1,0 +1,80 @@
+package team.washer.server.v2.domain.reservation.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import team.washer.server.v2.domain.reservation.service.CancelOverdueReservationService;
+import team.washer.server.v2.global.thirdparty.smartthings.SmartThingsOperationTimePolicy;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReservationTimeoutScheduler 예약 타임아웃 스케줄러")
+class ReservationTimeoutSchedulerTest {
+
+    @InjectMocks
+    private ReservationTimeoutScheduler reservationTimeoutScheduler;
+
+    @Mock
+    private CancelOverdueReservationService cancelOverdueReservationService;
+
+    @Mock
+    private SmartThingsOperationTimePolicy operationTimePolicy;
+
+    @Nested
+    @DisplayName("운영 시간 확인")
+    class OperationTimeTest {
+
+        @Test
+        @DisplayName("운영 시간 내이면 타임아웃 취소를 수행한다")
+        void shouldExecute_WhenWithinOperationHours() {
+            // Given
+            when(operationTimePolicy.isOperationAllowed()).thenReturn(true);
+
+            // When
+            reservationTimeoutScheduler.checkReservationTimeouts();
+
+            // Then
+            verify(cancelOverdueReservationService, times(1)).execute();
+        }
+
+        @Test
+        @DisplayName("운영 시간 외이면 타임아웃 취소를 수행하지 않는다")
+        void shouldSkip_WhenOutsideOperationHours() {
+            // Given
+            when(operationTimePolicy.isOperationAllowed()).thenReturn(false);
+
+            // When
+            reservationTimeoutScheduler.checkReservationTimeouts();
+
+            // Then
+            verify(cancelOverdueReservationService, never()).execute();
+        }
+    }
+
+    @Nested
+    @DisplayName("예외 처리")
+    class ExceptionHandlingTest {
+
+        @Test
+        @DisplayName("타임아웃 취소가 실패해도 예외를 전파하지 않는다")
+        void shouldNotPropagate_WhenExecutionFails() {
+            // Given
+            when(operationTimePolicy.isOperationAllowed()).thenReturn(true);
+            doThrow(new IllegalStateException("타임아웃 취소 실패")).when(cancelOverdueReservationService).execute();
+
+            // When & Then
+            assertThatCode(() -> reservationTimeoutScheduler.checkReservationTimeouts()).doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
@@ -234,6 +234,8 @@ class ReservationLifecycleProcessorTest {
             verify(reservation, times(1)).incrementCompletionCount();
             verify(reservation, times(1)).complete();
             verify(reservation, times(1)).clearCompletionCount();
+            verify(reservation, times(1)).clearInterruptionCount();
+            verify(reservation, times(1)).clearPausedAt();
             verify(machine, times(1)).markAsAvailable();
             verify(reservationRepository, times(1)).save(reservation);
             verify(machineRepository, times(1)).save(machine);


### PR DESCRIPTION
## 개요

`docs/analysis-reservation-state-transition.md`에 정리한 별건 항목 중 `2-5`와 `2-7`을 처리하였습니다. 운영 시간 외에 예약이 자동 시작 기회 없이 취소되며 패널티까지 부과되던 문제와, 완료된 예약에 진행 중에만 의미가 있는 값이 남던 문제입니다.

> **이 PR은 #103 위에 쌓은 스택 PR입니다.** base가 `develop`이 아니라 `fix/reservation-completion-detection-unification`입니다. `2-7`이 #103에서 재작성한 `completeReservation`을 수정하기 때문입니다. #103이 머지되면 base가 자동으로 `develop`으로 전환됩니다. **#103을 먼저 리뷰해 주세요.**

## 본문

### 2-5. 예약 타임아웃 스케줄러에 운영 시간 확인 추가

`ReservationTimeoutScheduler`만 `operationTimePolicy` 확인이 없었습니다.

| 스케줄러 | 주기 | 운영 시간 확인 |
|---|---|---|
| `ReservationLifecycleScheduler` | 30초 | 기존에도 있음 |
| `IdleMachineShutdownScheduler` | 60초 | 기존에도 있음 |
| `ReservationTimeoutScheduler` | 60초 | **이번에 추가** |

운영 시간 외에는 라이프사이클 스케줄러가 멈춰 있어 `RESERVED` → `RUNNING` 전환이 일어나지 않습니다. 그런데 타임아웃 스케줄러는 60초마다 계속 돌면서 `RESERVED` 예약을 취소하고 `OverdueReservationProcessor`를 통해 패널티(쿨다운 · 취소 횟수 · 48시간 블록)를 부과하였습니다. 결과적으로 그 시간대에 남아 있던 예약은 자동 시작 기회 없이 취소와 패널티만 받게 되어, 다른 두 스케줄러와 동일한 가드를 추가하였습니다.

### 2-7. 예약 완료 시 잔여 상태 정리

`completeReservation`이 `reservation.complete()`만 호출하여, `pausedAt`과 `interruptionCount`가 `COMPLETED` 예약에 그대로 남아 관리자 이력에 노출되었습니다.

중단 경로와 일시정지 타임아웃 경로는 이미 `clearInterruptionCount` / `clearPausedAt`을 호출하고 있었고 완료 경로만 빠져 있었습니다. 세 경로가 동일하게 잔여 상태를 정리하도록 맞추었습니다.

### 테스트

- `ReservationTimeoutSchedulerTest`를 신규 작성하였습니다. 운영 시간 내 수행 · 운영 시간 외 건너뜀 · 예외 비전파 세 가지를 검증합니다.
- `ReservationLifecycleProcessorTest`의 완료 확정 테스트에 `clearInterruptionCount`와 `clearPausedAt` 호출 검증을 추가하였습니다.
- 전체 378개 테스트가 통과합니다.

### 참고 사항

`2-6`(강제정지 취소 조건 및 취소 알림)과 `2-8`(활성 예약 선택 규칙 통일)은 각각 별도 브랜치로 진행합니다. 분할 근거는 `docs/analysis-reservation-state-transition.md`의 「작업 분할」 절에 갱신하였습니다.
