### PR TITLE
[machine] 기기 동작 상태 판정을 enum으로 통일

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/machine/dto/response/ForceStopMachineResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/dto/response/ForceStopMachineResDto.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import team.washer.server.v2.domain.machine.enums.ForceStopResult;
 import team.washer.server.v2.domain.machine.enums.MachineAvailability;
 import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 
 @Schema(description = "기기 강제 정지 응답 DTO")
 public record ForceStopMachineResDto(@Schema(description = "기기 ID", example = "1") Long machineId,
@@ -11,7 +12,7 @@ public record ForceStopMachineResDto(@Schema(description = "기기 ID", example 
         @Schema(description = "기기 타입", example = "WASHER") MachineType machineType,
         @Schema(description = "SmartThings Device ID", example = "device-abc") String deviceId,
         @Schema(description = "SmartThings 강제 정지 처리 결과", example = "STOPPED") ForceStopResult forceStopResult,
-        @Schema(description = "처리 전 기기 동작 상태", example = "run") String previousMachineState,
+        @Schema(description = "처리 전 기기 동작 상태", example = "run") MachineOperatingState previousMachineState,
         @Schema(description = "취소된 활성 예약 ID", example = "1") Long cancelledReservationId,
         @Schema(description = "활성 예약 취소 여부", example = "true") boolean reservationCancelled,
         @Schema(description = "변경된 기기 사용 가능 상태", example = "AVAILABLE") MachineAvailability availability) {

--- a/src/main/java/team/washer/server/v2/domain/machine/dto/response/MachineStatusResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/dto/response/MachineStatusResDto.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import team.washer.server.v2.domain.machine.enums.MachineAvailability;
 import team.washer.server.v2.domain.machine.enums.MachineStatus;
 import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 
 @Schema(description = "기기 상태 응답")
 public record MachineStatusResDto(@Schema(description = "기기 ID", example = "1") Long machineId,
@@ -18,7 +19,7 @@ public record MachineStatusResDto(@Schema(description = "기기 ID", example = "
 
         @Schema(description = "사용 가능 여부", example = "AVAILABLE") MachineAvailability availability,
 
-        @Schema(description = "작동 상태", example = "running") String operatingState,
+        @Schema(description = "작동 상태", example = "run") MachineOperatingState operatingState,
 
         @Schema(description = "작업 상태", example = "washing") String jobState,
 

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/ForceStopMachineServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/ForceStopMachineServiceImpl.java
@@ -23,6 +23,7 @@ import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.smartthings.dto.request.SmartThingsCommandReqDto;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 import team.washer.server.v2.domain.smartthings.service.SendDeviceCommandService;
 import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
 
@@ -42,7 +43,9 @@ public class ForceStopMachineServiceImpl implements ForceStopMachineService {
         final var machine = machineRepository.findById(machineId)
                 .orElseThrow(() -> new ExpectedException("기기를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
         final var status = deviceStatusQuerySupport.queryDeviceStatus(machine.getDeviceId());
-        final var previousMachineState = extractMachineState(machine, status);
+        final var previousMachineState = status == null
+                ? MachineOperatingState.UNKNOWN
+                : status.getOperatingState(machine.isWasher());
         final var forceStopResult = forceStop(machine, status, previousMachineState);
         final var updateResult = updateMachineAndReservation(machineId, forceStopResult);
 
@@ -63,17 +66,19 @@ public class ForceStopMachineServiceImpl implements ForceStopMachineService {
                 updateResult.availability());
     }
 
-    private ForceStopResult forceStop(Machine machine, SmartThingsDeviceStatusResDto status, String machineState) {
+    private ForceStopResult forceStop(Machine machine,
+            SmartThingsDeviceStatusResDto status,
+            MachineOperatingState machineState) {
         if (status == null) {
             throw new ExpectedException("기기 상태를 확인할 수 없습니다", HttpStatus.BAD_GATEWAY);
         }
         if (!machine.isWasher() && !machine.isDryer()) {
             throw new ExpectedException("지원하지 않는 기기 유형입니다", HttpStatus.BAD_REQUEST);
         }
-        if ("off".equalsIgnoreCase(status.getSwitchStatus()) || "stop".equalsIgnoreCase(machineState)) {
+        if (status.isSwitchOff() || machineState == MachineOperatingState.STOP) {
             return ForceStopResult.ALREADY_STOPPED;
         }
-        if (!"run".equalsIgnoreCase(machineState) && !"pause".equalsIgnoreCase(machineState)) {
+        if (!machineState.isOperating()) {
             throw new ExpectedException("기기 동작 상태를 확인할 수 없습니다", HttpStatus.BAD_GATEWAY);
         }
 
@@ -140,19 +145,6 @@ public class ForceStopMachineServiceImpl implements ForceStopMachineService {
             }
         }
         machine.markAsAvailable();
-    }
-
-    private String extractMachineState(Machine machine, SmartThingsDeviceStatusResDto status) {
-        if (status == null) {
-            return null;
-        }
-        if (machine.isWasher()) {
-            return status.getWasherOperatingState();
-        }
-        if (machine.isDryer()) {
-            return status.getDryerOperatingState();
-        }
-        return null;
     }
 
     private record UpdateResult(Long machineId, String machineName, MachineType machineType, String deviceId,

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
@@ -21,6 +21,7 @@ import team.washer.server.v2.domain.machine.service.QueryAllMachinesStatusServic
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.global.util.DateTimeUtil;
@@ -66,15 +67,15 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
     private MachineStatusResDto mapToStatusDto(Machine machine,
             SmartThingsDeviceStatusResDto deviceStatus,
             Reservation reservation) {
-        String operatingState = null;
+        MachineOperatingState operatingState = MachineOperatingState.UNKNOWN;
         String jobState = null;
         String switchStatus = null;
         LocalDateTime expectedCompletionTime = null;
         Long remainingMinutes = null;
 
         if (deviceStatus != null) {
-            operatingState = getOperatingState(machine, deviceStatus);
-            jobState = getJobState(machine, deviceStatus);
+            operatingState = deviceStatus.getOperatingState(machine.isWasher());
+            jobState = deviceStatus.getJobState(machine.isWasher());
             switchStatus = deviceStatus.getSwitchStatus();
 
             if (reservation != null) {
@@ -131,34 +132,7 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
      * 기기가 물리적으로 작동 중(run 또는 pause)인지 판정한다. 세탁기/건조기는 타입에 맞는 machineState를 본다.
      */
     private boolean isOperating(Machine machine, SmartThingsDeviceStatusResDto deviceStatus) {
-        if (deviceStatus == null) {
-            return false;
-        }
-        String machineState = null;
-        if (machine.isWasher()) {
-            machineState = deviceStatus.getWasherOperatingState();
-        } else if (machine.isDryer()) {
-            machineState = deviceStatus.getDryerOperatingState();
-        }
-        return "run".equalsIgnoreCase(machineState) || "pause".equalsIgnoreCase(machineState);
-    }
-
-    private String getOperatingState(Machine machine, SmartThingsDeviceStatusResDto deviceStatus) {
-        if (machine.isWasher()) {
-            return deviceStatus.getWasherOperatingState();
-        } else if (machine.isDryer()) {
-            return deviceStatus.getDryerOperatingState();
-        }
-        return null;
-    }
-
-    private String getJobState(Machine machine, SmartThingsDeviceStatusResDto deviceStatus) {
-        if (machine.isWasher()) {
-            return deviceStatus.getWasherJobState();
-        } else if (machine.isDryer()) {
-            return deviceStatus.getDryerJobState();
-        }
-        return null;
+        return deviceStatus != null && deviceStatus.getOperatingState(machine.isWasher()).isOperating();
     }
 
     private Long calculateRemainingMinutes(LocalDateTime completionTime) {

--- a/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationCompletionDecisionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationCompletionDecisionSupport.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 import team.washer.server.v2.global.util.DateTimeUtil;
 
@@ -124,8 +125,7 @@ public class ReservationCompletionDecisionSupport {
         if (status == null || machineStateDetectionSupport.isPoweredOff(status)) {
             return Optional.empty();
         }
-        if (!"stop".equalsIgnoreCase(getOperatingState(status, isWasher))
-                || !isResetJobState(getJobState(status, isWasher))) {
+        if (!isStopped(status, isWasher) || !status.isJobStateReset(isWasher)) {
             return Optional.empty();
         }
 
@@ -140,8 +140,8 @@ public class ReservationCompletionDecisionSupport {
             return Optional.empty();
         }
         // 이번 사이클에서 실제로 상태가 갱신됐다는 근거가 없으면 이전 사이클의 잔재로 본다.
-        if (!isTimestampAtOrAfterStart(getOperatingStateTimestamp(status, isWasher), startTime)
-                && !isTimestampAtOrAfterStart(getJobStateTimestamp(status, isWasher), startTime)) {
+        if (!isTimestampAtOrAfterStart(resolveOperatingStateTimestamp(status, isWasher), startTime)
+                && !isTimestampAtOrAfterStart(resolveJobStateTimestamp(status, isWasher), startTime)) {
             return Optional.empty();
         }
 
@@ -149,10 +149,6 @@ public class ReservationCompletionDecisionSupport {
                 completionTime,
                 startTime);
         return Optional.of(now);
-    }
-
-    private boolean isResetJobState(String jobState) {
-        return jobState == null || jobState.isBlank() || "none".equalsIgnoreCase(jobState);
     }
 
     private boolean isTimestampAtOrAfterStart(String timestamp, LocalDateTime startTime) {
@@ -169,7 +165,7 @@ public class ReservationCompletionDecisionSupport {
     private Optional<LocalDateTime> findNearCompletionStopTime(Reservation reservation,
             SmartThingsDeviceStatusResDto status,
             boolean isWasher) {
-        if (!"stop".equalsIgnoreCase(getOperatingState(status, isWasher))) {
+        if (!isStopped(status, isWasher)) {
             return Optional.empty();
         }
 
@@ -206,8 +202,8 @@ public class ReservationCompletionDecisionSupport {
         if (completionTime.isBefore(startTime)) {
             return true;
         }
-        return isTimestampBeforeStart(getOperatingStateTimestamp(status, isWasher), startTime)
-                || isTimestampBeforeStart(getJobStateTimestamp(status, isWasher), startTime);
+        return isTimestampBeforeStart(resolveOperatingStateTimestamp(status, isWasher), startTime)
+                || isTimestampBeforeStart(resolveJobStateTimestamp(status, isWasher), startTime);
     }
 
     /**
@@ -230,39 +226,23 @@ public class ReservationCompletionDecisionSupport {
         return updatedAt != null && updatedAt.isBefore(startTime);
     }
 
+    /**
+     * 기기가 물리적으로 정지(machineState=stop) 상태인지 판정한다.
+     */
+    private boolean isStopped(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        return status != null && status.getOperatingState(isWasher) == MachineOperatingState.STOP;
+    }
+
     private String getCompletionTime(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        if (status == null) {
-            return null;
-        }
-        return isWasher ? status.getWasherCompletionTime() : status.getDryerCompletionTime();
+        return status == null ? null : status.getCompletionTime(isWasher);
     }
 
-    private String getOperatingState(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        if (status == null) {
-            return null;
-        }
-        return isWasher ? status.getWasherOperatingState() : status.getDryerOperatingState();
+    private String resolveOperatingStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        return status == null ? null : status.getOperatingStateTimestamp(isWasher);
     }
 
-    private String getJobState(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        if (status == null) {
-            return null;
-        }
-        return isWasher ? status.getWasherJobState() : status.getDryerJobState();
-    }
-
-    private String getOperatingStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        if (status == null) {
-            return null;
-        }
-        return isWasher ? status.getWasherOperatingStateTimestamp() : status.getDryerOperatingStateTimestamp();
-    }
-
-    private String getJobStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        if (status == null) {
-            return null;
-        }
-        return isWasher ? status.getWasherJobStateTimestamp() : status.getDryerJobStateTimestamp();
+    private String resolveJobStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        return status == null ? null : status.getJobStateTimestamp(isWasher);
     }
 
     private record CompletionCandidate(LocalDateTime completionTime, String reason) {

--- a/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsDeviceStatusResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsDeviceStatusResDto.java
@@ -6,11 +6,17 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 
 @Schema(description = "SmartThings 기기 상태 응답")
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record SmartThingsDeviceStatusResDto(
         @Schema(description = "컴포넌트 목록") @JsonProperty("components") Map<String, ComponentStatus> components) {
+
+    private static final String WASHER_FINISHED_JOB_STATE = "finish";
+    private static final String DRYER_FINISHED_JOB_STATE = "finished";
+    private static final String IDLE_JOB_STATE = "none";
+    private static final String SWITCH_OFF = "off";
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record ComponentStatus(@JsonProperty("washerOperatingState") WasherOperatingState washerOperatingState,
@@ -172,11 +178,54 @@ public record SmartThingsDeviceStatusResDto(
         return null;
     }
 
-    /** 스위치 상태 값 반환: "on" | "off" */
+    /** 기기 타입에 해당하는 완료 예정 시간 반환 */
     public String getCompletionTime(boolean isWasher) {
         return isWasher ? getWasherCompletionTime() : getDryerCompletionTime();
     }
 
+    /**
+     * 기기 타입에 해당하는 machineState를 {@link MachineOperatingState}로 반환한다. 세탁기·건조기
+     * capability를 동시에 노출하는 기기에서 반대쪽 값을 읽지 않도록, 분기는 이 메서드로 일원화한다.
+     */
+    public MachineOperatingState getOperatingState(boolean isWasher) {
+        return MachineOperatingState.from(isWasher ? getWasherOperatingState() : getDryerOperatingState());
+    }
+
+    /** 기기 타입에 해당하는 machineState 갱신 시각 반환 */
+    public String getOperatingStateTimestamp(boolean isWasher) {
+        return isWasher ? getWasherOperatingStateTimestamp() : getDryerOperatingStateTimestamp();
+    }
+
+    /** 기기 타입에 해당하는 jobState 반환 */
+    public String getJobState(boolean isWasher) {
+        return isWasher ? getWasherJobState() : getDryerJobState();
+    }
+
+    /** 기기 타입에 해당하는 jobState 갱신 시각 반환 */
+    public String getJobStateTimestamp(boolean isWasher) {
+        return isWasher ? getWasherJobStateTimestamp() : getDryerJobStateTimestamp();
+    }
+
+    /** jobState가 사이클 종료 직후 리셋된 값(none·공백·null)인지 여부 반환 */
+    public boolean isJobStateReset(boolean isWasher) {
+        var jobState = getJobState(isWasher);
+        return jobState == null || jobState.isBlank() || IDLE_JOB_STATE.equalsIgnoreCase(jobState);
+    }
+
+    /**
+     * jobState가 정상 완료를 뜻하는 값인지 여부 반환. 세탁기는 finish, 건조기는 finished로 보고한다.
+     */
+    public boolean isJobStateFinished(boolean isWasher) {
+        return (isWasher ? WASHER_FINISHED_JOB_STATE : DRYER_FINISHED_JOB_STATE)
+                .equalsIgnoreCase(getJobState(isWasher));
+    }
+
+    /** 기기 전원이 꺼진 상태(switch=off)인지 여부 반환 */
+    public boolean isSwitchOff() {
+        return SWITCH_OFF.equalsIgnoreCase(getSwitchStatus());
+    }
+
+    /** 스위치 상태 값 반환: "on" | "off" */
     public String getSwitchStatus() {
         var main = getMainComponent();
         if (main == null || main.switchCapability() == null) {

--- a/src/main/java/team/washer/server/v2/domain/smartthings/enums/MachineOperatingState.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/enums/MachineOperatingState.java
@@ -1,0 +1,50 @@
+package team.washer.server.v2.domain.smartthings.enums;
+
+import java.util.Arrays;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * SmartThings의 washerOperatingState/dryerOperatingState capability가 보고하는
+ * machineState 값.
+ *
+ * <p>
+ * SmartThings는 이 값을 소문자 문자열("run" | "pause" | "stop")로 내려주며, 기기가 해당 capability를
+ * 노출하지 않거나 응답이 비어 있을 수 있다. 그런 경우를 호출 측에서 null 검사로 흩어 처리하지 않도록
+ * {@link #UNKNOWN}으로 흡수한다.
+ *
+ * <p>
+ * API 응답에는 {@link JsonValue}를 통해 SmartThings와 동일한 원시 소문자 값으로 직렬화된다
+ * ({@link #UNKNOWN}은 null). 내부 판정만 enum으로 하고 클라이언트가 보던 계약은 그대로 유지하기 위함이다.
+ */
+@Getter
+@AllArgsConstructor
+public enum MachineOperatingState {
+    RUN("run", "작동 중"), PAUSE("pause", "일시정지"), STOP("stop", "정지"), UNKNOWN(null, "확인 불가");
+
+    @JsonValue
+    private final String value;
+    private final String description;
+
+    /**
+     * SmartThings가 내려준 원시 machineState 문자열을 enum으로 변환한다. 값이 없거나 알 수 없는 값이면
+     * {@link #UNKNOWN}을 반환한다.
+     */
+    public static MachineOperatingState from(final String rawValue) {
+        if (rawValue == null || rawValue.isBlank()) {
+            return UNKNOWN;
+        }
+        return Arrays.stream(values()).filter(state -> rawValue.equalsIgnoreCase(state.value)).findFirst()
+                .orElse(UNKNOWN);
+    }
+
+    /**
+     * 기기가 사이클을 물리적으로 점유 중인 상태(run 또는 pause)인지 여부를 반환한다.
+     */
+    public boolean isOperating() {
+        return this == RUN || this == PAUSE;
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 import team.washer.server.v2.global.util.DateTimeUtil;
 
 /**
@@ -15,6 +16,11 @@ import team.washer.server.v2.global.util.DateTimeUtil;
  * <p>
  * 모든 판정은 기기 타입(세탁기/건조기)에 해당하는 capability만 검사한다. 하나의 deviceId가 세탁기·건조기
  * capability를 동시에 노출하는 경우, 사용하지 않는 쪽의 유휴 상태를 비정상 중단으로 오판하지 않기 위함이다.
+ *
+ * <p>
+ * 세탁기/건조기 분기와 원시 문자열 해석은 {@link SmartThingsDeviceStatusResDto}의 타입 인자 접근자
+ * ({@code getOperatingState(isWasher)} 등)가 담당한다. 이 컴포넌트는 그 위에서 "작동 중·완료·중단" 같은
+ * 판정만 수행한다.
  */
 @Component
 @Slf4j
@@ -28,8 +34,7 @@ public class MachineStateDetectionSupport {
         if (status == null) {
             return false;
         }
-        var machineState = isWasher ? status.getWasherOperatingState() : status.getDryerOperatingState();
-        var isRunning = "run".equalsIgnoreCase(machineState);
+        var isRunning = status.getOperatingState(isWasher) == MachineOperatingState.RUN;
         if (isRunning) {
             log.debug("device is running isWasher={}", isWasher);
         }
@@ -50,60 +55,41 @@ public class MachineStateDetectionSupport {
             return Optional.empty();
         }
         var now = DateTimeUtil.nowInKorea();
-        if (isWasher) {
-            return evaluateCompletion(status.getWasherJobState(),
-                    "finish",
-                    status.getWasherOperatingState(),
-                    status.getWasherCompletionTime(),
-                    now);
-        }
-        return evaluateCompletion(status
-                .getDryerJobState(), "finished", status.getDryerOperatingState(), status.getDryerCompletionTime(), now);
-    }
-
-    /**
-     * jobState·machineState·completionTime을 종합하여 단일 기기 타입의 완료 여부를 판정한다.
-     */
-    private Optional<LocalDateTime> evaluateCompletion(String jobState,
-            String finishedJobState,
-            String machineState,
-            String completionTimeStr,
-            LocalDateTime now) {
-        if (!"stop".equalsIgnoreCase(machineState)) {
-            if (finishedJobState.equalsIgnoreCase(jobState)) {
+        if (status.getOperatingState(isWasher) != MachineOperatingState.STOP) {
+            if (status.isJobStateFinished(isWasher)) {
                 log.debug("job finished but machine not stopped yet machineState={} jobState={}",
-                        machineState,
-                        jobState);
+                        status.getOperatingState(isWasher),
+                        status.getJobState(isWasher));
             }
             return Optional.empty();
         }
+
+        var completionTimeStr = status.getCompletionTime(isWasher);
         var completionTime = (completionTimeStr != null && !completionTimeStr.isBlank())
                 ? DateTimeUtil.parseAndConvertToKoreaTime(completionTimeStr)
                 : null;
-        if (finishedJobState.equalsIgnoreCase(jobState)) {
-            log.debug("device job is completed jobState={} completionTime={}", jobState, completionTime);
+        if (status.isJobStateFinished(isWasher)) {
+            log.debug("device job is completed jobState={} completionTime={}",
+                    status.getJobState(isWasher),
+                    completionTime);
             return Optional.of(completionTime != null && !completionTime.isAfter(now) ? completionTime : now);
         }
 
         if (completionTime != null && completionTime.isAfter(now)) {
             log.debug("device stopped but completion time still in future completionTime={} jobState={}",
                     completionTime,
-                    jobState);
+                    status.getJobState(isWasher));
             return Optional.empty();
         }
 
-        if (isResetJobState(jobState) && completionTime != null) {
+        if (status.isJobStateReset(isWasher) && completionTime != null) {
             log.debug("device job is completed after job reset jobState={} completionTime={}",
-                    jobState,
+                    status.getJobState(isWasher),
                     completionTime);
             return Optional.of(completionTime);
         }
 
         return Optional.empty();
-    }
-
-    private boolean isResetJobState(String jobState) {
-        return jobState == null || jobState.isBlank() || "none".equalsIgnoreCase(jobState);
     }
 
     /**
@@ -117,7 +103,7 @@ public class MachineStateDetectionSupport {
         if (status == null) {
             return false;
         }
-        var isPoweredOff = "off".equalsIgnoreCase(status.getSwitchStatus());
+        var isPoweredOff = status.isSwitchOff();
         if (isPoweredOff) {
             log.debug("device power off detected switch=off");
         }
@@ -141,22 +127,19 @@ public class MachineStateDetectionSupport {
             return true;
         }
 
-        var machineState = isWasher ? status.getWasherOperatingState() : status.getDryerOperatingState();
-        if (!"stop".equalsIgnoreCase(machineState)) {
+        if (status.getOperatingState(isWasher) != MachineOperatingState.STOP) {
+            return false;
+        }
+        if (status.isJobStateFinished(isWasher)) {
+            return false;
+        }
+        if (status.isJobStateReset(isWasher)) {
+            log.debug("machine stopped with idle jobState, not treated as interruption jobState={}",
+                    status.getJobState(isWasher));
             return false;
         }
 
-        var jobState = isWasher ? status.getWasherJobState() : status.getDryerJobState();
-        var finishedJobState = isWasher ? "finish" : "finished";
-        if (finishedJobState.equalsIgnoreCase(jobState)) {
-            return false;
-        }
-        if (jobState == null || jobState.isBlank() || "none".equalsIgnoreCase(jobState)) {
-            log.debug("machine stopped with idle jobState, not treated as interruption jobState={}", jobState);
-            return false;
-        }
-
-        log.debug("machine interrupted mid-cycle machineState=stop jobState={}", jobState);
+        log.debug("machine interrupted mid-cycle machineState=stop jobState={}", status.getJobState(isWasher));
         return true;
     }
 
@@ -167,8 +150,7 @@ public class MachineStateDetectionSupport {
         if (status == null) {
             return false;
         }
-        var machineState = isWasher ? status.getWasherOperatingState() : status.getDryerOperatingState();
-        var isPaused = "pause".equalsIgnoreCase(machineState);
+        var isPaused = status.getOperatingState(isWasher) == MachineOperatingState.PAUSE;
         if (isPaused) {
             log.debug("device is paused isWasher={}", isWasher);
         }

--- a/src/test/java/team/washer/server/v2/domain/machine/service/ForceStopMachineServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/ForceStopMachineServiceTest.java
@@ -41,6 +41,7 @@ import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceSt
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.DryerOperatingState;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.SwitchCapability;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.WasherOperatingState;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 import team.washer.server.v2.domain.smartthings.service.SendDeviceCommandService;
 import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
 import team.washer.server.v2.domain.user.entity.User;
@@ -155,7 +156,7 @@ class ForceStopMachineServiceTest {
                 // Then
                 assertThat(result.machineId()).isEqualTo(machineId);
                 assertThat(result.forceStopResult()).isEqualTo(ForceStopResult.STOPPED);
-                assertThat(result.previousMachineState()).isEqualTo("run");
+                assertThat(result.previousMachineState()).isEqualTo(MachineOperatingState.RUN);
                 assertThat(result.cancelledReservationId()).isEqualTo(reservationId);
                 assertThat(result.reservationCancelled()).isTrue();
                 assertThat(result.availability()).isEqualTo(MachineAvailability.AVAILABLE);

--- a/src/test/java/team/washer/server/v2/domain/smartthings/enums/MachineOperatingStateTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/enums/MachineOperatingStateTest.java
@@ -1,0 +1,102 @@
+package team.washer.server.v2.domain.smartthings.enums;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@DisplayName("MachineOperatingState 변환 및 판정")
+class MachineOperatingStateTest {
+
+    @Nested
+    @DisplayName("from 원시 문자열 변환")
+    class From {
+
+        @Test
+        @DisplayName("SmartThings가 내려주는 소문자 값을 대응하는 상수로 변환한다")
+        void 소문자_값을_변환한다() {
+            // Given & When & Then
+            assertThat(MachineOperatingState.from("run")).isEqualTo(MachineOperatingState.RUN);
+            assertThat(MachineOperatingState.from("pause")).isEqualTo(MachineOperatingState.PAUSE);
+            assertThat(MachineOperatingState.from("stop")).isEqualTo(MachineOperatingState.STOP);
+        }
+
+        @Test
+        @DisplayName("대소문자를 구분하지 않고 변환한다")
+        void 대소문자를_구분하지_않는다() {
+            // Given
+            final var rawValue = "RuN";
+
+            // When
+            final var result = MachineOperatingState.from(rawValue);
+
+            // Then
+            assertThat(result).isEqualTo(MachineOperatingState.RUN);
+        }
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        @ValueSource(strings = {"   ", "running", "unknownState"})
+        @DisplayName("값이 없거나 알 수 없는 값이면 UNKNOWN을 반환한다")
+        void 알_수_없는_값은_UNKNOWN이다(final String rawValue) {
+            // Given & When
+            final var result = MachineOperatingState.from(rawValue);
+
+            // Then
+            assertThat(result).isEqualTo(MachineOperatingState.UNKNOWN);
+        }
+    }
+
+    @Nested
+    @DisplayName("JSON 직렬화")
+    class Serialization {
+
+        private final ObjectMapper objectMapper = new ObjectMapper();
+
+        @Test
+        @DisplayName("SmartThings와 동일한 원시 소문자 값으로 직렬화한다")
+        void 소문자_값으로_직렬화한다() throws Exception {
+            // Given & When & Then
+            assertThat(objectMapper.writeValueAsString(MachineOperatingState.RUN)).isEqualTo("\"run\"");
+            assertThat(objectMapper.writeValueAsString(MachineOperatingState.PAUSE)).isEqualTo("\"pause\"");
+            assertThat(objectMapper.writeValueAsString(MachineOperatingState.STOP)).isEqualTo("\"stop\"");
+        }
+
+        @Test
+        @DisplayName("UNKNOWN은 상태를 알 수 없다는 뜻이므로 null로 직렬화한다")
+        void UNKNOWN은_null로_직렬화한다() throws Exception {
+            // Given & When
+            final var result = objectMapper.writeValueAsString(MachineOperatingState.UNKNOWN);
+
+            // Then
+            assertThat(result).isEqualTo("null");
+        }
+    }
+
+    @Nested
+    @DisplayName("isOperating 사이클 점유 판정")
+    class IsOperating {
+
+        @Test
+        @DisplayName("run과 pause는 사이클을 점유 중인 상태로 판정한다")
+        void run과_pause는_점유_중이다() {
+            // Given & When & Then
+            assertThat(MachineOperatingState.RUN.isOperating()).isTrue();
+            assertThat(MachineOperatingState.PAUSE.isOperating()).isTrue();
+        }
+
+        @Test
+        @DisplayName("stop과 UNKNOWN은 사이클을 점유하지 않은 상태로 판정한다")
+        void stop과_UNKNOWN은_점유_중이_아니다() {
+            // Given & When & Then
+            assertThat(MachineOperatingState.STOP.isOperating()).isFalse();
+            assertThat(MachineOperatingState.UNKNOWN.isOperating()).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
## 개요

`ForceStopMachineServiceImpl`이 SmartThings의 `machineState` 값을 `"run"` / `"pause"` / `"stop"` 문자열로 직접 비교하고, 세탁기·건조기 분기를 자체 구현하고 있었습니다. 이 값을 나타내는 `MachineOperatingState` enum을 추가하고, 프로젝트 전반에 흩어져 있던 동일한 판정 로직을 통합하였습니다. 동작 변경은 없는 리팩터링입니다.

## 본문

### 문제

`machineState` 값을 나타내는 타입이 없어 문자열 비교가 네 개 파일에 흩어져 있었습니다.

- `ForceStopMachineServiceImpl` — `"off"` / `"stop"` / `"run"` / `"pause"` 직접 비교
- `QueryAllMachinesStatusServiceImpl` — `"run"` / `"pause"` 직접 비교
- `ReservationCompletionDecisionSupport` — `"stop"` 직접 비교 두 곳
- `MachineStateDetectionSupport` — 위 판정을 이미 `isRunning` / `isPaused` / `isPoweredOff`로 제공 중

특히 `ForceStopMachineServiceImpl`은 이미 존재하는 `MachineStateDetectionSupport`의 판정을 그대로 재구현하고 있었고, 세탁기·건조기 타입 분기 또한 세 곳에서 중복되고 있었습니다.

### 변경 사항

**`MachineOperatingState` 추가**

`RUN` / `PAUSE` / `STOP` / `UNKNOWN`으로 구성되며, `from(String)`이 대소문자를 무시하고 변환합니다. 값이 없거나 알 수 없는 경우를 `UNKNOWN`으로 흡수하여 호출 측이 `null` 검사를 흩어 두지 않도록 하였습니다. `isOperating()`은 사이클 점유 여부(`RUN` 또는 `PAUSE`)를 반환합니다.

**`SmartThingsDeviceStatusResDto`에 기기 타입별 접근자 추가**

세탁기·건조기 두 capability를 모두 가진 이 DTO로 분기를 일원화하였습니다. `getOperatingState(isWasher)`, `getJobState(isWasher)`, `isJobStateReset(isWasher)`, `isJobStateFinished(isWasher)`, `isSwitchOff()`을 추가하고, `finish` / `finished` / `none` / `off` 리터럴을 상수로 흡수하였습니다.

**호출 측 정리**

`ForceStopMachineServiceImpl`의 `extractMachineState`, `QueryAllMachinesStatusServiceImpl`의 분기 게터 세 개, `ReservationCompletionDecisionSupport`의 `isResetJobState`와 분기 게터를 모두 제거하였습니다. `MachineStateDetectionSupport`는 문자열 해석을 DTO에 위임하고 판정만 담당하도록 정리하였으며, 공개 메서드 시그니처와 판정 결과는 그대로입니다.

### API 호환성

응답 DTO의 `previousMachineState`와 `operatingState` 타입이 `String`에서 `MachineOperatingState`로 바뀌었으나, enum에 `@JsonValue`를 적용하여 직렬화 값은 기존과 동일한 소문자 원시값입니다. `UNKNOWN`은 `null`로 직렬화되므로 상태 조회 실패 시의 기존 동작도 유지됩니다. 클라이언트 영향은 없습니다.

### 참고

이 브랜치는 `develop`이 아니라 `fix/reservation-completion-detection-unification`을 기준으로 분기하였습니다. 리팩터링 대상인 `ReservationCompletionDecisionSupport`의 변경이 해당 브랜치에 아직 병합되지 않았기 때문입니다.

### 검증

`./gradlew spotlessApply test` 전체 통과하였으며, `MachineOperatingStateTest`로 변환 규칙과 직렬화 값을 검증하였습니다.
