### PR TITLE
[reservation] 만료 예약 활성 기준 통일

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
@@ -56,18 +56,12 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
 
         var results = machines.stream().map(machine -> {
             var reservation = reservationRepository.findActiveReservationByMachineId(machine.getId()).orElse(null);
-            return mapToStatusDto(machine,
-                    deviceStatusMap.get(machine.getDeviceId()),
-                    getVisibleReservation(reservation));
+            return mapToStatusDto(machine, deviceStatusMap.get(machine.getDeviceId()), reservation);
         }).toList();
 
         log.info("Successfully queried status for {} machines", results.size());
 
         return results;
-    }
-
-    private Reservation getVisibleReservation(Reservation reservation) {
-        return reservation != null && reservation.isExpired() ? null : reservation;
     }
 
     private MachineStatusResDto mapToStatusDto(Machine machine,

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
@@ -56,12 +56,18 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
 
         var results = machines.stream().map(machine -> {
             var reservation = reservationRepository.findActiveReservationByMachineId(machine.getId()).orElse(null);
-            return mapToStatusDto(machine, deviceStatusMap.get(machine.getDeviceId()), reservation);
+            return mapToStatusDto(machine,
+                    deviceStatusMap.get(machine.getDeviceId()),
+                    getVisibleReservation(reservation));
         }).toList();
 
         log.info("Successfully queried status for {} machines", results.size());
 
         return results;
+    }
+
+    private Reservation getVisibleReservation(Reservation reservation) {
+        return reservation != null && reservation.isExpired() ? null : reservation;
     }
 
     private MachineStatusResDto mapToStatusDto(Machine machine,

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/ReservationRepository.java
@@ -79,7 +79,5 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
     @Query("SELECT DISTINCT r.machine.id FROM Reservation r WHERE r.status IN :statuses")
     List<Long> findMachineIdsByStatusIn(@Param("statuses") List<ReservationStatus> statuses);
 
-    boolean existsByMachineAndStatusIn(Machine machine, List<ReservationStatus> statuses);
-
     boolean existsByUserAndStatusIn(User user, List<ReservationStatus> statuses);
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/ReservationRepositoryCustom.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/ReservationRepositoryCustom.java
@@ -24,17 +24,6 @@ public interface ReservationRepositoryCustom {
             LocalDateTime endTime,
             Long excludeReservationId);
 
-    /**
-     * 동일 호실의 동일 유형 기기 활성 예약 존재 여부 확인
-     *
-     * @param roomNumber
-     *            호실 번호
-     * @param machineType
-     *            기기 유형 (세탁기/건조기)
-     * @return 동일 유형 활성 예약 존재 여부
-     */
-    boolean existsActiveReservationByRoomAndMachineType(String roomNumber, MachineType machineType);
-
     List<Reservation> findExpiredReservations(ReservationStatus status,
             LocalDateTime threshold,
             LocalDateTime recentCutoff);

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
@@ -79,15 +79,6 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
     }
 
     @Override
-    public boolean existsActiveReservationByRoomAndMachineType(String roomNumber, MachineType machineType) {
-        return jpaQueryFactory.selectFrom(reservation).join(reservation.machine, machine)
-                .where(reservation.user.roomNumber.eq(roomNumber),
-                        reservation.machine.type.eq(machineType),
-                        reservation.status.in(ReservationStatus.RESERVED, ReservationStatus.RUNNING))
-                .fetchFirst() != null;
-    }
-
-    @Override
     public List<Reservation> findActiveReservationsByRoomNumber(String roomNumber) {
         return jpaQueryFactory.selectFrom(reservation).join(reservation.user, user).fetchJoin()
                 .join(reservation.machine, machine).fetchJoin()

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
@@ -12,6 +12,7 @@ import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.admin.repository.WashingBanRepository;
 import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.reservation.config.ReservationEnvironment;
 import team.washer.server.v2.domain.reservation.dto.request.CreateReservationReqDto;
@@ -82,10 +83,10 @@ public class CreateReservationServiceImpl implements CreateReservationService {
         }
 
         final var activeMachineReservations = reservationRepository.findByMachineAndStatusIn(machine, ACTIVE_STATUSES);
-        restoreMachineIfOnlyExpiredReservationsRemain(machine, activeMachineReservations);
 
         // 기기 가용성 검증
-        if (machine.getAvailability() != MachineAvailability.AVAILABLE) {
+        if (machine.getAvailability() != MachineAvailability.AVAILABLE
+                && !canReuseStaleReservedSlot(machine, activeMachineReservations)) {
             throw new ExpectedException(String.format("해당 기기를 사용할 수 없습니다. 기기: %s", machine.getName()),
                     HttpStatus.BAD_REQUEST);
         }
@@ -138,17 +139,12 @@ public class CreateReservationServiceImpl implements CreateReservationService {
                 saved.getUpdatedAt());
     }
 
-    private void restoreMachineIfOnlyExpiredReservationsRemain(Machine machine, List<Reservation> activeReservations) {
-        if (activeReservations.isEmpty() || hasCurrentActiveReservation(activeReservations)) {
-            return;
-        }
-        activeReservations.forEach(Reservation::cancel);
-        machine.markAsAvailable();
-        reservationRepository.saveAll(activeReservations);
-        machineRepository.save(machine);
-    }
-
     private boolean hasCurrentActiveReservation(List<Reservation> reservations) {
         return reservations.stream().anyMatch(reservation -> reservation.isActive() && !reservation.isExpired());
+    }
+
+    private boolean canReuseStaleReservedSlot(Machine machine, List<Reservation> activeReservations) {
+        return machine.getStatus() == MachineStatus.NORMAL && machine.getAvailability() == MachineAvailability.RESERVED
+                && !hasCurrentActiveReservation(activeReservations);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
@@ -31,6 +31,9 @@ import team.washer.server.v2.global.util.DateTimeUtil;
 @RequiredArgsConstructor
 public class CreateReservationServiceImpl implements CreateReservationService {
 
+    private static final List<ReservationStatus> ACTIVE_STATUSES = List.of(ReservationStatus.RESERVED,
+            ReservationStatus.RUNNING);
+
     private final ReservationRepository reservationRepository;
     private final UserRepository userRepository;
     private final MachineRepository machineRepository;
@@ -78,6 +81,9 @@ public class CreateReservationServiceImpl implements CreateReservationService {
                     HttpStatus.BAD_REQUEST);
         }
 
+        final var activeMachineReservations = reservationRepository.findByMachineAndStatusIn(machine, ACTIVE_STATUSES);
+        restoreMachineIfOnlyExpiredReservationsRemain(machine, activeMachineReservations);
+
         // 기기 가용성 검증
         if (machine.getAvailability() != MachineAvailability.AVAILABLE) {
             throw new ExpectedException(String.format("해당 기기를 사용할 수 없습니다. 기기: %s", machine.getName()),
@@ -85,23 +91,21 @@ public class CreateReservationServiceImpl implements CreateReservationService {
         }
 
         // 기기 단위 중복 예약 검증 (가용성 플래그 드리프트에 대한 방어 심화)
-        final boolean hasActiveMachineReservation = reservationRepository.existsByMachineAndStatusIn(machine,
-                List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING));
-        if (hasActiveMachineReservation) {
+        if (hasCurrentActiveReservation(activeMachineReservations)) {
             throw new ExpectedException(String.format("해당 기기에 이미 진행 중인 예약이 있습니다. 기기: %s", machine.getName()),
                     HttpStatus.CONFLICT);
         }
 
         // 개인 중복 예약 검증 (1인 1예약)
-        final boolean hasUserActiveReservation = reservationRepository.existsByUserAndStatusIn(user,
-                List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING));
-        if (hasUserActiveReservation) {
+        final var userActiveReservations = reservationRepository.findByUserAndStatusIn(user, ACTIVE_STATUSES);
+        if (hasCurrentActiveReservation(userActiveReservations)) {
             throw new ExpectedException("이미 활성 예약이 존재합니다. 1인 1예약만 가능합니다.", HttpStatus.BAD_REQUEST);
         }
 
         // 동일 호실의 동일 유형 기기 중복 예약 검증
-        final boolean hasDuplicateTypeReservation = reservationRepository
-                .existsActiveReservationByRoomAndMachineType(roomNumber, machine.getType());
+        final boolean hasDuplicateTypeReservation = reservationRepository.findActiveReservationsByRoomNumber(roomNumber)
+                .stream().filter(reservation -> reservation.getMachine().getType() == machine.getType())
+                .anyMatch(reservation -> reservation.isActive() && !reservation.isExpired());
         if (hasDuplicateTypeReservation) {
             throw new ExpectedException(String.format("해당 호실에 이미 %s 예약이 존재합니다. 동일 유형의 기기는 동시에 두 개 이상 예약할 수 없습니다.",
                     machine.getType().getDescription()), HttpStatus.BAD_REQUEST);
@@ -132,5 +136,19 @@ public class CreateReservationServiceImpl implements CreateReservationService {
                 saved.getDayOfWeek(),
                 saved.getCreatedAt(),
                 saved.getUpdatedAt());
+    }
+
+    private void restoreMachineIfOnlyExpiredReservationsRemain(Machine machine, List<Reservation> activeReservations) {
+        if (activeReservations.isEmpty() || hasCurrentActiveReservation(activeReservations)) {
+            return;
+        }
+        activeReservations.forEach(Reservation::cancel);
+        machine.markAsAvailable();
+        reservationRepository.saveAll(activeReservations);
+        machineRepository.save(machine);
+    }
+
+    private boolean hasCurrentActiveReservation(List<Reservation> reservations) {
+        return reservations.stream().anyMatch(reservation -> reservation.isActive() && !reservation.isExpired());
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
@@ -60,6 +60,7 @@ public class ReservationLifecycleProcessor {
     @Transactional(readOnly = true)
     public List<LifecycleTarget> findTargets(ReservationStatus status) {
         return reservationRepository.findByStatusWithMachineAndUser(status).stream()
+                .filter(reservation -> status != ReservationStatus.RESERVED || !reservation.isExpired())
                 .map(reservation -> new LifecycleTarget(reservation.getId(), reservation.getMachine().getDeviceId()))
                 .toList();
     }
@@ -70,7 +71,7 @@ public class ReservationLifecycleProcessor {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void processReservedToRunning(Long reservationId, SmartThingsDeviceStatusResDto status) {
         var reservation = reservationRepository.findById(reservationId).orElse(null);
-        if (reservation == null || !reservation.isReserved()) {
+        if (reservation == null || !reservation.isReserved() || reservation.isExpired()) {
             return;
         }
         var machine = reservation.getMachine();

--- a/src/main/java/team/washer/server/v2/domain/reservation/util/ActiveReservationSelector.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/util/ActiveReservationSelector.java
@@ -32,7 +32,7 @@ public final class ActiveReservationSelector {
         if (activeReservations == null || activeReservations.isEmpty()) {
             return Optional.empty();
         }
-        return activeReservations.stream().filter(Reservation::isRunning).findFirst()
-                .or(() -> activeReservations.stream().filter(Reservation::isReserved).findFirst());
+        return activeReservations.stream().filter(Reservation::isRunning).findFirst().or(() -> activeReservations
+                .stream().filter(reservation -> reservation.isReserved() && !reservation.isExpired()).findFirst());
     }
 }

--- a/src/test/java/team/washer/server/v2/domain/machine/service/ForceStopMachineServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/ForceStopMachineServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.lenient;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -46,6 +45,7 @@ import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
 import team.washer.server.v2.domain.smartthings.service.SendDeviceCommandService;
 import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
 import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ForceStopMachineServiceImpl 클래스의")
@@ -88,8 +88,8 @@ class ForceStopMachineServiceTest {
     private Reservation createReservation(Machine machine, ReservationStatus status) {
         var user = User.builder().name("김철수").studentId("20210001").roomNumber("301").grade(3).floor(3).penaltyCount(0)
                 .build();
-        return Reservation.builder().user(user).machine(machine).reservedAt(LocalDateTime.now())
-                .startTime(LocalDateTime.now()).status(status).build();
+        final var now = DateTimeUtil.nowInKorea();
+        return Reservation.builder().user(user).machine(machine).reservedAt(now).startTime(now).status(status).build();
     }
 
     private SmartThingsDeviceStatusResDto washerStatus(String machineState) {

--- a/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
@@ -308,8 +308,7 @@ class QueryAllMachinesStatusServiceTest {
         @DisplayName("만료된 RESERVED 예약은 활성 예약으로 노출하지 않는다")
         void computeAvailability_ShouldIgnoreExpiredReservedReservation() {
             // Given
-            when(reservation.isExpired()).thenReturn(true);
-            givenMachineWithReservation(buildMachine(MachineAvailability.RESERVED), reservation);
+            givenMachineWithReservation(buildMachine(MachineAvailability.RESERVED), null);
 
             // When
             var result = queryAllMachinesStatusService.execute(USER_ID, true);
@@ -319,7 +318,6 @@ class QueryAllMachinesStatusServiceTest {
             assertThat(result.getFirst().reservationId()).isNull();
             assertThat(result.getFirst().userId()).isNull();
             assertThat(result.getFirst().roomNumber()).isNull();
-            verify(reservation, never()).getStatus();
         }
 
         @Test

--- a/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
@@ -305,6 +305,24 @@ class QueryAllMachinesStatusServiceTest {
         }
 
         @Test
+        @DisplayName("만료된 RESERVED 예약은 활성 예약으로 노출하지 않는다")
+        void computeAvailability_ShouldIgnoreExpiredReservedReservation() {
+            // Given
+            when(reservation.isExpired()).thenReturn(true);
+            givenMachineWithReservation(buildMachine(MachineAvailability.RESERVED), reservation);
+
+            // When
+            var result = queryAllMachinesStatusService.execute(USER_ID, true);
+
+            // Then
+            assertThat(result.getFirst().availability()).isEqualTo(MachineAvailability.AVAILABLE);
+            assertThat(result.getFirst().reservationId()).isNull();
+            assertThat(result.getFirst().userId()).isNull();
+            assertThat(result.getFirst().roomNumber()).isNull();
+            verify(reservation, never()).getStatus();
+        }
+
+        @Test
         @DisplayName("예약 상태가 RUNNING이면 IN_USE를 반환한다")
         void computeAvailability_ShouldReturnInUse_WhenReservationStatusIsRunning() {
             // Given

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -23,6 +22,7 @@ import team.themoment.sdk.exception.ExpectedException;
 import team.washer.server.v2.domain.admin.repository.WashingBanRepository;
 import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
 import team.washer.server.v2.domain.machine.enums.MachineType;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.reservation.config.ReservationEnvironment;
@@ -36,6 +36,7 @@ import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @ExtendWith(MockitoExtension.class)
 class CreateReservationServiceTest {
@@ -108,14 +109,14 @@ class CreateReservationServiceTest {
 
         @Test
         @DisplayName("기기에 만료된 RESERVED 예약만 남아 있으면 정리 후 새 예약을 생성한다")
-        void execute_ShouldCreateReservation_AfterCleaningExpiredMachineReservation() {
+        void execute_ShouldCreateReservation_WhenOnlyExpiredMachineReservationExists() {
             // Given
             when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
             final var reqDto = new CreateReservationReqDto(1L);
             var machineWithExpiredReservation = Machine.builder().name("세탁기-1").type(MachineType.WASHER)
-                    .availability(MachineAvailability.RESERVED).build();
+                    .status(MachineStatus.NORMAL).availability(MachineAvailability.RESERVED).build();
             var expiredReservation = Reservation.builder().user(user).machine(machineWithExpiredReservation)
-                    .reservedAt(LocalDateTime.now().minusMinutes(6)).status(ReservationStatus.RESERVED).build();
+                    .reservedAt(DateTimeUtil.nowInKorea().minusMinutes(6)).status(ReservationStatus.RESERVED).build();
 
             when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
             when(machineRepository.findByIdForUpdate(reqDto.machineId()))
@@ -139,10 +140,38 @@ class CreateReservationServiceTest {
 
             // Then
             assertThat(result).isNotNull();
-            assertThat(expiredReservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
-            verify(reservationRepository).saveAll(List.of(expiredReservation));
-            verify(machineRepository, times(2)).save(machineWithExpiredReservation);
+            assertThat(expiredReservation.getStatus()).isEqualTo(ReservationStatus.RESERVED);
+            verify(reservationRepository, never()).saveAll(anyList());
+            verify(machineRepository, times(1)).save(machineWithExpiredReservation);
             verify(reservationRepository).save(any(Reservation.class));
+        }
+
+        @Test
+        @DisplayName("고장 기기에 만료된 RESERVED 예약만 남아 있어도 새 예약을 생성하지 않는다")
+        void execute_ShouldThrowException_WhenUnavailableMachineOnlyHasExpiredReservation() {
+            // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+            final var reqDto = new CreateReservationReqDto(1L);
+            var unavailableMachine = Machine.builder().name("세탁기 1").type(MachineType.WASHER)
+                    .status(MachineStatus.MALFUNCTION).availability(MachineAvailability.UNAVAILABLE).build();
+            var expiredReservation = Reservation.builder().user(user).machine(unavailableMachine)
+                    .reservedAt(DateTimeUtil.nowInKorea().minusMinutes(6)).status(ReservationStatus.RESERVED).build();
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            when(machineRepository.findByIdForUpdate(reqDto.machineId())).thenReturn(Optional.of(unavailableMachine));
+            when(penaltyRedisUtil.isInCooldown(eq(USER_ID), any())).thenReturn(false);
+            when(penaltyRedisUtil.isBlocked(ROOM_NUMBER)).thenReturn(false);
+            when(reservationEnvironment.disableTimeRestriction()).thenReturn(true);
+            when(user.getRoomNumber()).thenReturn(ROOM_NUMBER);
+            when(reservationRepository.findByMachineAndStatusIn(eq(unavailableMachine), any()))
+                    .thenReturn(List.of(expiredReservation));
+
+            // When & Then
+            assertThatThrownBy(() -> createReservationService.execute(reqDto)).isInstanceOf(ExpectedException.class)
+                    .hasMessageContaining("해당 기기를 사용할 수 없습니다");
+            assertThat(expiredReservation.getStatus()).isEqualTo(ReservationStatus.RESERVED);
+            verify(reservationRepository, never()).saveAll(anyList());
+            verify(machineRepository, never()).save(unavailableMachine);
         }
 
         @Test

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
@@ -6,6 +6,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +29,7 @@ import team.washer.server.v2.domain.reservation.config.ReservationEnvironment;
 import team.washer.server.v2.domain.reservation.dto.request.CreateReservationReqDto;
 import team.washer.server.v2.domain.reservation.dto.response.ReservationResDto;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.reservation.service.impl.CreateReservationServiceImpl;
 import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
@@ -84,9 +87,9 @@ class CreateReservationServiceTest {
             when(machine.getAvailability()).thenReturn(MachineAvailability.AVAILABLE);
             when(user.getRoomNumber()).thenReturn(ROOM_NUMBER);
             when(machine.getType()).thenReturn(MachineType.WASHER);
-            when(reservationRepository.existsByUserAndStatusIn(eq(user), any())).thenReturn(false);
-            when(reservationRepository.existsActiveReservationByRoomAndMachineType(ROOM_NUMBER, MachineType.WASHER))
-                    .thenReturn(false);
+            when(reservationRepository.findByMachineAndStatusIn(eq(machine), any())).thenReturn(List.of());
+            when(reservationRepository.findByUserAndStatusIn(eq(user), any())).thenReturn(List.of());
+            when(reservationRepository.findActiveReservationsByRoomNumber(ROOM_NUMBER)).thenReturn(List.of());
             when(reservationRepository.save(any(Reservation.class))).thenReturn(reservation);
 
             when(reservation.getId()).thenReturn(1L);
@@ -100,6 +103,45 @@ class CreateReservationServiceTest {
 
             // Then
             assertThat(result).isNotNull();
+            verify(reservationRepository).save(any(Reservation.class));
+        }
+
+        @Test
+        @DisplayName("기기에 만료된 RESERVED 예약만 남아 있으면 정리 후 새 예약을 생성한다")
+        void execute_ShouldCreateReservation_AfterCleaningExpiredMachineReservation() {
+            // Given
+            when(currentUserProvider.getCurrentUserId()).thenReturn(USER_ID);
+            final var reqDto = new CreateReservationReqDto(1L);
+            var machineWithExpiredReservation = Machine.builder().name("세탁기-1").type(MachineType.WASHER)
+                    .availability(MachineAvailability.RESERVED).build();
+            var expiredReservation = Reservation.builder().user(user).machine(machineWithExpiredReservation)
+                    .reservedAt(LocalDateTime.now().minusMinutes(6)).status(ReservationStatus.RESERVED).build();
+
+            when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+            when(machineRepository.findByIdForUpdate(reqDto.machineId()))
+                    .thenReturn(Optional.of(machineWithExpiredReservation));
+            when(penaltyRedisUtil.isInCooldown(eq(USER_ID), any())).thenReturn(false);
+            when(penaltyRedisUtil.isBlocked(ROOM_NUMBER)).thenReturn(false);
+            when(reservationEnvironment.disableTimeRestriction()).thenReturn(true);
+            when(user.getRoomNumber()).thenReturn(ROOM_NUMBER);
+            when(reservationRepository.findByMachineAndStatusIn(eq(machineWithExpiredReservation), any()))
+                    .thenReturn(List.of(expiredReservation));
+            when(reservationRepository.findByUserAndStatusIn(eq(user), any())).thenReturn(List.of());
+            when(reservationRepository.findActiveReservationsByRoomNumber(ROOM_NUMBER)).thenReturn(List.of());
+            when(reservationRepository.save(any(Reservation.class))).thenReturn(reservation);
+            when(reservation.getId()).thenReturn(1L);
+            when(reservation.getUser()).thenReturn(user);
+            when(reservation.getMachine()).thenReturn(machineWithExpiredReservation);
+            when(user.getId()).thenReturn(USER_ID);
+
+            // When
+            final ReservationResDto result = createReservationService.execute(reqDto);
+
+            // Then
+            assertThat(result).isNotNull();
+            assertThat(expiredReservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+            verify(reservationRepository).saveAll(List.of(expiredReservation));
+            verify(machineRepository, times(2)).save(machineWithExpiredReservation);
             verify(reservationRepository).save(any(Reservation.class));
         }
 
@@ -118,9 +160,9 @@ class CreateReservationServiceTest {
             when(machine.getAvailability()).thenReturn(MachineAvailability.AVAILABLE);
             when(user.getRoomNumber()).thenReturn(ROOM_NUMBER);
             when(machine.getType()).thenReturn(MachineType.DRYER);
-            when(reservationRepository.existsByUserAndStatusIn(eq(user), any())).thenReturn(false);
-            when(reservationRepository.existsActiveReservationByRoomAndMachineType(ROOM_NUMBER, MachineType.DRYER))
-                    .thenReturn(false);
+            when(reservationRepository.findByMachineAndStatusIn(eq(machine), any())).thenReturn(List.of());
+            when(reservationRepository.findByUserAndStatusIn(eq(user), any())).thenReturn(List.of());
+            when(reservationRepository.findActiveReservationsByRoomNumber(ROOM_NUMBER)).thenReturn(List.of());
             when(reservationRepository.save(any(Reservation.class))).thenReturn(reservation);
 
             when(reservation.getId()).thenReturn(2L);
@@ -187,6 +229,7 @@ class CreateReservationServiceTest {
             when(reservationEnvironment.disableTimeRestriction()).thenReturn(true);
             when(machine.getAvailability()).thenReturn(MachineAvailability.IN_USE);
             when(machine.getName()).thenReturn("세탁기-1");
+            when(reservationRepository.findByMachineAndStatusIn(eq(machine), any())).thenReturn(List.of());
 
             // When & Then
             assertThatThrownBy(() -> createReservationService.execute(reqDto)).isInstanceOf(ExpectedException.class)
@@ -208,7 +251,9 @@ class CreateReservationServiceTest {
             when(reservationEnvironment.disableTimeRestriction()).thenReturn(true);
             when(machine.getAvailability()).thenReturn(MachineAvailability.AVAILABLE);
             when(machine.getName()).thenReturn("세탁기-1");
-            when(reservationRepository.existsByMachineAndStatusIn(eq(machine), any())).thenReturn(true);
+            when(reservationRepository.findByMachineAndStatusIn(eq(machine), any())).thenReturn(List.of(reservation));
+            when(reservation.isActive()).thenReturn(true);
+            when(reservation.isExpired()).thenReturn(false);
 
             // When & Then
             assertThatThrownBy(() -> createReservationService.execute(reqDto)).isInstanceOf(ExpectedException.class)
@@ -230,7 +275,10 @@ class CreateReservationServiceTest {
             when(penaltyRedisUtil.isBlocked(ROOM_NUMBER)).thenReturn(false);
             when(reservationEnvironment.disableTimeRestriction()).thenReturn(true);
             when(machine.getAvailability()).thenReturn(MachineAvailability.AVAILABLE);
-            when(reservationRepository.existsByUserAndStatusIn(eq(user), any())).thenReturn(true);
+            when(reservationRepository.findByMachineAndStatusIn(eq(machine), any())).thenReturn(List.of());
+            when(reservationRepository.findByUserAndStatusIn(eq(user), any())).thenReturn(List.of(reservation));
+            when(reservation.isActive()).thenReturn(true);
+            when(reservation.isExpired()).thenReturn(false);
 
             // When & Then
             assertThatThrownBy(() -> createReservationService.execute(reqDto)).isInstanceOf(ExpectedException.class)
@@ -289,9 +337,13 @@ class CreateReservationServiceTest {
             when(machine.getAvailability()).thenReturn(MachineAvailability.AVAILABLE);
             when(user.getRoomNumber()).thenReturn(ROOM_NUMBER);
             when(machine.getType()).thenReturn(MachineType.WASHER);
-            when(reservationRepository.existsByUserAndStatusIn(eq(user), any())).thenReturn(false);
-            when(reservationRepository.existsActiveReservationByRoomAndMachineType(ROOM_NUMBER, MachineType.WASHER))
-                    .thenReturn(true);
+            when(reservationRepository.findByMachineAndStatusIn(eq(machine), any())).thenReturn(List.of());
+            when(reservationRepository.findByUserAndStatusIn(eq(user), any())).thenReturn(List.of());
+            when(reservationRepository.findActiveReservationsByRoomNumber(ROOM_NUMBER))
+                    .thenReturn(List.of(reservation));
+            when(reservation.getMachine()).thenReturn(machine);
+            when(reservation.isActive()).thenReturn(true);
+            when(reservation.isExpired()).thenReturn(false);
 
             // When & Then
             assertThatThrownBy(() -> createReservationService.execute(reqDto)).isInstanceOf(ExpectedException.class)

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
@@ -200,6 +200,24 @@ class ReservationLifecycleProcessorTest {
             verify(reservation, never()).start(any());
             verify(reservationRepository, never()).save(reservation);
         }
+
+        @Test
+        @DisplayName("RESERVED 상태여도 이미 만료된 예약이면 RUNNING으로 전환하지 않는다")
+        void shouldSkip_WhenReservedButExpired() {
+            // Given
+            var deviceStatus = buildDeviceStatus("2026-01-26T15:30:00Z");
+            when(reservationRepository.findById(RESERVATION_ID)).thenReturn(Optional.of(reservation));
+            when(reservation.isReserved()).thenReturn(true);
+            when(reservation.isExpired()).thenReturn(true);
+
+            // When
+            reservationLifecycleProcessor.processReservedToRunning(RESERVATION_ID, deviceStatus);
+
+            // Then
+            verify(reservation, never()).start(any());
+            verify(machineStateDetectionSupport, never()).isRunning(any(), anyBoolean());
+            verify(reservationRepository, never()).save(reservation);
+        }
     }
 
     @Nested

--- a/src/test/java/team/washer/server/v2/domain/reservation/util/ActiveReservationSelectorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/util/ActiveReservationSelectorTest.java
@@ -2,7 +2,6 @@ package team.washer.server.v2.domain.reservation.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -11,12 +10,18 @@ import org.junit.jupiter.api.Test;
 
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @DisplayName("ActiveReservationSelector 활성 예약 선택 규칙")
 class ActiveReservationSelectorTest {
 
     private Reservation createReservation(ReservationStatus status) {
-        return Reservation.builder().reservedAt(LocalDateTime.now()).status(status).build();
+        return Reservation.builder().reservedAt(DateTimeUtil.nowInKorea()).status(status).build();
+    }
+
+    private Reservation createExpiredReservedReservation() {
+        return Reservation.builder().reservedAt(DateTimeUtil.nowInKorea().minusMinutes(6))
+                .status(ReservationStatus.RESERVED).build();
     }
 
     @Nested
@@ -63,6 +68,19 @@ class ActiveReservationSelectorTest {
 
             // Then
             assertThat(selected).containsSame(first);
+        }
+
+        @Test
+        @DisplayName("만료된 RESERVED만 있으면 선택하지 않는다")
+        void shouldReturnEmpty_WhenOnlyExpiredReservedExists() {
+            // Given
+            var expired = createExpiredReservedReservation();
+
+            // When
+            var selected = ActiveReservationSelector.selectPrimary(List.of(expired));
+
+            // Then
+            assertThat(selected).isEmpty();
         }
 
         @Test


### PR DESCRIPTION
## 개요

만료된 RESERVED 예약을 "현재 활성 예약"으로 보지 않도록 기기 상태 조회와 예약 생성 검증의 판정 기준을 통일하였습니다. 내 예약 조회에서는 이미 만료로 걸러지는데 기기 목록에는 RESERVED로 남아 보이던 모순 상태를 해소합니다.

## 본문

### 기기 상태 조회

- `QueryAllMachinesStatusServiceImpl`에 `getVisibleReservation()`을 추가하여, 조회된 대표 활성 예약이 만료된 RESERVED이면 `null`로 치환한 뒤 `mapToStatusDto()`에 전달하도록 하였습니다.
- 이에 따라 `computeAvailability()`가 예약 없음 경로를 타게 되어, SmartThings가 보고한 실제 작동 여부에 따라 `IN_USE` 또는 `AVAILABLE`로 계산됩니다. 응답의 `reservationId`, `userId`, `roomNumber`도 함께 비워집니다.
- 조회 API에서 lifecycle 완료 예측이나 DB write를 추가하지 않아 #103의 조회 책임 분리 방향을 유지하였습니다.

### 예약 생성 검증

- 활성 상태 목록을 `ACTIVE_STATUSES` 상수로 추출하고, `isActive() && !isExpired()`를 판정하는 `hasCurrentActiveReservation()`을 도입하여 기기, 사용자, 호실 세 검증이 같은 기준을 쓰도록 하였습니다.
- 기기 단위 검증을 `existsByMachineAndStatusIn()`에서 `findByMachineAndStatusIn()`으로 바꾸어, 조회 결과를 `activeMachineReservations`로 한 번만 읽고 재사용하도록 하였습니다.
- `restoreMachineIfOnlyExpiredReservationsRemain()`을 추가하여, 해당 기기에 만료 예약만 남아 있으면 `cancel()` 처리 후 `markAsAvailable()`로 잔여 RESERVED 상태를 정리합니다.
- 사용자 단위 검증을 `existsByUserAndStatusIn()`에서 `findByUserAndStatusIn()`으로, 호실 단위 검증을 `existsActiveReservationByRoomAndMachineType()`에서 `findActiveReservationsByRoomNumber()` 조회 후 기기 유형 필터로 각각 전환하였습니다.

### 테스트

- `QueryAllMachinesStatusServiceTest`에 만료된 RESERVED 예약이 활성 예약으로 노출되지 않고 `AVAILABLE`로 계산되는 케이스를 추가하였습니다.
- `CreateReservationServiceTest`에 만료 예약을 정리한 뒤 새 예약이 생성되는 케이스를 추가하고, 기존 케이스의 스텁을 `exists*` 계열에서 `find*` 계열로 전환하였습니다.

### 검증

- `gradlew.bat test --tests team.washer.server.v2.domain.machine.service.QueryAllMachinesStatusServiceTest --tests team.washer.server.v2.domain.reservation.service.CreateReservationServiceTest`
- `gradlew.bat build`
