### PR TITLE
[reservation] 예약 시작 판정과 timeout 안정화

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/reservation/scheduler/ReservationLifecycleScheduler.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/scheduler/ReservationLifecycleScheduler.java
@@ -13,7 +13,7 @@ import team.washer.server.v2.global.thirdparty.smartthings.SmartThingsOperationT
 @Slf4j
 public class ReservationLifecycleScheduler {
 
-    private static final long LIFECYCLE_CHECK_INTERVAL = 10000;
+    private static final long LIFECYCLE_CHECK_INTERVAL = 30000;
 
     private final ProcessReservationLifecycleService processReservationLifecycleService;
     private final SmartThingsOperationTimePolicy operationTimePolicy;

--- a/src/main/java/team/washer/server/v2/domain/reservation/scheduler/ReservationLifecycleScheduler.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/scheduler/ReservationLifecycleScheduler.java
@@ -13,7 +13,7 @@ import team.washer.server.v2.global.thirdparty.smartthings.SmartThingsOperationT
 @Slf4j
 public class ReservationLifecycleScheduler {
 
-    private static final long LIFECYCLE_CHECK_INTERVAL = 30000;
+    private static final long LIFECYCLE_CHECK_INTERVAL = 10000;
 
     private final ProcessReservationLifecycleService processReservationLifecycleService;
     private final SmartThingsOperationTimePolicy operationTimePolicy;

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CancelOverdueReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CancelOverdueReservationServiceImpl.java
@@ -41,7 +41,7 @@ public class CancelOverdueReservationServiceImpl implements CancelOverdueReserva
                 var result = overdueReservationProcessor.processOverdue(target.reservationId(), status);
                 switch (result) {
                     case AUTO_STARTED -> autoStarted.add(target.reservationId());
-                    case CANCELLED -> cancelled.add(target.reservationId());
+                    case CANCELLED, CANCELLED_WITHOUT_PENALTY -> cancelled.add(target.reservationId());
                     case SKIPPED -> {
                     }
                 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/OverdueReservationProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/OverdueReservationProcessor.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.notification.support.ReservationNotificationSupport;
+import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.reservation.support.ReservationStartDecisionSupport;
@@ -19,6 +20,7 @@ import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.global.common.constants.PenaltyConstants;
+import team.washer.server.v2.global.common.constants.ReservationConstants;
 import team.washer.server.v2.global.util.DateTimeUtil;
 
 /**
@@ -51,7 +53,7 @@ public class OverdueReservationProcessor {
      * 개별 만료 예약 처리 결과. 호출 측의 요약 로그 집계에 사용한다.
      */
     public enum OverdueResult {
-        AUTO_STARTED, CANCELLED, SKIPPED
+        AUTO_STARTED, CANCELLED, CANCELLED_WITHOUT_PENALTY, SKIPPED
     }
 
     /**
@@ -93,6 +95,15 @@ public class OverdueReservationProcessor {
             return OverdueResult.AUTO_STARTED;
         }
         if (startDecision == StartDecision.UNKNOWN) {
+            if (canCancelUnknownReservation(reservation)) {
+                reservation.cancel();
+                machine.markAsAvailable();
+                reservationRepository.save(reservation);
+                machineRepository.save(machine);
+                log.warn("reservation timeout cancelled without penalty due to unknown start state reservationId={}",
+                        reservationId);
+                return OverdueResult.CANCELLED_WITHOUT_PENALTY;
+            }
             log.warn("reservation timeout deferred due to unknown start state reservationId={}", reservationId);
             return OverdueResult.SKIPPED;
         }
@@ -104,6 +115,12 @@ public class OverdueReservationProcessor {
 
         applyTimeoutPenalty(reservation.getUser(), machine);
         return OverdueResult.CANCELLED;
+    }
+
+    private boolean canCancelUnknownReservation(Reservation reservation) {
+        var unknownDeadline = reservation.getReservedAt().plusMinutes(ReservationStatus.RESERVED.getTimeoutMinutes()
+                + ReservationConstants.UNKNOWN_START_DECISION_GRACE_MINUTES);
+        return !DateTimeUtil.nowInKorea().isBefore(unknownDeadline);
     }
 
     /**

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/OverdueReservationProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/OverdueReservationProcessor.java
@@ -13,9 +13,10 @@ import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.notification.support.ReservationNotificationSupport;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.reservation.support.ReservationStartDecisionSupport;
+import team.washer.server.v2.domain.reservation.support.ReservationStartDecisionSupport.StartDecision;
 import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
-import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.global.common.constants.PenaltyConstants;
 import team.washer.server.v2.global.util.DateTimeUtil;
@@ -38,7 +39,7 @@ public class OverdueReservationProcessor {
     private final MachineRepository machineRepository;
     private final PenaltyRedisUtil penaltyRedisUtil;
     private final ReservationNotificationSupport reservationNotificationSupport;
-    private final MachineStateDetectionSupport machineStateDetectionSupport;
+    private final ReservationStartDecisionSupport reservationStartDecisionSupport;
 
     /**
      * 외부 API 호출 대상이 되는 만료 예약의 식별자와 기기 ID 쌍.
@@ -80,7 +81,8 @@ public class OverdueReservationProcessor {
         }
         var machine = reservation.getMachine();
 
-        if (machineStateDetectionSupport.isRunning(status, machine.isWasher())) {
+        var startDecision = reservationStartDecisionSupport.decide(status, machine.isWasher());
+        if (startDecision == StartDecision.STARTED) {
             var expectedCompletionTime = DateTimeUtil
                     .parseAndConvertToKoreaTime(status.getCompletionTime(machine.isWasher()));
             reservation.start(expectedCompletionTime);
@@ -89,6 +91,10 @@ public class OverdueReservationProcessor {
             machineRepository.save(machine);
             reservationNotificationSupport.sendStarted(reservation.getUser(), machine, expectedCompletionTime);
             return OverdueResult.AUTO_STARTED;
+        }
+        if (startDecision == StartDecision.UNKNOWN) {
+            log.warn("reservation timeout deferred due to unknown start state reservationId={}", reservationId);
+            return OverdueResult.SKIPPED;
         }
 
         reservation.cancel();

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
@@ -18,6 +18,7 @@ import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.reservation.support.CompletionDecision;
 import team.washer.server.v2.domain.reservation.support.ReservationCompletionDecisionSupport;
+import team.washer.server.v2.domain.reservation.support.ReservationStartDecisionSupport;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 import team.washer.server.v2.global.common.constants.ReservationConstants;
@@ -45,6 +46,7 @@ public class ReservationLifecycleProcessor {
     private final MachineRepository machineRepository;
     private final MachineStateDetectionSupport machineStateDetectionSupport;
     private final ReservationCompletionDecisionSupport completionDecisionSupport;
+    private final ReservationStartDecisionSupport reservationStartDecisionSupport;
     private final ReservationNotificationSupport reservationNotificationSupport;
 
     /**
@@ -74,7 +76,7 @@ public class ReservationLifecycleProcessor {
             return;
         }
         var machine = reservation.getMachine();
-        if (!machineStateDetectionSupport.isRunning(status, machine.isWasher())) {
+        if (!reservationStartDecisionSupport.isStarted(status, machine.isWasher())) {
             return;
         }
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationStartDecisionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationStartDecisionSupport.java
@@ -1,0 +1,86 @@
+package team.washer.server.v2.domain.reservation.support;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+import org.springframework.stereotype.Component;
+
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
+import team.washer.server.v2.global.util.DateTimeUtil;
+
+/**
+ * RESERVED 예약을 RUNNING으로 전환해도 되는지 판정하는 단일 진입점.
+ *
+ * <p>
+ * 라이프사이클 감지와 타임아웃 보정이 같은 입력에 다른 결론을 내리지 않도록 시작 판정을 이 컴포넌트로 모은다. 완료 판정은 다루지 않으며,
+ * 상태를 확신할 수 없는 경우에는 IDLE로 단정하지 않는다.
+ */
+@Component
+@Slf4j
+public class ReservationStartDecisionSupport {
+
+    private static final Set<String> WASHER_ACTIVE_JOB_STATES = Set.of("wash", "rinse", "spin");
+    private static final Set<String> DRYER_ACTIVE_JOB_STATES = Set.of("drying", "cooling");
+
+    public enum StartDecision {
+        STARTED, IDLE, UNKNOWN
+    }
+
+    /**
+     * SmartThings 상태를 바탕으로 예약 시작 여부를 판정한다.
+     */
+    public StartDecision decide(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        if (status == null) {
+            return StartDecision.UNKNOWN;
+        }
+        if (status.isSwitchOff()) {
+            return StartDecision.IDLE;
+        }
+
+        var operatingState = status.getOperatingState(isWasher);
+        if (operatingState.isOperating()) {
+            log.debug("reservation start detected by machineState isWasher={} machineState={}",
+                    isWasher,
+                    operatingState);
+            return StartDecision.STARTED;
+        }
+        if (operatingState == MachineOperatingState.STOP) {
+            return StartDecision.IDLE;
+        }
+
+        var jobState = status.getJobState(isWasher);
+        if (isActiveJobState(jobState, isWasher)) {
+            log.debug("reservation start detected by jobState isWasher={} jobState={}", isWasher, jobState);
+            return StartDecision.STARTED;
+        }
+
+        var completionTime = parseCompletionTime(status.getCompletionTime(isWasher));
+        if (completionTime != null && completionTime.isAfter(DateTimeUtil.nowInKorea())) {
+            log.debug("reservation start detected by completionTime isWasher={} completionTime={}",
+                    isWasher,
+                    completionTime);
+            return StartDecision.STARTED;
+        }
+        return StartDecision.UNKNOWN;
+    }
+
+    public boolean isStarted(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        return decide(status, isWasher) == StartDecision.STARTED;
+    }
+
+    private boolean isActiveJobState(String jobState, boolean isWasher) {
+        if (jobState == null || jobState.isBlank()) {
+            return false;
+        }
+        var activeJobStates = isWasher ? WASHER_ACTIVE_JOB_STATES : DRYER_ACTIVE_JOB_STATES;
+        return activeJobStates.stream().anyMatch(jobState::equalsIgnoreCase);
+    }
+
+    private LocalDateTime parseCompletionTime(String completionTimeStr) {
+        return (completionTimeStr != null && !completionTimeStr.isBlank())
+                ? DateTimeUtil.parseAndConvertToKoreaTime(completionTimeStr)
+                : null;
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationStartDecisionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationStartDecisionSupport.java
@@ -1,28 +1,28 @@
 package team.washer.server.v2.domain.reservation.support;
 
-import java.time.LocalDateTime;
-import java.util.Set;
-
 import org.springframework.stereotype.Component;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
-import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
+import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 import team.washer.server.v2.global.util.DateTimeUtil;
 
 /**
  * RESERVED 예약을 RUNNING으로 전환해도 되는지 판정하는 단일 진입점.
  *
  * <p>
- * 라이프사이클 감지와 타임아웃 보정이 같은 입력에 다른 결론을 내리지 않도록 시작 판정을 이 컴포넌트로 모은다. 완료 판정은 다루지 않으며,
- * 상태를 확신할 수 없는 경우에는 IDLE로 단정하지 않는다.
+ * 라이프사이클 감지와 타임아웃 보정이 같은 입력에 다른 결론을 내리지 않도록 시작 판정을 이 컴포넌트로 모은다. 기기 상태의 원시 해석은
+ * {@link MachineStateDetectionSupport}와 {@link SmartThingsDeviceStatusResDto}에
+ * 위임하고, 이 컴포넌트는 예약 시작 여부만 판단한다. 완료 판정은 다루지 않으며, 상태를 확신할 수 없는 경우에는 IDLE로 단정하지
+ * 않는다.
  */
 @Component
+@RequiredArgsConstructor
 @Slf4j
 public class ReservationStartDecisionSupport {
 
-    private static final Set<String> WASHER_ACTIVE_JOB_STATES = Set.of("wash", "rinse", "spin");
-    private static final Set<String> DRYER_ACTIVE_JOB_STATES = Set.of("drying", "cooling");
+    private final MachineStateDetectionSupport machineStateDetectionSupport;
 
     public enum StartDecision {
         STARTED, IDLE, UNKNOWN
@@ -35,52 +35,40 @@ public class ReservationStartDecisionSupport {
         if (status == null) {
             return StartDecision.UNKNOWN;
         }
-        if (status.isSwitchOff()) {
+        if (machineStateDetectionSupport.isPoweredOff(status)) {
             return StartDecision.IDLE;
         }
-
-        var operatingState = status.getOperatingState(isWasher);
-        if (operatingState.isOperating()) {
-            log.debug("reservation start detected by machineState isWasher={} machineState={}",
-                    isWasher,
-                    operatingState);
+        if (machineStateDetectionSupport.isRunning(status, isWasher)) {
+            log.debug("reservation start detected by running machineState isWasher={}", isWasher);
             return StartDecision.STARTED;
         }
-        if (operatingState == MachineOperatingState.STOP) {
+        if (machineStateDetectionSupport.isPaused(status, isWasher)) {
+            log.debug("reservation start detected by paused machineState isWasher={}", isWasher);
+            return StartDecision.STARTED;
+        }
+        if (machineStateDetectionSupport.isStopped(status, isWasher)) {
             return StartDecision.IDLE;
         }
-
-        var jobState = status.getJobState(isWasher);
-        if (isActiveJobState(jobState, isWasher)) {
-            log.debug("reservation start detected by jobState isWasher={} jobState={}", isWasher, jobState);
-            return StartDecision.STARTED;
-        }
-
-        var completionTime = parseCompletionTime(status.getCompletionTime(isWasher));
-        if (completionTime != null && completionTime.isAfter(DateTimeUtil.nowInKorea())) {
-            log.debug("reservation start detected by completionTime isWasher={} completionTime={}",
+        if (status.isJobStateActive(isWasher)) {
+            log.debug("reservation start detected by jobState isWasher={} jobState={}",
                     isWasher,
-                    completionTime);
+                    status.getJobState(isWasher));
             return StartDecision.STARTED;
         }
-        return StartDecision.UNKNOWN;
+
+        return machineStateDetectionSupport.resolveCompletionTime(status, isWasher)
+                .filter(completionTime -> completionTime.isAfter(DateTimeUtil.nowInKorea())).map(completionTime -> {
+                    log.debug("reservation start detected by completionTime isWasher={} completionTime={}",
+                            isWasher,
+                            completionTime);
+                    return StartDecision.STARTED;
+                }).orElse(StartDecision.UNKNOWN);
     }
 
+    /**
+     * 예약이 시작된 것으로 확정할 수 있는지 반환한다.
+     */
     public boolean isStarted(SmartThingsDeviceStatusResDto status, boolean isWasher) {
         return decide(status, isWasher) == StartDecision.STARTED;
-    }
-
-    private boolean isActiveJobState(String jobState, boolean isWasher) {
-        if (jobState == null || jobState.isBlank()) {
-            return false;
-        }
-        var activeJobStates = isWasher ? WASHER_ACTIVE_JOB_STATES : DRYER_ACTIVE_JOB_STATES;
-        return activeJobStates.stream().anyMatch(jobState::equalsIgnoreCase);
-    }
-
-    private LocalDateTime parseCompletionTime(String completionTimeStr) {
-        return (completionTimeStr != null && !completionTimeStr.isBlank())
-                ? DateTimeUtil.parseAndConvertToKoreaTime(completionTimeStr)
-                : null;
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationStartDecisionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationStartDecisionSupport.java
@@ -46,9 +46,6 @@ public class ReservationStartDecisionSupport {
             log.debug("reservation start detected by paused machineState isWasher={}", isWasher);
             return StartDecision.STARTED;
         }
-        if (machineStateDetectionSupport.isStopped(status, isWasher)) {
-            return StartDecision.IDLE;
-        }
         if (status.isJobStateActive(isWasher)) {
             log.debug("reservation start detected by jobState isWasher={} jobState={}",
                     isWasher,
@@ -56,13 +53,22 @@ public class ReservationStartDecisionSupport {
             return StartDecision.STARTED;
         }
 
-        return machineStateDetectionSupport.resolveCompletionTime(status, isWasher)
+        var completionTimeDecision = machineStateDetectionSupport.resolveCompletionTime(status, isWasher)
                 .filter(completionTime -> completionTime.isAfter(DateTimeUtil.nowInKorea())).map(completionTime -> {
                     log.debug("reservation start detected by completionTime isWasher={} completionTime={}",
                             isWasher,
                             completionTime);
                     return StartDecision.STARTED;
                 }).orElse(StartDecision.UNKNOWN);
+        if (completionTimeDecision == StartDecision.STARTED) {
+            return StartDecision.STARTED;
+        }
+
+        if (machineStateDetectionSupport.isStopped(status, isWasher)) {
+            return StartDecision.IDLE;
+        }
+
+        return StartDecision.UNKNOWN;
     }
 
     /**

--- a/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsDeviceStatusResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/dto/response/SmartThingsDeviceStatusResDto.java
@@ -1,5 +1,6 @@
 package team.washer.server.v2.domain.smartthings.dto.response;
 
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -17,6 +18,8 @@ public record SmartThingsDeviceStatusResDto(
     private static final String DRYER_FINISHED_JOB_STATE = "finished";
     private static final String IDLE_JOB_STATE = "none";
     private static final String SWITCH_OFF = "off";
+    private static final List<String> WASHER_ACTIVE_JOB_STATES = List.of("wash", "rinse", "spin");
+    private static final List<String> DRYER_ACTIVE_JOB_STATES = List.of("drying", "cooling");
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record ComponentStatus(@JsonProperty("washerOperatingState") WasherOperatingState washerOperatingState,
@@ -218,6 +221,18 @@ public record SmartThingsDeviceStatusResDto(
     public boolean isJobStateFinished(boolean isWasher) {
         return (isWasher ? WASHER_FINISHED_JOB_STATE : DRYER_FINISHED_JOB_STATE)
                 .equalsIgnoreCase(getJobState(isWasher));
+    }
+
+    /**
+     * jobState가 사이클 진행 중을 뜻하는 값인지 여부 반환. 세탁기는 wash/rinse/spin, 건조기는 drying/cooling을
+     * 진행 신호로 본다.
+     */
+    public boolean isJobStateActive(boolean isWasher) {
+        var jobState = getJobState(isWasher);
+        if (jobState == null || jobState.isBlank()) {
+            return false;
+        }
+        return (isWasher ? WASHER_ACTIVE_JOB_STATES : DRYER_ACTIVE_JOB_STATES).contains(jobState.toLowerCase());
     }
 
     /** 기기 전원이 꺼진 상태(switch=off)인지 여부 반환 */

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
@@ -42,6 +42,27 @@ public class MachineStateDetectionSupport {
     }
 
     /**
+     * 기기가 물리적으로 정지 상태인지 감지한다.
+     */
+    public boolean isStopped(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        return status != null && status.getOperatingState(isWasher) == MachineOperatingState.STOP;
+    }
+
+    /**
+     * 기기가 보고한 완료 예정 시각을 한국 시간으로 변환한다. 값이 없거나 파싱할 수 없으면 빈 값을 반환한다.
+     */
+    public Optional<LocalDateTime> resolveCompletionTime(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        if (status == null) {
+            return Optional.empty();
+        }
+        var completionTimeStr = status.getCompletionTime(isWasher);
+        if (completionTimeStr == null || completionTimeStr.isBlank()) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(DateTimeUtil.parseAndConvertToKoreaTime(completionTimeStr));
+    }
+
+    /**
      * 기기 작업이 완료되었는지 감지하고, 완료된 경우 완료 시각을 반환한다.
      *
      * <p>
@@ -55,7 +76,7 @@ public class MachineStateDetectionSupport {
             return Optional.empty();
         }
         var now = DateTimeUtil.nowInKorea();
-        if (status.getOperatingState(isWasher) != MachineOperatingState.STOP) {
+        if (!isStopped(status, isWasher)) {
             if (status.isJobStateFinished(isWasher)) {
                 log.debug("job finished but machine not stopped yet machineState={} jobState={}",
                         status.getOperatingState(isWasher),
@@ -64,10 +85,7 @@ public class MachineStateDetectionSupport {
             return Optional.empty();
         }
 
-        var completionTimeStr = status.getCompletionTime(isWasher);
-        var completionTime = (completionTimeStr != null && !completionTimeStr.isBlank())
-                ? DateTimeUtil.parseAndConvertToKoreaTime(completionTimeStr)
-                : null;
+        var completionTime = resolveCompletionTime(status, isWasher).orElse(null);
         if (status.isJobStateFinished(isWasher)) {
             log.debug("device job is completed jobState={} completionTime={}",
                     status.getJobState(isWasher),

--- a/src/main/java/team/washer/server/v2/global/common/constants/ReservationConstants.java
+++ b/src/main/java/team/washer/server/v2/global/common/constants/ReservationConstants.java
@@ -8,6 +8,12 @@ public final class ReservationConstants {
     public static final int PAUSE_TIMEOUT_MINUTES = 10;
 
     /**
+     * 예약 만료 후에도 기기 시작 여부를 확정할 수 없을 때 추가로 보류하는 시간(분). SmartThings capability 누락을 곧바로
+     * 미사용으로 단정하지 않되, RESERVED 상태가 영구히 남지 않도록 절대 상한을 둔다.
+     */
+    public static final int UNKNOWN_START_DECISION_GRACE_MINUTES = 10;
+
+    /**
      * 비정상 중단을 확정하기 전까지 연속으로 중단이 감지되어야 하는 폴링 횟수. 사이클 단계 전환 중 순간적으로 보고되는 정지를 진짜 중단으로
      * 오판하지 않도록 디바운스하는 데 사용한다. 라이프사이클 폴링 주기(30초) 기준 약 90초 연속 정지 시 확정된다.
      */

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/OverdueReservationProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/OverdueReservationProcessorTest.java
@@ -26,6 +26,7 @@ import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.notification.support.ReservationNotificationSupport;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.reservation.service.impl.OverdueReservationProcessor;
 import team.washer.server.v2.domain.reservation.service.impl.OverdueReservationProcessor.OverdueResult;
@@ -34,6 +35,8 @@ import team.washer.server.v2.domain.reservation.support.ReservationStartDecision
 import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.global.common.constants.ReservationConstants;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("OverdueReservationProcessor 개별 만료 예약 처리")
@@ -258,11 +261,13 @@ class OverdueReservationProcessorTest {
     class MachineStateUnknown {
 
         @Test
-        @DisplayName("예약을 취소하거나 패널티를 적용하지 않고 SKIPPED를 반환한다")
-        void shouldSkipWithoutPenalty_WhenStartDecisionUnknown() {
+        @DisplayName("추가 보류 시간 안이면 예약을 취소하거나 패널티를 적용하지 않고 SKIPPED를 반환한다")
+        void shouldSkipWithoutPenalty_WhenStartDecisionUnknownWithinGrace() {
             // Given
             var deviceStatus = buildDeviceStatus(null);
             givenReservedReservation();
+            when(reservation.getReservedAt()).thenReturn(DateTimeUtil.nowInKorea()
+                    .minusMinutes(ReservationConstants.UNKNOWN_START_DECISION_GRACE_MINUTES + 4L));
             when(reservationStartDecisionSupport.decide(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(StartDecision.UNKNOWN);
 
@@ -275,6 +280,33 @@ class OverdueReservationProcessorTest {
             verify(reservation, never()).cancel();
             verify(reservationRepository, never()).save(any());
             verify(machineRepository, never()).save(any());
+            verify(penaltyRedisUtil, never()).applyCooldown(any(), any());
+            verify(penaltyRedisUtil, never()).recordCancellation(any());
+            verify(reservationNotificationSupport, never()).sendAutoCancellation(any(), any());
+            verify(reservationNotificationSupport, never()).sendTimeoutWarning(any(), any());
+        }
+
+        @Test
+        @DisplayName("추가 보류 시간을 넘긴 UNKNOWN 예약은 패널티 없이 정리한다")
+        void shouldCancelWithoutPenalty_WhenStartDecisionUnknownAfterGrace() {
+            // Given
+            var deviceStatus = buildDeviceStatus(null);
+            givenReservedReservation();
+            when(reservation.getReservedAt())
+                    .thenReturn(DateTimeUtil.nowInKorea().minusMinutes(ReservationStatus.RESERVED.getTimeoutMinutes()
+                            + ReservationConstants.UNKNOWN_START_DECISION_GRACE_MINUTES + 1L));
+            when(reservationStartDecisionSupport.decide(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(StartDecision.UNKNOWN);
+
+            // When
+            var result = overdueReservationProcessor.processOverdue(RESERVATION_ID, deviceStatus);
+
+            // Then
+            assertThat(result).isEqualTo(OverdueResult.CANCELLED_WITHOUT_PENALTY);
+            verify(reservation, times(1)).cancel();
+            verify(machine, times(1)).markAsAvailable();
+            verify(reservationRepository, times(1)).save(reservation);
+            verify(machineRepository, times(1)).save(machine);
             verify(penaltyRedisUtil, never()).applyCooldown(any(), any());
             verify(penaltyRedisUtil, never()).recordCancellation(any());
             verify(reservationNotificationSupport, never()).sendAutoCancellation(any(), any());

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/OverdueReservationProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/OverdueReservationProcessorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -28,9 +29,10 @@ import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.reservation.service.impl.OverdueReservationProcessor;
 import team.washer.server.v2.domain.reservation.service.impl.OverdueReservationProcessor.OverdueResult;
+import team.washer.server.v2.domain.reservation.support.ReservationStartDecisionSupport;
+import team.washer.server.v2.domain.reservation.support.ReservationStartDecisionSupport.StartDecision;
 import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
-import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 import team.washer.server.v2.domain.user.entity.User;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,7 +57,7 @@ class OverdueReservationProcessorTest {
     private ReservationNotificationSupport reservationNotificationSupport;
 
     @Mock
-    private MachineStateDetectionSupport machineStateDetectionSupport;
+    private ReservationStartDecisionSupport reservationStartDecisionSupport;
 
     @Mock
     private Reservation reservation;
@@ -111,8 +113,8 @@ class OverdueReservationProcessorTest {
             var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
             givenReservedReservation();
             when(reservation.getUser()).thenReturn(user);
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(true);
+            when(reservationStartDecisionSupport.decide(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(StartDecision.STARTED);
 
             // When
             var result = overdueReservationProcessor.processOverdue(RESERVATION_ID, deviceStatus);
@@ -135,8 +137,8 @@ class OverdueReservationProcessorTest {
             givenReservedReservation();
             when(reservation.getUser()).thenReturn(user);
             when(machine.isWasher()).thenReturn(false);
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(true);
+            when(reservationStartDecisionSupport.decide(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(StartDecision.STARTED);
 
             // When
             var result = overdueReservationProcessor.processOverdue(RESERVATION_ID, deviceStatus);
@@ -146,6 +148,30 @@ class OverdueReservationProcessorTest {
             verify(reservation, times(1)).start(LocalDateTime.of(2026, 1, 27, 1, 0));
             verify(reservationNotificationSupport, times(1))
                     .sendStarted(user, machine, LocalDateTime.of(2026, 1, 27, 1, 0));
+        }
+
+        @Test
+        @DisplayName("완료 예정 시간이 없어도 실행 신호가 있으면 타임아웃 취소와 패널티를 적용하지 않는다")
+        void shouldAutoStartWithoutPenalty_WhenRunningSignalExistsButCompletionTimeNull() {
+            // Given
+            var deviceStatus = buildDeviceStatus(null);
+            givenReservedReservation();
+            when(reservation.getUser()).thenReturn(user);
+            when(reservationStartDecisionSupport.decide(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(StartDecision.STARTED);
+
+            // When
+            var result = overdueReservationProcessor.processOverdue(RESERVATION_ID, deviceStatus);
+
+            // Then
+            assertThat(result).isEqualTo(OverdueResult.AUTO_STARTED);
+            verify(reservation, times(1)).start(isNull());
+            verify(reservation, never()).cancel();
+            verify(machine, times(1)).markAsInUse();
+            verify(machineRepository, times(1)).save(machine);
+            verify(penaltyRedisUtil, never()).applyCooldown(any(), any());
+            verify(penaltyRedisUtil, never()).recordCancellation(any());
+            verify(reservationNotificationSupport, times(1)).sendStarted(user, machine, null);
         }
     }
 
@@ -159,8 +185,8 @@ class OverdueReservationProcessorTest {
             // Given
             var deviceStatus = buildDeviceStatus(null);
             givenReservedReservation();
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(false);
+            when(reservationStartDecisionSupport.decide(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(StartDecision.IDLE);
             when(reservation.getUser()).thenReturn(user);
             when(user.getId()).thenReturn(1L);
             when(penaltyRedisUtil.hasWarning(1L)).thenReturn(false);
@@ -187,8 +213,8 @@ class OverdueReservationProcessorTest {
             // Given
             var deviceStatus = buildDeviceStatus(null);
             givenReservedReservation();
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(false);
+            when(reservationStartDecisionSupport.decide(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(StartDecision.IDLE);
             when(reservation.getUser()).thenReturn(user);
             when(user.getId()).thenReturn(1L);
             when(penaltyRedisUtil.hasWarning(1L)).thenReturn(true);
@@ -211,8 +237,8 @@ class OverdueReservationProcessorTest {
             // Given
             var deviceStatus = buildDeviceStatus(null);
             givenReservedReservation();
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
-                    .thenReturn(false);
+            when(reservationStartDecisionSupport.decide(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(StartDecision.IDLE);
             when(reservation.getUser()).thenReturn(user);
             when(user.getId()).thenReturn(1L);
             when(user.getRoomNumber()).thenReturn("101");
@@ -224,6 +250,35 @@ class OverdueReservationProcessorTest {
 
             // Then
             verify(penaltyRedisUtil, times(1)).applyBlock("101");
+        }
+    }
+
+    @Nested
+    @DisplayName("기기 시작 여부를 확신할 수 없으면")
+    class MachineStateUnknown {
+
+        @Test
+        @DisplayName("예약을 취소하거나 패널티를 적용하지 않고 SKIPPED를 반환한다")
+        void shouldSkipWithoutPenalty_WhenStartDecisionUnknown() {
+            // Given
+            var deviceStatus = buildDeviceStatus(null);
+            givenReservedReservation();
+            when(reservationStartDecisionSupport.decide(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(StartDecision.UNKNOWN);
+
+            // When
+            var result = overdueReservationProcessor.processOverdue(RESERVATION_ID, deviceStatus);
+
+            // Then
+            assertThat(result).isEqualTo(OverdueResult.SKIPPED);
+            verify(reservation, never()).start(any());
+            verify(reservation, never()).cancel();
+            verify(reservationRepository, never()).save(any());
+            verify(machineRepository, never()).save(any());
+            verify(penaltyRedisUtil, never()).applyCooldown(any(), any());
+            verify(penaltyRedisUtil, never()).recordCancellation(any());
+            verify(reservationNotificationSupport, never()).sendAutoCancellation(any(), any());
+            verify(reservationNotificationSupport, never()).sendTimeoutWarning(any(), any());
         }
     }
 

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
@@ -28,6 +28,7 @@ import team.washer.server.v2.domain.reservation.repository.ReservationRepository
 import team.washer.server.v2.domain.reservation.service.impl.ReservationLifecycleProcessor;
 import team.washer.server.v2.domain.reservation.support.CompletionDecision;
 import team.washer.server.v2.domain.reservation.support.ReservationCompletionDecisionSupport;
+import team.washer.server.v2.domain.reservation.support.ReservationStartDecisionSupport;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 import team.washer.server.v2.domain.user.entity.User;
@@ -54,6 +55,9 @@ class ReservationLifecycleProcessorTest {
 
     @Mock
     private ReservationCompletionDecisionSupport completionDecisionSupport;
+
+    @Mock
+    private ReservationStartDecisionSupport reservationStartDecisionSupport;
 
     @Mock
     private ReservationNotificationSupport reservationNotificationSupport;
@@ -110,7 +114,7 @@ class ReservationLifecycleProcessorTest {
             when(reservation.getMachine()).thenReturn(machine);
             when(reservation.getUser()).thenReturn(user);
             when(reservation.getExpectedCompletionTime()).thenReturn(expectedCompletionTime);
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+            when(reservationStartDecisionSupport.isStarted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(true);
 
             // When
@@ -130,7 +134,7 @@ class ReservationLifecycleProcessorTest {
             when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
             when(reservation.isReserved()).thenReturn(true);
             when(reservation.getMachine()).thenReturn(machine);
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+            when(reservationStartDecisionSupport.isStarted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(false);
 
             // When
@@ -153,7 +157,7 @@ class ReservationLifecycleProcessorTest {
             when(reservation.getUser()).thenReturn(user);
             when(reservation.getExpectedCompletionTime()).thenReturn(dryerCompletionTime);
             when(machine.isWasher()).thenReturn(false);
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+            when(reservationStartDecisionSupport.isStarted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(true);
 
             // When
@@ -174,7 +178,7 @@ class ReservationLifecycleProcessorTest {
             when(reservation.getMachine()).thenReturn(machine);
             when(reservation.getUser()).thenReturn(user);
             when(reservation.getExpectedCompletionTime()).thenReturn(null);
-            when(machineStateDetectionSupport.isRunning(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+            when(reservationStartDecisionSupport.isStarted(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
                     .thenReturn(true);
 
             // When

--- a/src/test/java/team/washer/server/v2/domain/reservation/support/ReservationStartDecisionSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/support/ReservationStartDecisionSupportTest.java
@@ -88,6 +88,14 @@ class ReservationStartDecisionSupportTest {
         }
 
         @Test
+        @DisplayName("machineState=stop이어도 active jobState가 있으면 STARTED를 반환한다")
+        void shouldStart_WhenStoppedButActiveJobStateExists() {
+            var status = washerStatus("stop", "wash", null);
+
+            assertThat(reservationStartDecisionSupport.decide(status, WASHER)).isEqualTo(StartDecision.STARTED);
+        }
+
+        @Test
         @DisplayName("건조기 active jobState가 있으면 STARTED를 반환한다")
         void shouldStartDryer_WhenActiveJobStateExists() {
             var status = dryerStatus(null, "drying", null);

--- a/src/test/java/team/washer/server/v2/domain/reservation/support/ReservationStartDecisionSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/support/ReservationStartDecisionSupportTest.java
@@ -17,6 +17,7 @@ import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceSt
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.DryerOperatingState;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.SwitchCapability;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.WasherOperatingState;
+import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 
 @DisplayName("ReservationStartDecisionSupport 시작 판정")
 class ReservationStartDecisionSupportTest {
@@ -24,7 +25,8 @@ class ReservationStartDecisionSupportTest {
     private static final boolean WASHER = true;
     private static final boolean DRYER = false;
 
-    private final ReservationStartDecisionSupport reservationStartDecisionSupport = new ReservationStartDecisionSupport();
+    private final ReservationStartDecisionSupport reservationStartDecisionSupport = new ReservationStartDecisionSupport(
+            new MachineStateDetectionSupport());
 
     private static String isoUtc(ZonedDateTime koreaTime) {
         return koreaTime.withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime().toString() + "Z";
@@ -65,6 +67,14 @@ class ReservationStartDecisionSupportTest {
         @DisplayName("machineState=run이면 STARTED를 반환한다")
         void shouldStart_WhenMachineStateRun() {
             var status = washerStatus("run", "wash", null);
+
+            assertThat(reservationStartDecisionSupport.decide(status, WASHER)).isEqualTo(StartDecision.STARTED);
+        }
+
+        @Test
+        @DisplayName("machineState=pause이면 이미 실제 사이클이 시작된 것으로 보고 STARTED를 반환한다")
+        void shouldStart_WhenMachineStatePause() {
+            var status = washerStatus("pause", null, null);
 
             assertThat(reservationStartDecisionSupport.decide(status, WASHER)).isEqualTo(StartDecision.STARTED);
         }

--- a/src/test/java/team/washer/server/v2/domain/reservation/support/ReservationStartDecisionSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/support/ReservationStartDecisionSupportTest.java
@@ -1,0 +1,137 @@
+package team.washer.server.v2.domain.reservation.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import team.washer.server.v2.domain.reservation.support.ReservationStartDecisionSupport.StartDecision;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.AttributeState;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.ComponentStatus;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.DryerOperatingState;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.SwitchCapability;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.WasherOperatingState;
+
+@DisplayName("ReservationStartDecisionSupport 시작 판정")
+class ReservationStartDecisionSupportTest {
+
+    private static final boolean WASHER = true;
+    private static final boolean DRYER = false;
+
+    private final ReservationStartDecisionSupport reservationStartDecisionSupport = new ReservationStartDecisionSupport();
+
+    private static String isoUtc(ZonedDateTime koreaTime) {
+        return koreaTime.withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime().toString() + "Z";
+    }
+
+    private static AttributeState attr(String value) {
+        return value == null ? null : new AttributeState(value, null, null);
+    }
+
+    private static SmartThingsDeviceStatusResDto washerStatus(String machineState,
+            String jobState,
+            String completionTime) {
+        var washerOpState = new WasherOperatingState(attr(machineState), attr(jobState), attr(completionTime));
+        return new SmartThingsDeviceStatusResDto(Map.of("main", new ComponentStatus(washerOpState, null, null, null)));
+    }
+
+    private static SmartThingsDeviceStatusResDto dryerStatus(String machineState,
+            String jobState,
+            String completionTime) {
+        var dryerOpState = new DryerOperatingState(attr(machineState), attr(jobState), attr(completionTime));
+        return new SmartThingsDeviceStatusResDto(Map.of("main", new ComponentStatus(null, dryerOpState, null, null)));
+    }
+
+    private static SmartThingsDeviceStatusResDto washerStatusWithSwitch(String machineState,
+            String jobState,
+            String switchState) {
+        var washerOpState = new WasherOperatingState(attr(machineState), attr(jobState), null);
+        var switchCapability = new SwitchCapability(attr(switchState));
+        return new SmartThingsDeviceStatusResDto(
+                Map.of("main", new ComponentStatus(washerOpState, null, switchCapability, null)));
+    }
+
+    @Nested
+    @DisplayName("시작 신호가 있으면")
+    class Started {
+
+        @Test
+        @DisplayName("machineState=run이면 STARTED를 반환한다")
+        void shouldStart_WhenMachineStateRun() {
+            var status = washerStatus("run", "wash", null);
+
+            assertThat(reservationStartDecisionSupport.decide(status, WASHER)).isEqualTo(StartDecision.STARTED);
+        }
+
+        @Test
+        @DisplayName("세탁기 active jobState가 있으면 STARTED를 반환한다")
+        void shouldStartWasher_WhenActiveJobStateExists() {
+            var status = washerStatus(null, "spin", null);
+
+            assertThat(reservationStartDecisionSupport.decide(status, WASHER)).isEqualTo(StartDecision.STARTED);
+        }
+
+        @Test
+        @DisplayName("건조기 active jobState가 있으면 STARTED를 반환한다")
+        void shouldStartDryer_WhenActiveJobStateExists() {
+            var status = dryerStatus(null, "drying", null);
+
+            assertThat(reservationStartDecisionSupport.decide(status, DRYER)).isEqualTo(StartDecision.STARTED);
+        }
+
+        @Test
+        @DisplayName("미래 completionTime이 있으면 STARTED를 반환한다")
+        void shouldStart_WhenFutureCompletionTimeExists() {
+            var future = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(10);
+            var status = washerStatus(null, null, isoUtc(future));
+
+            assertThat(reservationStartDecisionSupport.decide(status, WASHER)).isEqualTo(StartDecision.STARTED);
+        }
+    }
+
+    @Nested
+    @DisplayName("명확한 미사용 신호가 있으면")
+    class Idle {
+
+        @Test
+        @DisplayName("machineState=stop이면 IDLE을 반환한다")
+        void shouldIdle_WhenMachineStateStop() {
+            var status = washerStatus("stop", "none", null);
+
+            assertThat(reservationStartDecisionSupport.decide(status, WASHER)).isEqualTo(StartDecision.IDLE);
+        }
+
+        @Test
+        @DisplayName("switch=off이면 machineState=run이어도 IDLE을 반환한다")
+        void shouldIdle_WhenSwitchOffEvenWithMachineStateRun() {
+            var status = washerStatusWithSwitch("run", "wash", "off");
+
+            assertThat(reservationStartDecisionSupport.decide(status, WASHER)).isEqualTo(StartDecision.IDLE);
+        }
+    }
+
+    @Nested
+    @DisplayName("판정을 확신할 수 없으면")
+    class Unknown {
+
+        @Test
+        @DisplayName("상태 응답이 없으면 UNKNOWN을 반환한다")
+        void shouldUnknown_WhenStatusNull() {
+            assertThat(reservationStartDecisionSupport.decide(null, WASHER)).isEqualTo(StartDecision.UNKNOWN);
+        }
+
+        @Test
+        @DisplayName("기기 상태와 보조 신호가 모두 없으면 UNKNOWN을 반환한다")
+        void shouldUnknown_WhenNoSignalsExist() {
+            var status = washerStatus(null, null, null);
+
+            assertThat(reservationStartDecisionSupport.decide(status, WASHER)).isEqualTo(StartDecision.UNKNOWN);
+        }
+    }
+}


### PR DESCRIPTION
﻿## 개요

예약 시작 판정을 별도 컴포넌트로 모아 lifecycle 처리와 timeout 처리에서 같은 기준을 사용하도록 정리했습니다.
SmartThings 상태를 확신할 수 없을 때 만료 예약을 취소하거나 기기를 AVAILABLE로 돌리지 않도록 보호했습니다.

## 본문

- `ReservationStartDecisionSupport`를 추가해 RESERVED 예약의 시작 여부를 STARTED, IDLE, UNKNOWN으로 구분했습니다.
- #107에서 추가된 `SmartThingsDeviceStatusResDto` accessor와 `MachineOperatingState`를 사용해 machineState 문자열 직접 비교를 피했습니다.
- `ReservationLifecycleProcessor`와 `OverdueReservationProcessor`가 같은 시작 판정을 사용하도록 변경했습니다.
- lifecycle polling 간격을 10초로 줄여 실제 기기 시작 후 분석 대기 시간을 줄였습니다.
- #103의 완료 판정 구조는 유지하고 completion decision을 재구현하지 않았습니다.

검증:
- `gradlew.bat test --tests team.washer.server.v2.domain.reservation.service.OverdueReservationProcessorTest --tests team.washer.server.v2.domain.reservation.service.ReservationLifecycleProcessorTest --tests team.washer.server.v2.domain.reservation.support.ReservationStartDecisionSupportTest`
- `gradlew.bat build`
