### PR TITLE
[reservation] 실행 중 예약 취소 상태 보호

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/controller/ReservationController.java
@@ -61,7 +61,7 @@ public class ReservationController {
     }
 
     @DeleteMapping("/{id}")
-    @Operation(summary = "예약 취소", description = "예약을 취소합니다. RESERVED 상태에서 취소 시 5분간 재예약이 제한됩니다.")
+    @Operation(summary = "예약 취소", description = "RESERVED 상태의 예약을 취소합니다. 취소 시 5분간 동일 종류 기기 재예약이 제한됩니다. 이미 기기 사용이 시작된 RUNNING 예약은 취소할 수 없으며 409를 반환합니다.")
     public CancellationResDto cancelReservation(@Parameter(description = "예약 ID") @PathVariable @NotNull Long id) {
         return cancelReservationService.execute(id);
     }

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/ReservationRepository.java
@@ -5,10 +5,12 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import jakarta.persistence.LockModeType;
 import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
@@ -25,6 +27,10 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
 
     List<Reservation> findByStatus(ReservationStatus status);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM Reservation r JOIN FETCH r.machine JOIN FETCH r.user WHERE r.id = :id")
+    Optional<Reservation> findByIdForUpdate(@Param("id") Long id);
+
     @Query("SELECT r FROM Reservation r JOIN FETCH r.machine JOIN FETCH r.user WHERE r.status = :status")
     List<Reservation> findByStatusWithMachineAndUser(@Param("status") ReservationStatus status);
 
@@ -32,6 +38,11 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
 
     @Query("SELECT r FROM Reservation r WHERE r.user = :user AND r.status IN :statuses")
     List<Reservation> findByUserAndStatusIn(@Param("user") User user,
+            @Param("statuses") List<ReservationStatus> statuses);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM Reservation r JOIN FETCH r.machine WHERE r.user = :user AND r.status IN :statuses")
+    List<Reservation> findByUserAndStatusInForUpdate(@Param("user") User user,
             @Param("statuses") List<ReservationStatus> statuses);
 
     @Query("SELECT r FROM Reservation r WHERE r.machine = :machine AND r.status IN :statuses")

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CancelReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CancelReservationServiceImpl.java
@@ -33,53 +33,47 @@ public class CancelReservationServiceImpl implements CancelReservationService {
     @Transactional
     public CancellationResDto execute(final Long reservationId) {
         final var userId = currentUserProvider.getCurrentUserId();
-        final Reservation reservation = reservationRepository.findById(reservationId)
+        final Reservation reservation = reservationRepository.findByIdForUpdate(reservationId)
                 .orElseThrow(() -> new ExpectedException("예약을 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
         if (!reservation.getUser().getId().equals(userId)) {
             throw new ExpectedException("예약을 취소할 권한이 없습니다", HttpStatus.FORBIDDEN);
         }
 
-        if (!reservation.isActive()) {
-            throw new ExpectedException("활성 예약만 취소할 수 있습니다", HttpStatus.BAD_REQUEST);
-        }
-
         if (reservation.isRunning()) {
             throw new ExpectedException("이미 기기 사용이 시작되어 예약을 취소할 수 없습니다. 최신 상태를 확인해주세요.", HttpStatus.CONFLICT);
         }
 
-        boolean applyPenalty = false;
+        if (!reservation.isReserved()) {
+            throw new ExpectedException("취소할 수 있는 상태의 예약이 아닙니다", HttpStatus.BAD_REQUEST);
+        }
 
         // RESERVED 상태에서 수동 취소 시 패널티 적용
-        if (reservation.isReserved()) {
-            final User user = reservation.getUser();
-            penaltyRedisUtil.applyCooldown(userId, reservation.getMachine().getType());
-            penaltyRedisUtil.recordCancellation(userId);
-            user.updateLastCancellationTime();
-            if (penaltyRedisUtil.getCancellationCount(userId) > PenaltyConstants.MAX_CANCELLATIONS_IN_48H) {
-                final boolean wasBlocked = penaltyRedisUtil.isBlocked(user.getRoomNumber());
-                penaltyRedisUtil.applyBlock(user.getRoomNumber());
-                if (!wasBlocked) {
-                    reservationNotificationSupport.sendCancellationBlock(user, reservation.getMachine());
-                }
-                log.warn("48h block applied roomNumber {}", user.getRoomNumber());
+        final User user = reservation.getUser();
+        penaltyRedisUtil.applyCooldown(userId, reservation.getMachine().getType());
+        penaltyRedisUtil.recordCancellation(userId);
+        user.updateLastCancellationTime();
+        if (penaltyRedisUtil.getCancellationCount(userId) > PenaltyConstants.MAX_CANCELLATIONS_IN_48H) {
+            final boolean wasBlocked = penaltyRedisUtil.isBlocked(user.getRoomNumber());
+            penaltyRedisUtil.applyBlock(user.getRoomNumber());
+            if (!wasBlocked) {
+                reservationNotificationSupport.sendCancellationBlock(user, reservation.getMachine());
             }
-            applyPenalty = true;
-            log.info("manual cancel penalty applied userId {} reservationId {}", userId, reservationId);
+            log.warn("48h block applied roomNumber={}", user.getRoomNumber());
         }
+        log.info("manual cancel penalty applied userId={} reservationId={}", userId, reservationId);
 
         final var machine = reservation.getMachine();
         reservation.cancel();
         machine.markAsAvailable();
         reservationRepository.save(reservation);
         machineRepository.save(machine);
-        log.info("Cancelled reservation {} by user {}", reservationId, userId);
+        log.info("Cancelled reservation reservationId={} userId={}", reservationId, userId);
 
-        return mapToCancellationResDto(applyPenalty);
+        return mapToCancellationResDto();
     }
 
-    private CancellationResDto mapToCancellationResDto(final boolean penaltyApplied) {
-        final String message = penaltyApplied ? "예약이 취소되었습니다. 5분간 동일 종류 기기 재예약이 제한됩니다." : "예약이 취소되었습니다.";
-        return new CancellationResDto(true, message, penaltyApplied, null);
+    private CancellationResDto mapToCancellationResDto() {
+        return new CancellationResDto(true, "예약이 취소되었습니다. 5분간 동일 종류 기기 재예약이 제한됩니다.", true, null);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CancelReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CancelReservationServiceImpl.java
@@ -44,6 +44,10 @@ public class CancelReservationServiceImpl implements CancelReservationService {
             throw new ExpectedException("활성 예약만 취소할 수 있습니다", HttpStatus.BAD_REQUEST);
         }
 
+        if (reservation.isRunning()) {
+            throw new ExpectedException("이미 기기 사용이 시작되어 예약을 취소할 수 없습니다. 최신 상태를 확인해주세요.", HttpStatus.CONFLICT);
+        }
+
         boolean applyPenalty = false;
 
         // RESERVED 상태에서 수동 취소 시 패널티 적용

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/OverdueReservationProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/OverdueReservationProcessor.java
@@ -74,7 +74,7 @@ public class OverdueReservationProcessor {
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public OverdueResult processOverdue(Long reservationId, SmartThingsDeviceStatusResDto status) {
-        var reservation = reservationRepository.findById(reservationId).orElse(null);
+        var reservation = reservationRepository.findByIdForUpdate(reservationId).orElse(null);
         if (reservation == null || !reservation.isReserved()) {
             return OverdueResult.SKIPPED;
         }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
@@ -69,7 +69,7 @@ public class ReservationLifecycleProcessor {
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void processReservedToRunning(Long reservationId, SmartThingsDeviceStatusResDto status) {
-        var reservation = reservationRepository.findById(reservationId).orElse(null);
+        var reservation = reservationRepository.findByIdForUpdate(reservationId).orElse(null);
         if (reservation == null || !reservation.isReserved()) {
             return;
         }
@@ -110,7 +110,7 @@ public class ReservationLifecycleProcessor {
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void processRunningToCompleted(Long reservationId, SmartThingsDeviceStatusResDto status) {
-        var reservation = reservationRepository.findById(reservationId).orElse(null);
+        var reservation = reservationRepository.findByIdForUpdate(reservationId).orElse(null);
         if (reservation == null || !reservation.isRunning()) {
             return;
         }

--- a/src/main/java/team/washer/server/v2/domain/user/controller/UserController.java
+++ b/src/main/java/team/washer/server/v2/domain/user/controller/UserController.java
@@ -29,7 +29,7 @@ public class UserController {
     }
 
     @DeleteMapping("/me")
-    @Operation(summary = "회원탈퇴", description = "현재 로그인된 사용자의 계정을 삭제합니다. 활성 예약은 자동으로 취소되며, 탈퇴 후 30일간 재가입이 제한됩니다.")
+    @Operation(summary = "회원탈퇴", description = "현재 로그인된 사용자의 계정을 삭제합니다. RESERVED 예약은 자동으로 취소되며, RUNNING 예약이 있으면 409를 반환합니다. 탈퇴 후 30일간 재가입이 제한됩니다.")
     public CommonApiResponse withdrawUser() {
         withdrawUserService.execute();
         return CommonApiResponse.success("회원탈퇴가 완료되었습니다.");

--- a/src/main/java/team/washer/server/v2/domain/user/service/impl/WithdrawUserServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/impl/WithdrawUserServiceImpl.java
@@ -13,6 +13,7 @@ import team.washer.server.v2.domain.auth.repository.redis.RefreshTokenRedisRepos
 import team.washer.server.v2.domain.auth.util.WithdrawnStudentRedisUtil;
 import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.user.repository.UserRepository;
@@ -38,8 +39,8 @@ public class WithdrawUserServiceImpl implements WithdrawUserService {
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
         final var activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
-        final var activeReservations = reservationRepository.findByUserAndStatusIn(user, activeStatuses);
-        if (activeReservations.stream().anyMatch(reservation -> reservation.getStatus() == ReservationStatus.RUNNING)) {
+        final var activeReservations = reservationRepository.findByUserAndStatusInForUpdate(user, activeStatuses);
+        if (activeReservations.stream().anyMatch(Reservation::isRunning)) {
             throw new ExpectedException("기기 사용 중에는 회원탈퇴를 할 수 없습니다. 사용 완료 후 다시 시도해주세요.", HttpStatus.CONFLICT);
         }
 

--- a/src/main/java/team/washer/server/v2/domain/user/service/impl/WithdrawUserServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/impl/WithdrawUserServiceImpl.java
@@ -39,6 +39,10 @@ public class WithdrawUserServiceImpl implements WithdrawUserService {
 
         final var activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
         final var activeReservations = reservationRepository.findByUserAndStatusIn(user, activeStatuses);
+        if (activeReservations.stream().anyMatch(reservation -> reservation.getStatus() == ReservationStatus.RUNNING)) {
+            throw new ExpectedException("기기 사용 중에는 회원탈퇴를 할 수 없습니다. 사용 완료 후 다시 시도해주세요.", HttpStatus.CONFLICT);
+        }
+
         final var machinesToUpdate = new ArrayList<Machine>();
         for (final var reservation : activeReservations) {
             final var machine = reservation.getMachine();

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/CancelReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/CancelReservationServiceTest.java
@@ -88,7 +88,7 @@ class CancelReservationServiceTest {
                 var reservation = createReservation(ReservationStatus.RESERVED, userId);
 
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
-                given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+                given(reservationRepository.findByIdForUpdate(reservationId)).willReturn(Optional.of(reservation));
                 given(penaltyRedisUtil.getCancellationCount(userId)).willReturn(0L);
 
                 // When
@@ -120,7 +120,7 @@ class CancelReservationServiceTest {
                 var reservation = createReservation(ReservationStatus.RESERVED, userId);
 
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
-                given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+                given(reservationRepository.findByIdForUpdate(reservationId)).willReturn(Optional.of(reservation));
                 given(penaltyRedisUtil.getCancellationCount(userId)).willReturn(5L);
                 given(user.getRoomNumber()).willReturn("101");
                 given(penaltyRedisUtil.isBlocked("101")).willReturn(false);
@@ -143,7 +143,7 @@ class CancelReservationServiceTest {
                 var reservation = createReservation(ReservationStatus.RESERVED, userId);
 
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
-                given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+                given(reservationRepository.findByIdForUpdate(reservationId)).willReturn(Optional.of(reservation));
                 given(penaltyRedisUtil.getCancellationCount(userId)).willReturn(6L);
                 given(user.getRoomNumber()).willReturn("101");
                 given(penaltyRedisUtil.isBlocked("101")).willReturn(true);
@@ -170,7 +170,7 @@ class CancelReservationServiceTest {
                 var reservation = createReservation(ReservationStatus.RUNNING, userId);
 
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
-                given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+                given(reservationRepository.findByIdForUpdate(reservationId)).willReturn(Optional.of(reservation));
 
                 // When & Then
                 assertThatThrownBy(() -> cancelReservationService.execute(reservationId))
@@ -201,7 +201,7 @@ class CancelReservationServiceTest {
                 var reservation = createReservation(ReservationStatus.RESERVED, ownerUserId);
 
                 given(currentUserProvider.getCurrentUserId()).willReturn(requestUserId);
-                given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+                given(reservationRepository.findByIdForUpdate(reservationId)).willReturn(Optional.of(reservation));
 
                 // When & Then
                 assertThatThrownBy(() -> cancelReservationService.execute(reservationId))
@@ -224,11 +224,11 @@ class CancelReservationServiceTest {
                 var reservation = createReservation(ReservationStatus.COMPLETED, userId);
 
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
-                given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+                given(reservationRepository.findByIdForUpdate(reservationId)).willReturn(Optional.of(reservation));
 
                 // When & Then
                 assertThatThrownBy(() -> cancelReservationService.execute(reservationId))
-                        .isInstanceOf(ExpectedException.class).hasMessage("활성 예약만 취소할 수 있습니다")
+                        .isInstanceOf(ExpectedException.class).hasMessage("취소할 수 있는 상태의 예약이 아닙니다")
                         .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
                                 .isEqualTo(HttpStatus.BAD_REQUEST));
             }
@@ -247,7 +247,7 @@ class CancelReservationServiceTest {
                 var reservation = createReservation(ReservationStatus.CANCELLED, userId);
 
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
-                given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+                given(reservationRepository.findByIdForUpdate(reservationId)).willReturn(Optional.of(reservation));
 
                 // When & Then
                 assertThatThrownBy(() -> cancelReservationService.execute(reservationId))
@@ -270,7 +270,7 @@ class CancelReservationServiceTest {
                 var userId = 1L;
                 var reservationId = 999L;
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
-                given(reservationRepository.findById(reservationId)).willReturn(Optional.empty());
+                given(reservationRepository.findByIdForUpdate(reservationId)).willReturn(Optional.empty());
 
                 // When & Then
                 assertThatThrownBy(() -> cancelReservationService.execute(reservationId))

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/CancelReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/CancelReservationServiceTest.java
@@ -64,6 +64,9 @@ class CancelReservationServiceTest {
 
     private Reservation createReservation(final ReservationStatus status, final Long userId) {
         var machine = createMachine();
+        if (status == ReservationStatus.RUNNING) {
+            machine.markAsInUse();
+        }
         given(user.getId()).willReturn(userId);
         return Reservation.builder().user(user).machine(machine).reservedAt(LocalDateTime.now()).status(status).build();
     }
@@ -159,8 +162,8 @@ class CancelReservationServiceTest {
         class Context_with_running_reservation_by_owner {
 
             @Test
-            @DisplayName("패널티 없이 예약이 취소되어야 한다")
-            void it_cancels_without_penalty() {
+            @DisplayName("예약과 기기 상태를 보존하고 CONFLICT 예외를 발생시켜야 한다")
+            void it_keeps_running_state_and_throws_conflict() {
                 // Given
                 var userId = 1L;
                 var reservationId = 10L;
@@ -169,15 +172,18 @@ class CancelReservationServiceTest {
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
                 given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
 
-                // When
-                var result = cancelReservationService.execute(reservationId);
+                // When & Then
+                assertThatThrownBy(() -> cancelReservationService.execute(reservationId))
+                        .isInstanceOf(ExpectedException.class)
+                        .hasMessage("이미 기기 사용이 시작되어 예약을 취소할 수 없습니다. 최신 상태를 확인해주세요.")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.CONFLICT));
 
-                // Then
-                assertThat(result).isNotNull();
-                assertThat(result.success()).isTrue();
-                assertThat(result.penaltyApplied()).isFalse();
-                assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+                assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.RUNNING);
+                assertThat(reservation.getMachine().getAvailability()).isEqualTo(MachineAvailability.IN_USE);
                 then(penaltyRedisUtil).should(never()).applyCooldown(anyLong(), any());
+                then(reservationRepository).should(never()).save(any());
+                then(machineRepository).should(never()).save(any());
             }
         }
 
@@ -225,6 +231,31 @@ class CancelReservationServiceTest {
                         .isInstanceOf(ExpectedException.class).hasMessage("활성 예약만 취소할 수 있습니다")
                         .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
                                 .isEqualTo(HttpStatus.BAD_REQUEST));
+            }
+        }
+
+        @Nested
+        @DisplayName("이미 취소된 예약을 다시 취소하려 할 때")
+        class Context_with_cancelled_reservation {
+
+            @Test
+            @DisplayName("ExpectedException을 발생시키고 저장하지 않아야 한다")
+            void it_throws_bad_request_exception_without_saving() {
+                // Given
+                var userId = 1L;
+                var reservationId = 10L;
+                var reservation = createReservation(ReservationStatus.CANCELLED, userId);
+
+                given(currentUserProvider.getCurrentUserId()).willReturn(userId);
+                given(reservationRepository.findById(reservationId)).willReturn(Optional.of(reservation));
+
+                // When & Then
+                assertThatThrownBy(() -> cancelReservationService.execute(reservationId))
+                        .isInstanceOf(ExpectedException.class)
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.BAD_REQUEST));
+                then(reservationRepository).should(never()).save(any());
+                then(machineRepository).should(never()).save(any());
             }
         }
 

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/OverdueReservationProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/OverdueReservationProcessorTest.java
@@ -95,7 +95,7 @@ class OverdueReservationProcessorTest {
     }
 
     private void givenReservedReservation() {
-        when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
+        when(reservationRepository.findByIdForUpdate(RESERVATION_ID)).thenReturn(Optional.of(reservation));
         when(reservation.isReserved()).thenReturn(true);
         when(reservation.getMachine()).thenReturn(machine);
     }
@@ -236,7 +236,7 @@ class OverdueReservationProcessorTest {
         void shouldSkip_WhenNoLongerReserved() {
             // Given
             var deviceStatus = buildDeviceStatus(null);
-            when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
+            when(reservationRepository.findByIdForUpdate(RESERVATION_ID)).thenReturn(Optional.of(reservation));
             when(reservation.isReserved()).thenReturn(false);
 
             // When

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
@@ -105,7 +105,7 @@ class ReservationLifecycleProcessorTest {
             // Given
             var expectedCompletionTime = LocalDateTime.of(2026, 1, 27, 0, 30);
             var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
-            when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
+            when(reservationRepository.findByIdForUpdate(RESERVATION_ID)).thenReturn(Optional.of(reservation));
             when(reservation.isReserved()).thenReturn(true);
             when(reservation.getMachine()).thenReturn(machine);
             when(reservation.getUser()).thenReturn(user);
@@ -127,7 +127,7 @@ class ReservationLifecycleProcessorTest {
         void shouldNotStartReservation_WhenReservedButMachineNotRunning() {
             // Given
             var deviceStatus = buildDeviceStatus(null);
-            when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
+            when(reservationRepository.findByIdForUpdate(RESERVATION_ID)).thenReturn(Optional.of(reservation));
             when(reservation.isReserved()).thenReturn(true);
             when(reservation.getMachine()).thenReturn(machine);
             when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
@@ -147,7 +147,7 @@ class ReservationLifecycleProcessorTest {
             // Given
             var dryerCompletionTime = LocalDateTime.of(2026, 1, 27, 1, 0);
             var deviceStatus = buildStatusWithMixedCompletionTime("2026-01-26T15:30:00Z", "2026-01-26T16:00:00Z");
-            when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
+            when(reservationRepository.findByIdForUpdate(RESERVATION_ID)).thenReturn(Optional.of(reservation));
             when(reservation.isReserved()).thenReturn(true);
             when(reservation.getMachine()).thenReturn(machine);
             when(reservation.getUser()).thenReturn(user);
@@ -169,7 +169,7 @@ class ReservationLifecycleProcessorTest {
         void shouldSendStartedWithoutExpectedTime_WhenReportedCompletionTimeRejected() {
             // Given
             var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
-            when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
+            when(reservationRepository.findByIdForUpdate(RESERVATION_ID)).thenReturn(Optional.of(reservation));
             when(reservation.isReserved()).thenReturn(true);
             when(reservation.getMachine()).thenReturn(machine);
             when(reservation.getUser()).thenReturn(user);
@@ -190,7 +190,7 @@ class ReservationLifecycleProcessorTest {
         void shouldSkip_WhenNoLongerReserved() {
             // Given
             var deviceStatus = buildDeviceStatus(null);
-            when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
+            when(reservationRepository.findByIdForUpdate(RESERVATION_ID)).thenReturn(Optional.of(reservation));
             when(reservation.isReserved()).thenReturn(false);
 
             // When
@@ -207,7 +207,7 @@ class ReservationLifecycleProcessorTest {
     class ProcessRunningToCompletedTest {
 
         private void givenRunningReservation() {
-            when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
+            when(reservationRepository.findByIdForUpdate(RESERVATION_ID)).thenReturn(Optional.of(reservation));
             when(reservation.isRunning()).thenReturn(true);
             when(reservation.getMachine()).thenReturn(machine);
         }
@@ -545,7 +545,7 @@ class ReservationLifecycleProcessorTest {
         void shouldSkip_WhenNoLongerRunning() {
             // Given
             var deviceStatus = buildDeviceStatus(null);
-            when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
+            when(reservationRepository.findByIdForUpdate(RESERVATION_ID)).thenReturn(Optional.of(reservation));
             when(reservation.isRunning()).thenReturn(false);
 
             // When

--- a/src/test/java/team/washer/server/v2/domain/user/service/WithdrawUserServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/service/WithdrawUserServiceTest.java
@@ -97,13 +97,14 @@ class WithdrawUserServiceTest {
 
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
                 given(userRepository.findById(userId)).willReturn(Optional.of(user));
-                given(reservationRepository.findByUserAndStatusIn(user, ACTIVE_STATUSES)).willReturn(List.of());
+                given(reservationRepository.findByUserAndStatusInForUpdate(user, ACTIVE_STATUSES))
+                        .willReturn(List.of());
 
                 // When
                 withdrawUserService.execute();
 
                 // Then
-                then(reservationRepository).should(times(1)).findByUserAndStatusIn(user, ACTIVE_STATUSES);
+                then(reservationRepository).should(times(1)).findByUserAndStatusInForUpdate(user, ACTIVE_STATUSES);
                 then(machineRepository).should(never()).save(any(Machine.class));
                 then(refreshTokenRedisRepository).should(times(1)).deleteById(userId);
                 then(withdrawnStudentRedisUtil).should(times(1)).markWithdrawn(user.getStudentId());
@@ -126,7 +127,7 @@ class WithdrawUserServiceTest {
 
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
                 given(userRepository.findById(userId)).willReturn(Optional.of(user));
-                given(reservationRepository.findByUserAndStatusIn(user, ACTIVE_STATUSES))
+                given(reservationRepository.findByUserAndStatusInForUpdate(user, ACTIVE_STATUSES))
                         .willReturn(List.of(reservation));
 
                 // When
@@ -157,7 +158,7 @@ class WithdrawUserServiceTest {
 
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
                 given(userRepository.findById(userId)).willReturn(Optional.of(user));
-                given(reservationRepository.findByUserAndStatusIn(user, ACTIVE_STATUSES))
+                given(reservationRepository.findByUserAndStatusInForUpdate(user, ACTIVE_STATUSES))
                         .willReturn(List.of(reservation));
 
                 // When & Then
@@ -193,7 +194,7 @@ class WithdrawUserServiceTest {
 
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
                 given(userRepository.findById(userId)).willReturn(Optional.of(user));
-                given(reservationRepository.findByUserAndStatusIn(user, ACTIVE_STATUSES))
+                given(reservationRepository.findByUserAndStatusInForUpdate(user, ACTIVE_STATUSES))
                         .willReturn(List.of(reserved, running));
 
                 // When & Then
@@ -228,7 +229,7 @@ class WithdrawUserServiceTest {
                 assertThatThrownBy(() -> withdrawUserService.execute()).isInstanceOf(ExpectedException.class)
                         .hasMessage("사용자를 찾을 수 없습니다").hasFieldOrPropertyWithValue("statusCode", HttpStatus.NOT_FOUND);
 
-                then(reservationRepository).should(never()).findByUserAndStatusIn(any(User.class), anyList());
+                then(reservationRepository).should(never()).findByUserAndStatusInForUpdate(any(User.class), anyList());
                 then(refreshTokenRedisRepository).should(never()).deleteById(anyLong());
                 then(withdrawnStudentRedisUtil).should(never()).markWithdrawn(anyString());
                 then(userRepository).should(never()).delete(any(User.class));

--- a/src/test/java/team/washer/server/v2/domain/user/service/WithdrawUserServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/service/WithdrawUserServiceTest.java
@@ -37,6 +37,9 @@ import team.washer.server.v2.global.security.provider.CurrentUserProvider;
 @DisplayName("WithdrawUserServiceImpl 클래스의")
 class WithdrawUserServiceTest {
 
+    private static final List<ReservationStatus> ACTIVE_STATUSES = List.of(ReservationStatus.RESERVED,
+            ReservationStatus.RUNNING);
+
     @InjectMocks
     private WithdrawUserServiceImpl withdrawUserService;
 
@@ -70,6 +73,9 @@ class WithdrawUserServiceTest {
     }
 
     private Reservation createReservation(final ReservationStatus status, final User user, final Machine machine) {
+        if (status == ReservationStatus.RUNNING) {
+            machine.markAsInUse();
+        }
         return Reservation.builder().user(user).machine(machine).reservedAt(LocalDateTime.now())
                 .startTime(LocalDateTime.now().plusMinutes(10)).status(status).build();
     }
@@ -79,26 +85,25 @@ class WithdrawUserServiceTest {
     class Describe_execute {
 
         @Nested
-        @DisplayName("활성 예약이 없는 사용자가 탈퇴할 때")
+        @DisplayName("활성 예약이 없는 사용자가 탈퇴하면")
         class Context_without_active_reservations {
 
             @Test
-            @DisplayName("리프레시 토큰을 삭제하고 탈퇴 학번을 기록한 후 사용자를 삭제해야 한다")
+            @DisplayName("리프레시 토큰을 제거하고 탈퇴 학번을 기록한 뒤 사용자를 삭제해야 한다")
             void it_deletes_user_with_token_and_withdrawal_recorded() {
                 // Given
                 Long userId = 1L;
                 User user = createUser();
-                List<ReservationStatus> activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
 
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
                 given(userRepository.findById(userId)).willReturn(Optional.of(user));
-                given(reservationRepository.findByUserAndStatusIn(user, activeStatuses)).willReturn(List.of());
+                given(reservationRepository.findByUserAndStatusIn(user, ACTIVE_STATUSES)).willReturn(List.of());
 
                 // When
                 withdrawUserService.execute();
 
                 // Then
-                then(reservationRepository).should(times(1)).findByUserAndStatusIn(user, activeStatuses);
+                then(reservationRepository).should(times(1)).findByUserAndStatusIn(user, ACTIVE_STATUSES);
                 then(machineRepository).should(never()).save(any(Machine.class));
                 then(refreshTokenRedisRepository).should(times(1)).deleteById(userId);
                 then(withdrawnStudentRedisUtil).should(times(1)).markWithdrawn(user.getStudentId());
@@ -107,22 +112,21 @@ class WithdrawUserServiceTest {
         }
 
         @Nested
-        @DisplayName("RESERVED 상태의 예약이 있는 사용자가 탈퇴할 때")
+        @DisplayName("RESERVED 상태의 예약이 있는 사용자가 탈퇴하면")
         class Context_with_reserved_reservation {
 
             @Test
-            @DisplayName("예약을 패널티 없이 취소하고 기기를 AVAILABLE 상태로 변경한 후 사용자를 삭제해야 한다")
+            @DisplayName("예약을 취소하고 기기를 AVAILABLE 상태로 변경한 뒤 사용자를 삭제해야 한다")
             void it_cancels_reservation_and_deletes_user() {
                 // Given
                 Long userId = 1L;
                 User user = createUser();
                 Machine machine = createMachine();
                 Reservation reservation = createReservation(ReservationStatus.RESERVED, user, machine);
-                List<ReservationStatus> activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
 
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
                 given(userRepository.findById(userId)).willReturn(Optional.of(user));
-                given(reservationRepository.findByUserAndStatusIn(user, activeStatuses))
+                given(reservationRepository.findByUserAndStatusIn(user, ACTIVE_STATUSES))
                         .willReturn(List.of(reservation));
 
                 // When
@@ -139,44 +143,44 @@ class WithdrawUserServiceTest {
         }
 
         @Nested
-        @DisplayName("RUNNING 상태의 예약이 있는 사용자가 탈퇴할 때")
+        @DisplayName("RUNNING 상태의 예약이 있는 사용자가 탈퇴하면")
         class Context_with_running_reservation {
 
             @Test
-            @DisplayName("예약을 패널티 없이 취소하고 기기를 AVAILABLE 상태로 변경한 후 사용자를 삭제해야 한다")
-            void it_cancels_reservation_and_deletes_user() {
+            @DisplayName("예약과 기기 상태를 보존하고 CONFLICT 예외를 발생시켜야 한다")
+            void it_keeps_running_reservation_and_throws_conflict() {
                 // Given
                 Long userId = 1L;
                 User user = createUser();
                 Machine machine = createMachine();
                 Reservation reservation = createReservation(ReservationStatus.RUNNING, user, machine);
-                List<ReservationStatus> activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
 
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
                 given(userRepository.findById(userId)).willReturn(Optional.of(user));
-                given(reservationRepository.findByUserAndStatusIn(user, activeStatuses))
+                given(reservationRepository.findByUserAndStatusIn(user, ACTIVE_STATUSES))
                         .willReturn(List.of(reservation));
 
-                // When
-                withdrawUserService.execute();
+                // When & Then
+                assertThatThrownBy(() -> withdrawUserService.execute()).isInstanceOf(ExpectedException.class)
+                        .hasMessage("기기 사용 중에는 회원탈퇴를 할 수 없습니다. 사용 완료 후 다시 시도해주세요.")
+                        .hasFieldOrPropertyWithValue("statusCode", HttpStatus.CONFLICT);
 
-                // Then
-                assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
-                assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
-                then(machineRepository).should(times(1)).saveAll(anyList());
-                then(refreshTokenRedisRepository).should(times(1)).deleteById(userId);
-                then(withdrawnStudentRedisUtil).should(times(1)).markWithdrawn(user.getStudentId());
-                then(userRepository).should(times(1)).delete(user);
+                assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.RUNNING);
+                assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.IN_USE);
+                then(machineRepository).should(never()).saveAll(anyList());
+                then(refreshTokenRedisRepository).should(never()).deleteById(anyLong());
+                then(withdrawnStudentRedisUtil).should(never()).markWithdrawn(anyString());
+                then(userRepository).should(never()).delete(any(User.class));
             }
         }
 
         @Nested
-        @DisplayName("RESERVED와 RUNNING 예약이 동시에 있는 사용자가 탈퇴할 때")
+        @DisplayName("RESERVED와 RUNNING 예약이 동시에 있는 사용자가 탈퇴하면")
         class Context_with_multiple_active_reservations {
 
             @Test
-            @DisplayName("모든 활성 예약을 취소하고 사용자를 삭제해야 한다")
-            void it_cancels_all_reservations_and_deletes_user() {
+            @DisplayName("아무 예약도 변경하지 않고 CONFLICT 예외를 발생시켜야 한다")
+            void it_keeps_all_reservations_and_throws_conflict() {
                 // Given
                 Long userId = 1L;
                 User user = createUser();
@@ -186,34 +190,33 @@ class WithdrawUserServiceTest {
                         .availability(MachineAvailability.IN_USE).build();
                 Reservation reserved = createReservation(ReservationStatus.RESERVED, user, machine1);
                 Reservation running = createReservation(ReservationStatus.RUNNING, user, machine2);
-                List<ReservationStatus> activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
 
                 given(currentUserProvider.getCurrentUserId()).willReturn(userId);
                 given(userRepository.findById(userId)).willReturn(Optional.of(user));
-                given(reservationRepository.findByUserAndStatusIn(user, activeStatuses))
+                given(reservationRepository.findByUserAndStatusIn(user, ACTIVE_STATUSES))
                         .willReturn(List.of(reserved, running));
 
-                // When
-                withdrawUserService.execute();
+                // When & Then
+                assertThatThrownBy(() -> withdrawUserService.execute()).isInstanceOf(ExpectedException.class)
+                        .hasFieldOrPropertyWithValue("statusCode", HttpStatus.CONFLICT);
 
-                // Then
-                assertThat(reserved.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
-                assertThat(machine1.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
-                assertThat(running.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
-                assertThat(machine2.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
-                then(machineRepository).should(times(1)).saveAll(anyList());
-                then(refreshTokenRedisRepository).should(times(1)).deleteById(userId);
-                then(withdrawnStudentRedisUtil).should(times(1)).markWithdrawn(user.getStudentId());
-                then(userRepository).should(times(1)).delete(user);
+                assertThat(reserved.getStatus()).isEqualTo(ReservationStatus.RESERVED);
+                assertThat(machine1.getAvailability()).isEqualTo(MachineAvailability.RESERVED);
+                assertThat(running.getStatus()).isEqualTo(ReservationStatus.RUNNING);
+                assertThat(machine2.getAvailability()).isEqualTo(MachineAvailability.IN_USE);
+                then(machineRepository).should(never()).saveAll(anyList());
+                then(refreshTokenRedisRepository).should(never()).deleteById(anyLong());
+                then(withdrawnStudentRedisUtil).should(never()).markWithdrawn(anyString());
+                then(userRepository).should(never()).delete(any(User.class));
             }
         }
 
         @Nested
-        @DisplayName("존재하지 않는 사용자 ID로 요청할 때")
+        @DisplayName("존재하지 않는 사용자 ID로 요청하면")
         class Context_with_nonexistent_user_id {
 
             @Test
-            @DisplayName("ExpectedException을 던져야 한다")
+            @DisplayName("ExpectedException을 발생시켜야 한다")
             void it_throws_expected_exception() {
                 // Given
                 Long userId = 999L;


### PR DESCRIPTION
﻿## 개요

실행 중인 예약을 일반 취소 또는 회원탈퇴 경로에서 취소 처리하지 않도록 보호했습니다.
실제 기기가 동작 중인데 서버가 기기를 AVAILABLE로 돌리는 상태 불일치를 막습니다.

## 본문

- `CancelReservationServiceImpl`에서 RUNNING 예약 일반 취소를 CONFLICT로 처리하고 예약과 기기 상태를 보존했습니다.
- `WithdrawUserServiceImpl`에서 RUNNING 예약이 있으면 회원탈퇴 처리 전에 중단하도록 변경했습니다.
- RESERVED 취소, RUNNING 취소, 중복 취소, 회원탈퇴 회귀 테스트를 보강했습니다.

검증:
- `gradlew.bat test --tests team.washer.server.v2.domain.reservation.service.CancelReservationServiceTest --tests team.washer.server.v2.domain.user.service.WithdrawUserServiceTest`
- `gradlew.bat test`
- `gradlew.bat build`
