### PR TITLE
[machine] 강제 정지 취소 조건 수정 및 취소 알림 추가

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/ForceStopMachineServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/ForceStopMachineServiceImpl.java
@@ -18,6 +18,7 @@ import team.washer.server.v2.domain.machine.enums.MachineStatus;
 import team.washer.server.v2.domain.machine.enums.MachineType;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.machine.service.ForceStopMachineService;
+import team.washer.server.v2.domain.notification.support.ReservationNotificationSupport;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
@@ -35,6 +36,7 @@ public class ForceStopMachineServiceImpl implements ForceStopMachineService {
     private final ReservationRepository reservationRepository;
     private final DeviceStatusQuerySupport deviceStatusQuerySupport;
     private final SendDeviceCommandService sendDeviceCommandService;
+    private final ReservationNotificationSupport reservationNotificationSupport;
     private final TransactionTemplate transactionTemplate;
 
     @Override
@@ -112,15 +114,21 @@ public class ForceStopMachineServiceImpl implements ForceStopMachineService {
                 .or(() -> activeReservations.stream().filter(Reservation::isReserved).findFirst());
     }
 
+    /**
+     * 정지 명령을 실제로 전송한 경우에만 활성 예약을 취소하고, 취소된 사용자에게 알림을 보낸다.
+     *
+     * <p>
+     * {@code ALREADY_STOPPED}는 단발 조회로 판정하므로 라이프사이클의 디바운스를 거치지 않는다. 사이클 단계 전환 중
+     * 순간적으로 보고된 정지일 때 관리자가 버튼을 누르면 정상 진행 중인 예약이 취소되므로, 이 경우에는 취소하지 않는다. 기기가 이미 멈춘
+     * 채로 남아 있는 예약은 라이프사이클의 중단 확정이나 관리자 예약 취소가 처리한다.
+     */
     private Long cancelActiveReservationIfNeeded(Reservation reservation, ForceStopResult forceStopResult) {
-        if (reservation == null) {
-            return null;
-        }
-        if (forceStopResult != ForceStopResult.STOPPED && !reservation.isRunning()) {
+        if (reservation == null || forceStopResult != ForceStopResult.STOPPED) {
             return null;
         }
         reservation.cancel();
         reservationRepository.save(reservation);
+        reservationNotificationSupport.sendForceStop(reservation.getUser(), reservation.getMachine());
         return reservation.getId();
     }
 

--- a/src/main/java/team/washer/server/v2/domain/notification/entity/Notification.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/entity/Notification.java
@@ -112,6 +112,22 @@ public class Notification extends BaseEntity {
     }
 
     /**
+     * 관리자 강제 정지에 의한 예약 취소 알림을 생성합니다.
+     *
+     * @param user
+     *            알림 수신 사용자
+     * @param machine
+     *            대상 기기
+     * @return 생성된 강제 정지 알림
+     */
+    public static Notification createForceStopNotification(User user, Machine machine) {
+        String message = NotificationType.FORCE_STOPPED.formatMessage(machine.getName(), machine.getType());
+
+        return Notification.builder().user(user).machine(machine).type(NotificationType.FORCE_STOPPED).message(message)
+                .isRead(false).build();
+    }
+
+    /**
      * 일시정지 초과 알림을 생성합니다.
      *
      * @param user

--- a/src/main/java/team/washer/server/v2/domain/notification/enums/NotificationType.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/enums/NotificationType.java
@@ -24,7 +24,9 @@ public enum NotificationType {
                                                                     "예약 차단 알림",
                                                                     "48시간 내 예약 취소가 누적되어 해당 호실의 예약이 48시간 동안 제한됩니다."), CANCELLATION_BLOCK_EXTENDED(
                                                                             "예약 차단 연장 알림",
-                                                                            "관리자에 의해 예약 차단 기간이 연장되었습니다. {expiryAt}까지 해당 호실의 예약이 제한됩니다.");
+                                                                            "관리자에 의해 예약 차단 기간이 연장되었습니다. {expiryAt}까지 해당 호실의 예약이 제한됩니다."), FORCE_STOPPED(
+                                                                                    "강제 정지 알림",
+                                                                                    "관리자에 의해 {machineName}의 {action} 정지되어 예약이 패널티 없이 취소되었습니다.");
 
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
     private static final DateTimeFormatter EXPIRY_FORMATTER = DateTimeFormatter.ofPattern("MM월 dd일 HH시 mm분");

--- a/src/main/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupport.java
@@ -46,6 +46,15 @@ public class ReservationNotificationSupport {
     }
 
     /**
+     * 관리자 강제 정지에 의한 예약 취소 알림을 전송한다.
+     */
+    @Transactional
+    public void sendForceStop(User user, Machine machine) {
+        var notification = Notification.createForceStopNotification(user, machine);
+        persistAndSend(user, notification, machine.getType().getDescription() + " 강제 정지 알림");
+    }
+
+    /**
      * 일시정지 초과 알림을 전송한다.
      */
     @Transactional

--- a/src/test/java/team/washer/server/v2/domain/machine/service/ForceStopMachineServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/ForceStopMachineServiceTest.java
@@ -31,6 +31,7 @@ import team.washer.server.v2.domain.machine.enums.MachineType;
 import team.washer.server.v2.domain.machine.enums.Position;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.machine.service.impl.ForceStopMachineServiceImpl;
+import team.washer.server.v2.domain.notification.support.ReservationNotificationSupport;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
@@ -63,6 +64,9 @@ class ForceStopMachineServiceTest {
 
     @Mock
     private SendDeviceCommandService sendDeviceCommandService;
+
+    @Mock
+    private ReservationNotificationSupport reservationNotificationSupport;
 
     @Mock
     private TransactionTemplate transactionTemplate;
@@ -169,6 +173,45 @@ class ForceStopMachineServiceTest {
                 assertThat(command.arguments()).containsExactly("stop");
                 then(reservationRepository).should(times(1)).save(reservation);
                 then(machineRepository).should(times(1)).save(machine);
+                then(reservationNotificationSupport).should(times(1)).sendForceStop(reservation.getUser(), machine);
+            }
+        }
+
+        @Nested
+        @DisplayName("진행 중 예약이 있으나 이미 정지된 기기이면")
+        class Context_with_running_reservation_and_already_stopped_machine {
+
+            @Test
+            @DisplayName("순간 정지를 강제 정지로 오인하지 않도록 예약을 취소하지 않고 알림도 보내지 않는다")
+            void it_keeps_running_reservation_without_cancellation() {
+                // Given
+                var machineId = 1L;
+                var machine = createMachine(MachineType.WASHER, MachineStatus.NORMAL, MachineAvailability.IN_USE);
+                var reservation = createReservation(machine, ReservationStatus.RUNNING);
+                var status = washerStatus("stop");
+                setId(machine, machineId);
+                setId(reservation, 10L);
+
+                given(machineRepository.findById(machineId)).willReturn(Optional.of(machine));
+                given(machineRepository.findByIdForUpdate(machineId)).willReturn(Optional.of(machine));
+                given(deviceStatusQuerySupport.queryDeviceStatus("device-1")).willReturn(status);
+                given(reservationRepository.findFirstActiveReservationByMachineId(machineId,
+                        List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING)))
+                        .willReturn(List.of(reservation));
+                given(machineRepository.save(any(Machine.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+                // When
+                var result = forceStopMachineService.execute(machineId);
+
+                // Then
+                assertThat(result.forceStopResult()).isEqualTo(ForceStopResult.ALREADY_STOPPED);
+                assertThat(result.cancelledReservationId()).isNull();
+                assertThat(result.reservationCancelled()).isFalse();
+                assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.RUNNING);
+                assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.IN_USE);
+                then(sendDeviceCommandService).shouldHaveNoInteractions();
+                then(reservationRepository).should(never()).save(any(Reservation.class));
+                then(reservationNotificationSupport).shouldHaveNoInteractions();
             }
         }
 
@@ -278,6 +321,7 @@ class ForceStopMachineServiceTest {
                 assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.RESERVED);
                 then(sendDeviceCommandService).shouldHaveNoInteractions();
                 then(reservationRepository).should(never()).save(any(Reservation.class));
+                then(reservationNotificationSupport).shouldHaveNoInteractions();
             }
         }
 

--- a/src/test/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupportTest.java
@@ -159,6 +159,32 @@ class ReservationNotificationSupportTest {
     }
 
     @Nested
+    @DisplayName("강제 정지 알림 메시지는")
+    class Describe_force_stop_notification_message {
+
+        @ParameterizedTest
+        @EnumSource(MachineType.class)
+        @DisplayName("관리자 강제 정지로 예약이 취소되었음을 알려야 한다")
+        void it_notifies_cancellation_by_admin_force_stop(final MachineType machineType) {
+            // Given
+            User user = createUser();
+            Machine machine = createMachine(machineType);
+            given(notificationRepository.save(any(Notification.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+            given(notificationRepository.countByUser(user)).willReturn(1L);
+
+            // When
+            reservationNotificationSupport.sendForceStop(user, machine);
+
+            // Then
+            final String expectedBody = "관리자에 의해 " + machine.getName() + "의 " + machineType.getActionNoun()
+                    + " 정지되어 예약이 패널티 없이 취소되었습니다.";
+            then(fcmNotificationSupport).should(times(1))
+                    .send(user, machineType.getDescription() + " 강제 정지 알림", expectedBody);
+        }
+    }
+
+    @Nested
     @DisplayName("FCM 전송 시점은")
     class Describe_fcm_send_timing {
 


### PR DESCRIPTION
## 개요

관리자 강제 정지에서 정상 진행 중인 예약이 취소될 수 있던 문제와, 취소된 사용자에게 아무 알림도 가지 않던 문제를 함께 수정하였습니다. `docs/analysis-reservation-state-transition.md`의 `2-6` 항목입니다.

base가 `develop`이며 #103 · #104와 겹치는 파일이 없으므로 독립적으로 리뷰하고 머지할 수 있습니다.

## 본문

### (a) 취소 조건 수정

`cancelActiveReservationIfNeeded`의 조건이 `forceStopResult != STOPPED && !reservation.isRunning()`이었습니다. 뒤집어 보면 `ALREADY_STOPPED`와 `RUNNING`이 겹치는 조합에서 취소가 실행됩니다.

| `forceStopResult` | 예약 상태 | 기존 | 변경 후 |
|---|---|---|---|
| `STOPPED` | `RUNNING` | 취소 | 취소 |
| `STOPPED` | `RESERVED` | 취소 | 취소 |
| `ALREADY_STOPPED` | `RUNNING` | **취소** | 취소하지 않음 |
| `ALREADY_STOPPED` | `RESERVED` | 취소하지 않음 | 취소하지 않음 |

`ALREADY_STOPPED` 판정은 `forceStop`에서 단발 조회로 이루어지므로 라이프사이클의 디바운스를 거치지 않습니다. 사이클 단계 전환 중 순간적으로 `stop`이 보고된 시점에 관리자가 버튼을 누르면 정상 진행 중이던 예약이 취소되었습니다.

정지 명령을 실제로 전송한 경우(`STOPPED`)에만 취소하도록 좁혔습니다. 기기가 이미 멈춘 채 남아 있는 예약은 라이프사이클의 중단 확정이나 `AdminCancelReservationService`가 처리하므로 강제 정지가 떠안을 책임이 아닙니다.

### (b) 취소 알림 추가

기존에는 강제 정지로 취소된 사용자가 목록에서 예약이 사라진 것으로만 알 수 있었습니다.

| 취소 경로 | 알림 |
|---|---|
| 기기 중단 확정 | `sendInterruption` |
| 일시정지 타임아웃 | `sendPauseTimeout` |
| `RESERVED` 타임아웃 | `sendAutoCancellation` |
| 관리자 강제 정지 | **`sendForceStop` (이번에 추가)** |

`NotificationType.FORCE_STOPPED` → `Notification.createForceStopNotification` → `ReservationNotificationSupport.sendForceStop` 경로를 추가하고 취소 지점에서 호출합니다. 트랜잭션 안에서 호출하므로 다른 알림과 동일하게 커밋 이후에 FCM이 전송됩니다.

전송되는 문구는 다음과 같습니다.

> 관리자에 의해 W-2F-L1의 세탁이 정지되어 예약이 패널티 없이 취소되었습니다.

### 테스트

- `ALREADY_STOPPED`와 `RUNNING`이 겹치는 조합에서 예약이 유지되고 알림도 나가지 않는 회귀 테스트를 추가하였습니다.
- 정상 취소 시 `sendForceStop` 호출을 검증하고, `RESERVED` + `ALREADY_STOPPED` 케이스에는 알림 미전송 검증을 덧붙였습니다.
- `ReservationNotificationSupportTest`에 세탁기 · 건조기 문구 검증을 `@ParameterizedTest`로 추가하였습니다.
- 전체 359개 테스트가 통과합니다.

### 참고 사항

리뷰 시 함께 판단이 필요한 인접 문제 두 가지를 남깁니다. 둘 다 이번 범위가 아니라 수정하지 않았습니다.

- `AdminCancelReservationServiceImpl` 역시 취소 알림을 보내지 않습니다. `2-6`은 강제 정지만 다루고 있어 건드리지 않았습니다.
- `Notification.type` 컬럼이 `length = 20`인데 기존 `CANCELLATION_BLOCK_EXTENDED`가 27자로 이미 초과합니다. 이번에 추가한 `FORCE_STOPPED`는 13자라 영향이 없습니다.
