### PR TITLE
[reservation] 활성 예약 선택 규칙 통일

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/ForceStopMachineServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/ForceStopMachineServiceImpl.java
@@ -21,6 +21,7 @@ import team.washer.server.v2.domain.machine.service.ForceStopMachineService;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.reservation.util.ActiveReservationSelector;
 import team.washer.server.v2.domain.smartthings.dto.request.SmartThingsCommandReqDto;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.domain.smartthings.service.SendDeviceCommandService;
@@ -106,10 +107,9 @@ public class ForceStopMachineServiceImpl implements ForceStopMachineService {
     }
 
     private Optional<Reservation> findActiveReservationWithRunningPriority(Long machineId) {
-        final var activeReservations = reservationRepository.findFirstActiveReservationByMachineId(machineId,
-                List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING));
-        return activeReservations.stream().filter(Reservation::isRunning).findFirst()
-                .or(() -> activeReservations.stream().filter(Reservation::isReserved).findFirst());
+        return ActiveReservationSelector
+                .selectPrimary(reservationRepository.findFirstActiveReservationByMachineId(machineId,
+                        List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING)));
     }
 
     private Long cancelActiveReservationIfNeeded(Reservation reservation, ForceStopResult forceStopResult) {

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/ReservationRepository.java
@@ -13,6 +13,7 @@ import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.custom.ReservationRepositoryCustom;
+import team.washer.server.v2.domain.reservation.util.ActiveReservationSelector;
 import team.washer.server.v2.domain.user.entity.User;
 
 @Repository
@@ -52,9 +53,12 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
     List<Reservation> findFirstActiveReservationByMachineId(@Param("machineId") Long machineId,
             @Param("statuses") List<ReservationStatus> statuses);
 
+    /**
+     * 기기의 대표 활성 예약을 조회한다. 선택 규칙은 {@link ActiveReservationSelector}가 정의한다.
+     */
     default Optional<Reservation> findActiveReservationByMachineId(Long machineId) {
-        return findFirstActiveReservationByMachineId(machineId,
-                List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING)).stream().findFirst();
+        return ActiveReservationSelector.selectPrimary(findFirstActiveReservationByMachineId(machineId,
+                List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING)));
     }
 
     @Query("SELECT r FROM Reservation r WHERE r.status = :status AND r.startTime < :threshold")

--- a/src/main/java/team/washer/server/v2/domain/reservation/util/ActiveReservationSelector.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/util/ActiveReservationSelector.java
@@ -1,0 +1,38 @@
+package team.washer.server.v2.domain.reservation.util;
+
+import java.util.List;
+import java.util.Optional;
+
+import team.washer.server.v2.domain.reservation.entity.Reservation;
+
+/**
+ * 하나의 기기에 걸린 활성 예약 중 대표 예약 하나를 고르는 규칙.
+ *
+ * <p>
+ * RUNNING을 RESERVED보다 우선한다. 상태 드리프트로 두 상태가 공존할 때 나중에 생성된 RESERVED가 실제로 돌고 있는
+ * RUNNING을 가리면, 실제로는 사용 중인 기기가 예약 가능한 것처럼 표시되기 때문이다. 같은 상태 안에서는 넘겨받은 순서(조회 시점의
+ * 최근 생성 순)를 그대로 유지한다.
+ *
+ * <p>
+ * 목록 API와 강제 정지가 서로 다른 규칙을 쓰던 것을 이 한 곳으로 모았다.
+ */
+public final class ActiveReservationSelector {
+
+    private ActiveReservationSelector() {
+    }
+
+    /**
+     * 활성 예약 목록에서 대표 예약을 고른다.
+     *
+     * @param activeReservations
+     *            RESERVED · RUNNING 상태의 예약 목록. 최근 생성 순으로 정렬되어 있다고 가정한다
+     * @return 대표 예약. 활성 예약이 없으면 {@link Optional#empty()}
+     */
+    public static Optional<Reservation> selectPrimary(List<Reservation> activeReservations) {
+        if (activeReservations == null || activeReservations.isEmpty()) {
+            return Optional.empty();
+        }
+        return activeReservations.stream().filter(Reservation::isRunning).findFirst()
+                .or(() -> activeReservations.stream().filter(Reservation::isReserved).findFirst());
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/reservation/util/ActiveReservationSelectorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/util/ActiveReservationSelectorTest.java
@@ -1,0 +1,107 @@
+package team.washer.server.v2.domain.reservation.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+
+@DisplayName("ActiveReservationSelector 활성 예약 선택 규칙")
+class ActiveReservationSelectorTest {
+
+    private Reservation createReservation(ReservationStatus status) {
+        return Reservation.builder().reservedAt(LocalDateTime.now()).status(status).build();
+    }
+
+    @Nested
+    @DisplayName("RUNNING 우선 규칙")
+    class RunningPriorityTest {
+
+        @Test
+        @DisplayName("RUNNING과 RESERVED가 공존하면 RUNNING을 고른다")
+        void shouldSelectRunning_WhenBothStatusesExist() {
+            // Given
+            var reserved = createReservation(ReservationStatus.RESERVED);
+            var running = createReservation(ReservationStatus.RUNNING);
+
+            // When
+            var selected = ActiveReservationSelector.selectPrimary(List.of(reserved, running));
+
+            // Then
+            assertThat(selected).containsSame(running);
+        }
+
+        @Test
+        @DisplayName("최근 생성된 RESERVED가 앞에 와도 RUNNING을 고른다")
+        void shouldSelectRunning_WhenReservedIsMoreRecent() {
+            // Given
+            var recentReserved = createReservation(ReservationStatus.RESERVED);
+            var olderRunning = createReservation(ReservationStatus.RUNNING);
+
+            // When
+            var selected = ActiveReservationSelector.selectPrimary(List.of(recentReserved, olderRunning));
+
+            // Then
+            assertThat(selected).containsSame(olderRunning);
+        }
+
+        @Test
+        @DisplayName("RESERVED만 있으면 첫 번째 RESERVED를 고른다")
+        void shouldSelectFirstReserved_WhenOnlyReservedExists() {
+            // Given
+            var first = createReservation(ReservationStatus.RESERVED);
+            var second = createReservation(ReservationStatus.RESERVED);
+
+            // When
+            var selected = ActiveReservationSelector.selectPrimary(List.of(first, second));
+
+            // Then
+            assertThat(selected).containsSame(first);
+        }
+
+        @Test
+        @DisplayName("RUNNING이 여럿이면 첫 번째 RUNNING을 고른다")
+        void shouldSelectFirstRunning_WhenMultipleRunningExist() {
+            // Given
+            var first = createReservation(ReservationStatus.RUNNING);
+            var second = createReservation(ReservationStatus.RUNNING);
+
+            // When
+            var selected = ActiveReservationSelector.selectPrimary(List.of(first, second));
+
+            // Then
+            assertThat(selected).containsSame(first);
+        }
+    }
+
+    @Nested
+    @DisplayName("활성 예약이 없는 경우")
+    class EmptyInputTest {
+
+        @Test
+        @DisplayName("빈 목록이면 결과가 없다")
+        void shouldReturnEmpty_WhenListIsEmpty() {
+            // When
+            var selected = ActiveReservationSelector.selectPrimary(List.of());
+
+            // Then
+            assertThat(selected).isEmpty();
+        }
+
+        @Test
+        @DisplayName("null이면 결과가 없다")
+        void shouldReturnEmpty_WhenListIsNull() {
+            // When
+            var selected = ActiveReservationSelector.selectPrimary(null);
+
+            // Then
+            assertThat(selected).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## 개요

기기 하나에 걸린 활성 예약 중 어느 것을 대표로 볼지에 대한 규칙이 두 군데에 서로 다르게 구현되어 있었습니다. 이 규칙을 `ActiveReservationSelector` 한 곳으로 모았습니다. `docs/analysis-reservation-state-transition.md`의 `2-8` 항목입니다.

base가 `develop`이며 #103 · #104 · #105와 겹치는 변경 지점이 없으므로 독립적으로 리뷰하고 머지할 수 있습니다.

## 본문

### 문제

| 위치 | 선택 규칙 |
|---|---|
| `ForceStopMachineServiceImpl.findActiveReservationWithRunningPriority` | `RUNNING` 우선, 없으면 `RESERVED` |
| `ReservationRepository.findActiveReservationByMachineId` | `createdAt DESC` 첫 번째 |

목록 API(`QueryAllMachinesStatusServiceImpl`)는 후자를 사용합니다. 따라서 상태 드리프트로 `RUNNING`과 `RESERVED`가 한 기기에 공존하면, 나중에 생성된 `RESERVED`가 실제로 돌고 있는 `RUNNING`을 가립니다. 그 결과 실제로는 `IN_USE`인 기기가 목록에 `RESERVED`로 표시됩니다.

`computeAvailability`가 예약 상태를 그대로 가용성으로 옮기기 때문에, 잘못 고른 예약 하나가 곧바로 잘못된 가용성으로 이어집니다.

### 변경

`ActiveReservationSelector.selectPrimary`를 추가하고 두 호출 지점이 모두 이것을 거치도록 하였습니다.

- `RUNNING`을 `RESERVED`보다 우선합니다.
- 같은 상태 안에서는 넘겨받은 순서(조회 시점의 `createdAt DESC`)를 유지합니다.
- 활성 예약이 없으면 `Optional.empty()`를 반환합니다.

강제 정지의 기존 동작이 두 규칙 중 옳은 쪽이었으므로, 그 규칙을 공통 규칙으로 삼고 목록 API 경로를 여기에 맞추었습니다. `ForceStopMachineServiceImpl`의 동작은 그대로이며 중복 구현만 제거되었습니다.

### 선택 규칙을 정적 유틸로 둔 이유

규칙을 JPQL의 `ORDER BY`에 넣는 방법도 있었으나 두 가지 이유로 택하지 않았습니다.

- 이 프로젝트에는 컨텍스트를 띄우는 통합 테스트가 없어, `@Query` 변경은 애플리케이션 기동 시점까지 검증되지 않습니다.
- 리포지토리의 `default` 메서드에 규칙을 두면 Mockito가 목 객체에서 기본 구현을 건너뛰므로 단위 테스트로 규칙 자체를 검증할 수 없습니다.

정적 유틸로 분리하면 규칙을 직접 단위 테스트할 수 있고, 기존 서비스 테스트의 스텁을 바꾸지 않아도 됩니다.

### 테스트

`ActiveReservationSelectorTest`를 신규 작성하였습니다. `RUNNING` 우선 · 최근 `RESERVED`가 앞에 와도 `RUNNING` 선택 · 동일 상태 내 순서 유지 · 빈 목록 · `null` 입력을 검증합니다. 전체 362개 테스트가 통과합니다.

### 참고 사항

`findFirstActiveReservationByMachineId`는 이름과 달리 `List`를 반환합니다. 이름을 고치면 진행 중인 #105의 테스트가 같은 메서드를 참조하고 있어 머지 이후 컴파일이 깨지므로, 이번에는 손대지 않았습니다.
