### PR TITLE
[ci/cd] 컨테이너 프로필 실행 명령 정리

### DIFF
--- a/prod.dockerfile
+++ b/prod.dockerfile
@@ -5,4 +5,4 @@ COPY app.jar app.jar
 RUN chown appuser:appgroup app.jar
 USER appuser
 EXPOSE 8080
-CMD ["java", "-XX:MaxRAMPercentage=60.0", "-XX:+UseStringDeduplication", "-XX:+ExitOnOutOfMemoryError", "-jar", "-Dspring.profiles.active=prod", "app.jar"]
+CMD ["java", "-Dspring.profiles.active=prod", "-XX:MaxRAMPercentage=60.0", "-XX:+UseStringDeduplication", "-XX:+ExitOnOutOfMemoryError", "-jar", "app.jar"]

--- a/stage.dockerfile
+++ b/stage.dockerfile
@@ -5,4 +5,4 @@ COPY build/libs/app.jar app.jar
 RUN chown appuser:appgroup app.jar
 USER appuser
 EXPOSE 8080
-CMD ["java", "-XX:MaxRAMPercentage=60.0", "-XX:+UseStringDeduplication", "-XX:+ExitOnOutOfMemoryError", "-jar", "-Dspring.profiles.active=stage", "app.jar"]
+CMD ["java", "-Dspring.profiles.active=stage", "-XX:MaxRAMPercentage=60.0", "-XX:+UseStringDeduplication", "-XX:+ExitOnOutOfMemoryError", "-jar", "app.jar"]


### PR DESCRIPTION
﻿## 개요

prod와 stage 컨테이너 실행 명령에서 Spring profile JVM 옵션 위치를 수정했습니다.
프로필 값이 JVM system property로 확실히 적용되도록 `-jar` 앞에 배치했습니다.

## 본문

- `prod.dockerfile`의 `-Dspring.profiles.active=prod` 위치를 `-jar` 앞쪽으로 이동했습니다.
- `stage.dockerfile`의 `-Dspring.profiles.active=stage` 위치를 `-jar` 앞쪽으로 이동했습니다.
- prod/stage Docker image build와 inspect로 최종 `CMD` 배열을 확인했습니다.

검증:
- `gradlew.bat bootJar -x test`
- `gradlew.bat build`
- `docker build -f prod.dockerfile -t washer-backend-prod-profile-check .`
- `docker build -f stage.dockerfile -t washer-backend-stage-profile-check .`
- `docker image inspect washer-backend-prod-profile-check`
- `docker image inspect washer-backend-stage-profile-check`
