### PR TITLE
[reservation] 관리자 대리 예약 생성 API 추가

### DIFF
--- a/docs/spec-admin-proxy-reservation.md
+++ b/docs/spec-admin-proxy-reservation.md
@@ -1,0 +1,278 @@
+# 구현 스펙: 관리자 대리 예약 생성 기능
+
+## 1. 기능 요약
+
+관리자(기숙사자치위원회 포함)가 관리자 웹에서 특정 사용자와 기기를 지정하여 그 사용자 명의로 예약을 생성하는 기능.
+
+기존 예약 생성은 JWT 토큰에서 사용자를 해석한다(`CurrentUserProvider.getCurrentUserId()`). 대리 예약은 토큰의 사용자를 **예약 생성자(created_by)** 로만 기록하고, 예약의 주체(`user_id`)는 요청 바디의 `userId`로 지정한다.
+
+---
+
+## 2. 확정 요구사항
+
+| 항목 | 결정 |
+|------|------|
+| 대상 지정 방식 | `userId` 직접 지정. 호실은 해당 User에서 파생 |
+| 권한 | 기존 `/api/v2/admin/**` 규칙 그대로 (`DORMITORY_COUNCIL`, `ADMIN`) |
+| 우회하는 검증 | 시간대 제한, 48h 호실 차단, 5분 쿨다운 |
+| 유지하는 검증 | 층 제한, 호실 세탁금지(WashingBan), 기기 가용성, 기기 중복 예약, 1인 1예약, 호실 동일유형 중복 |
+| 감사 추적 | `Reservation.createdBy` (`@ManyToOne` → User, nullable) |
+| 타임아웃 자동 취소 시 패널티 | **면제** (대리 예약 한정) |
+| 사용자 본인의 수동 취소 시 패널티 | **면제** (대리 예약 한정) |
+| FCM 알림 | 발송하지 않음 |
+| 응답 노출 | `AdminReservationResDto`에만 `createdByAdminName` 추가. 사용자용 `ReservationResDto`는 변경 없음 |
+| 코드 구조 | 공통 `ReservationCreationSupport` 추출 후 일반/대리 두 서비스가 공유 |
+| DB 마이그레이션 | 불필요 (`ddl-auto: update`, 신규 컬럼 nullable) |
+| 테스트 | 신규 서비스 테스트 + 리팩터링 영향 경로 회귀 테스트 |
+
+### 검증 체인 비교
+
+| 검증 | 일반 예약 | 대리 예약 |
+|------|:--------:|:--------:|
+| 층 제한 `validateFloorRestriction()` | O | O |
+| 호실 세탁금지 `WashingBan` | O | O |
+| 48h 호실 차단 `isBlocked()` | O | **X** |
+| 시간대 제한 `validateTimeRestriction()` | O | **X** |
+| 5분 쿨다운 `isInCooldown()` | O | **X** |
+| 기기 가용성 `AVAILABLE` | O | O |
+| 기기 중복 예약 | O | O |
+| 1인 1예약 | O | O |
+| 호실 동일유형 중복 | O | O |
+
+---
+
+## 3. API 설계
+
+```
+POST /api/v2/admin/reservations
+```
+
+### Request
+
+```json
+{
+  "userId": 12,
+  "machineId": 3
+}
+```
+
+### Response (성공, 201 아님 — 기존 관리자 API와 동일하게 200)
+
+`AdminReservationResDto`를 반환하고 SDK가 자동 래핑한다.
+
+```json
+{
+  "id": 101,
+  "userId": 12,
+  "userName": "김철수",
+  "userRoomNumber": "301",
+  "userStudentId": "2404",
+  "machineId": 3,
+  "machineName": "W-2F-L1",
+  "machineAvailability": "RESERVED",
+  "reservedAt": "2026-08-31T21:30:00",
+  "startTime": null,
+  "expectedCompletionTime": null,
+  "actualCompletionTime": null,
+  "status": "RESERVED",
+  "cancelledAt": null,
+  "createdByAdminName": "박관리"
+}
+```
+
+### Error Cases
+
+| 조건 | 상태 코드 | 메시지 |
+|------|-----------|--------|
+| 권한 없음 | 403 | (Security 기본 응답) |
+| 대상 사용자 없음 | 404 | 사용자를 찾을 수 없습니다 |
+| 기기 없음 | 404 | 기기를 찾을 수 없습니다 |
+| 호실 정보 없음 | 400 | 호실 정보가 존재하지 않습니다. |
+| 층 제한 위반 | (기존 `validateFloorRestriction()` 그대로) | |
+| 호실 세탁 금지 | 403 | 해당 호실은 현재 세탁이 금지된 상태입니다. |
+| 기기 사용 불가 | 400 | 해당 기기를 사용할 수 없습니다. 기기: {name} |
+| 기기 중복 예약 | 409 | 해당 기기에 이미 진행 중인 예약이 있습니다. 기기: {name} |
+| 대상 사용자 활성 예약 존재 | 400 | 이미 활성 예약이 존재합니다. 1인 1예약만 가능합니다. |
+| 호실 동일유형 중복 | 400 | 해당 호실에 이미 {type} 예약이 존재합니다. ... |
+
+> 조회 API는 신규 불필요. 관리자 웹은 기존 `GET /api/v2/admin/users`(이름·학번 부분 검색 + 페이지네이션)와 `GET /api/v2/admin/machines`를 사용한다.
+
+---
+
+## 4. 구현 대상 파일 목록
+
+### 신규 생성
+
+| 파일 | 역할 |
+|------|------|
+| `reservation/dto/request/AdminCreateReservationReqDto.java` | `userId`, `machineId` (둘 다 `@NotNull`) |
+| `reservation/support/ReservationCreationSupport.java` | 두 경로가 공유하는 불변식 검증 + 기기 락 조회 + 엔티티 생성 |
+| `reservation/service/AdminCreateReservationService.java` | 인터페이스 (`execute(AdminCreateReservationReqDto)`) |
+| `reservation/service/impl/AdminCreateReservationServiceImpl.java` | 구현 |
+| `src/test/.../reservation/service/AdminCreateReservationServiceTest.java` | 신규 테스트 |
+
+### 수정
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `reservation/entity/Reservation.java` | `createdBy` 필드 + `isProxyReservation()` 메서드 추가 |
+| `reservation/controller/AdminReservationController.java` | `POST` 엔드포인트 + `@Operation` 추가 |
+| `reservation/service/impl/CreateReservationServiceImpl.java` | 공통 로직을 Support 호출로 대체 |
+| `reservation/service/impl/CancelReservationServiceImpl.java` | 대리 예약이면 패널티 스킵 |
+| `reservation/service/impl/OverdueReservationProcessor.java` | 대리 예약이면 `applyTimeoutPenalty()` 스킵 |
+| `reservation/dto/response/AdminReservationResDto.java` | `createdByAdminName` 필드 추가 |
+| `reservation/service/impl/QueryAllReservationsServiceImpl.java` | 매핑에 `createdByAdminName` 반영 |
+| `reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java` | `findAllWithFilters`(112행)에 `leftJoin(reservation.createdBy).fetchJoin()` 추가 |
+
+---
+
+## 5. 상세 설계
+
+### 5.1 Entity — `Reservation`
+
+```java
+@ManyToOne(fetch = FetchType.LAZY)
+@JoinColumn(name = "created_by_user_id", foreignKey = @ForeignKey(name = "fk_reservation_created_by"))
+private User createdBy;
+
+/**
+ * 관리자 대리 생성 예약 여부를 반환합니다.
+ * 대리 예약은 본인이 요청하지 않았으므로 취소·타임아웃 시 패널티를 부여하지 않습니다.
+ *
+ * @return 대리 예약 여부
+ */
+public boolean isProxyReservation() {
+    return this.createdBy != null;
+}
+```
+
+- nullable — 기존 행은 전부 `null`(본인 예약)로 안전하게 마이그레이션된다.
+- `@Builder` 사용 시 일반 예약 경로는 `createdBy`를 세팅하지 않는다.
+- 인덱스는 추가하지 않는다 (대리 예약 단독 조회 요구가 아직 없음).
+
+### 5.2 Support — `ReservationCreationSupport`
+
+두 경로가 공유하는 부분만 담는다. **정책 검증(시간대/차단/쿨다운)은 포함하지 않는다** — 각 서비스가 호출 전에 스스로 수행한다.
+
+```
+validateRoomConstraints(User user)      // 층 제한, roomNumber null 체크, WashingBan
+lockMachine(Long machineId)             // findByIdForUpdate + 404
+validateMachineAndReservations(User, Machine)
+                                        // 가용성 → 기기 중복 → 1인 1예약 → 호실 동일유형 중복
+create(User user, Machine machine, User createdBy)
+                                        // 엔티티 생성 + machine.markAsReserved() + save
+```
+
+- `create()`의 `createdBy`는 일반 경로에서 `null`을 넘긴다.
+- DTO 매핑은 Support에 두지 않는다 — 두 경로의 응답 타입이 다르기 때문(`ReservationResDto` vs `AdminReservationResDto`).
+- 순서는 기존 `CreateReservationServiceImpl`과 동일하게 유지한다. 특히 **기기 비관적 락(`findByIdForUpdate`)이 중복 검증보다 먼저** 와야 동시 예약 직렬화가 유지된다.
+
+### 5.3 `AdminCreateReservationServiceImpl`
+
+```
+@Transactional
+1. targetUser = userRepository.findById(reqDto.userId())  → 404
+2. adminUser  = userRepository.findById(currentUserProvider.getCurrentUserId()) → 404
+3. support.validateRoomConstraints(targetUser)
+   // 시간대 / 48h 차단 / 쿨다운 검증 없음
+4. machine = support.lockMachine(reqDto.machineId())
+5. support.validateMachineAndReservations(targetUser, machine)
+6. saved = support.create(targetUser, machine, adminUser)
+7. log.info("admin created proxy reservation reservationId={} targetUserId={} adminId={} machineId={}", ...)
+8. AdminReservationResDto 매핑 (createdByAdminName = adminUser.getName())
+```
+
+- 관리자가 자기 자신을 대상으로 지정하는 것은 별도로 막지 않는다(불변식은 그대로 적용되므로 무해).
+- 대상 사용자의 role은 검사하지 않는다.
+
+### 5.4 `CreateReservationServiceImpl` 리팩터링 후
+
+```
+@Transactional
+1. user = 토큰에서 해석 → 404
+2. support.validateRoomConstraints(user)
+3. 48h 차단 검증          ← 이 경로에만 남는다
+4. 시간대 제한 검증        ← 이 경로에만 남는다
+5. machine = support.lockMachine(...)
+6. 쿨다운 검증            ← 이 경로에만 남는다 (machine.getType() 필요하므로 락 이후)
+7. support.validateMachineAndReservations(user, machine)
+8. saved = support.create(user, machine, null)
+9. ReservationResDto 매핑 (기존과 동일)
+```
+
+외부 동작·에러 메시지·검증 순서는 리팩터링 전후로 완전히 동일해야 한다.
+
+### 5.5 패널티 면제 지점
+
+**`CancelReservationServiceImpl`** — 수동 취소:
+
+```java
+if (reservation.isReserved() && !reservation.isProxyReservation()) {
+    // 기존 패널티 블록 (쿨다운 + 취소 기록 + 48h 블록 판정)
+}
+```
+
+`applyPenalty` 플래그가 `false`로 남으므로 응답 메시지도 자동으로 "예약이 취소되었습니다."가 된다.
+
+**`OverdueReservationProcessor.processOverdue()`** — 타임아웃 자동 취소:
+
+```java
+reservation.cancel();
+machine.markAsAvailable();
+// ... save
+
+if (!reservation.isProxyReservation()) {
+    applyTimeoutPenalty(reservation.getUser(), machine);
+}
+return OverdueResult.CANCELLED;
+```
+
+- 취소 자체와 기기 반납(`markAsAvailable`)은 대리 예약도 동일하게 수행된다.
+- 자동 시작(`AUTO_STARTED`) 분기는 변경 없음 — 대리 예약도 기기가 돌기 시작하면 정상적으로 `RUNNING`이 되고 완료 알림까지 기존대로 흐른다.
+
+### 5.6 조회 경로
+
+`ReservationRepositoryCustomImpl.findAllWithFilters`에 `leftJoin(reservation.createdBy, ...).fetchJoin()`을 추가한다. QueryDSL `User` Q타입 별칭이 이미 `user`로 쓰이고 있으므로 `createdByUser` 등 별도 별칭을 선언해야 한다.
+
+`QueryAllReservationsServiceImpl:45` 매핑에서:
+
+```java
+reservation.getCreatedBy() != null ? reservation.getCreatedBy().getName() : null
+```
+
+---
+
+## 6. 테스트 계획
+
+### 신규 — `AdminCreateReservationServiceTest`
+
+| `@Nested` | `@DisplayName` |
+|-----------|----------------|
+| 성공 | 관리자가 지정한 사용자 명의로 예약이 생성된다 |
+| 성공 | 생성된 예약의 createdBy에 관리자가 기록된다 |
+| 정책 우회 | 시간 제한 시간대에도 대리 예약이 생성된다 |
+| 정책 우회 | 48시간 차단된 호실에도 대리 예약이 생성된다 |
+| 정책 우회 | 쿨다운 중인 사용자에게도 대리 예약이 생성된다 |
+| 실패 | 존재하지 않는 사용자면 404 |
+| 실패 | 존재하지 않는 기기면 404 |
+| 실패 | 세탁 금지 호실이면 403 |
+| 실패 | 기기가 사용 불가 상태면 400 |
+| 실패 | 기기에 이미 활성 예약이 있으면 409 |
+| 실패 | 대상 사용자에게 이미 활성 예약이 있으면 400 |
+| 실패 | 호실에 동일 유형 활성 예약이 있으면 400 |
+
+### 회귀
+
+| 대상 | 확인 내용 |
+|------|-----------|
+| `CreateReservationServiceTest` | Support 추출 후에도 기존 검증 순서·에러 메시지 동일 |
+| `CancelReservationServiceTest` | 본인 예약 취소 시 패널티 유지 / 대리 예약 취소 시 패널티 미적용 |
+| 타임아웃 처리 테스트 | 대리 예약 만료 시 `applyTimeoutPenalty` 미호출, 취소·기기 반납은 수행 |
+
+---
+
+## 7. 알려진 트레이드오프
+
+- **패널티 우회 경로**: 사용자가 관리자에게 대리 예약을 부탁하면 패널티 없는 취소권을 얻는다. 관리자 개입이 필요하고 `created_by_user_id`에 흔적이 남으므로 감수한다.
+- **사용자 미인지**: 알림을 보내지 않으므로 대상 사용자는 대리 예약을 모를 수 있다. 타임아웃 시 자동 취소되고 패널티도 없으므로 사용자 피해는 없으나, 그동안 기기가 묶인다. 관리자가 현장에서 구두 전달하는 운영을 전제로 한다.
+- **사용자 앱 미노출**: `ReservationResDto`를 바꾸지 않으므로 앱은 대리 예약을 일반 예약과 동일하게 표시한다. 추후 필요해지면 `isProxyReservation` 필드만 추가하면 된다.

--- a/src/main/java/team/washer/server/v2/domain/reservation/controller/AdminReservationController.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/controller/AdminReservationController.java
@@ -14,10 +14,12 @@ import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import team.themoment.sdk.response.CommonApiResponse;
 import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.reservation.dto.request.AdminCreateReservationReqDto;
 import team.washer.server.v2.domain.reservation.dto.request.ExtendBlockReqDto;
 import team.washer.server.v2.domain.reservation.dto.response.AdminCancellationResDto;
 import team.washer.server.v2.domain.reservation.dto.response.AdminMachineHistoryResDto;
 import team.washer.server.v2.domain.reservation.dto.response.AdminReservationListResDto;
+import team.washer.server.v2.domain.reservation.dto.response.AdminReservationResDto;
 import team.washer.server.v2.domain.reservation.dto.response.PenaltyStatusResDto;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.service.*;
@@ -35,6 +37,14 @@ public class AdminReservationController {
     private final QueryAllReservationsService queryAllReservationsService;
     private final AdminCancelReservationService adminCancelReservationService;
     private final QueryAdminMachineHistoryService queryAdminMachineHistoryService;
+    private final AdminCreateReservationService adminCreateReservationService;
+
+    @PostMapping
+    @Operation(summary = "대리 예약 생성", description = "관리자가 지정한 사용자 명의로 예약을 생성합니다. 시간대 제한, 48시간 호실 차단, 5분 쿨다운은 적용되지 않으며 층 제한, 호실 세탁 금지, 기기 가용성, 중복 예약 제한은 그대로 적용됩니다.")
+    public AdminReservationResDto createReservation(@Valid @RequestBody AdminCreateReservationReqDto reqDto) {
+
+        return adminCreateReservationService.execute(reqDto);
+    }
 
     @GetMapping("/users/{userId}/penalty-status")
     @Operation(summary = "사용자 패널티 상태 조회", description = "특정 사용자의 패널티 상태를 조회합니다.")

--- a/src/main/java/team/washer/server/v2/domain/reservation/dto/request/AdminCreateReservationReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/dto/request/AdminCreateReservationReqDto.java
@@ -1,0 +1,10 @@
+package team.washer.server.v2.domain.reservation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "관리자 대리 예약 생성 요청 DTO")
+public record AdminCreateReservationReqDto(
+        @NotNull(message = "사용자 ID는 필수입니다") @Schema(description = "예약 주체가 될 사용자 ID", example = "12") Long userId,
+        @NotNull(message = "기기 ID는 필수입니다") @Schema(description = "기기 ID", example = "1") Long machineId) {
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/dto/response/AdminReservationResDto.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/dto/response/AdminReservationResDto.java
@@ -20,5 +20,6 @@ public record AdminReservationResDto(@Schema(description = "예약 ID", example 
         @Schema(description = "예상 완료 시간", example = "2026-01-27T23:00:00") LocalDateTime expectedCompletionTime,
         @Schema(description = "실제 완료 시간", example = "2026-01-27T23:00:00") LocalDateTime actualCompletionTime,
         @Schema(description = "예약 상태", example = "RESERVED") ReservationStatus status,
-        @Schema(description = "취소 시간", example = "2026-01-27T21:20:00") LocalDateTime cancelledAt) {
+        @Schema(description = "취소 시간", example = "2026-01-27T21:20:00") LocalDateTime cancelledAt,
+        @Schema(description = "대리 예약을 생성한 관리자 이름. 사용자 본인 예약이면 null", example = "박관리") String createdByAdminName) {
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/entity/Reservation.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/entity/Reservation.java
@@ -41,6 +41,10 @@ public class Reservation extends BaseEntity {
     @JoinColumn(name = "machine_id", nullable = false, foreignKey = @ForeignKey(name = "fk_reservation_machine"))
     private Machine machine;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by_user_id", foreignKey = @ForeignKey(name = "fk_reservation_created_by"))
+    private User createdBy;
+
     @NotNull(message = "예약 시간은 필수입니다")
     @Column(name = "reserved_at", nullable = false)
     private LocalDateTime reservedAt;
@@ -241,6 +245,18 @@ public class Reservation extends BaseEntity {
      */
     public boolean isActive() {
         return this.status == ReservationStatus.RESERVED || this.status == ReservationStatus.RUNNING;
+    }
+
+    /**
+     * 관리자 대리 생성 예약 여부를 반환합니다.
+     *
+     * <p>
+     * 대리 예약은 사용자 본인이 요청한 것이 아니므로 취소·타임아웃 시 패널티를 부여하지 않습니다.
+     *
+     * @return 대리 예약 여부
+     */
+    public boolean isProxyReservation() {
+        return this.createdBy != null;
     }
 
     public boolean isReserved() {

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
@@ -23,12 +23,16 @@ import team.washer.server.v2.domain.reservation.entity.QReservation;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.custom.ReservationRepositoryCustom;
+import team.washer.server.v2.domain.user.entity.QUser;
 
 @Repository
 @RequiredArgsConstructor
 public class ReservationRepositoryCustomImpl implements ReservationRepositoryCustom {
 
     private static final QReservation latestReservation = new QReservation("latestReservation");
+
+    // QUser 기본 별칭(user)은 reservation.user 조인에 이미 사용되므로 대리 예약 생성자용 별칭을 따로 둔다
+    private static final QUser createdByUser = new QUser("createdByUser");
 
     private final JPAQueryFactory jpaQueryFactory;
 
@@ -118,9 +122,9 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
                 .groupBy(latestReservation.machine.id);
 
         final var content = jpaQueryFactory.selectFrom(reservation).leftJoin(reservation.user, user).fetchJoin()
-                .leftJoin(reservation.machine, machine).fetchJoin().where(reservation.id.in(latestReservationIds))
-                .orderBy(reservation.createdAt.desc()).offset(pageable.getOffset()).limit(pageable.getPageSize())
-                .fetch();
+                .leftJoin(reservation.machine, machine).fetchJoin().leftJoin(reservation.createdBy, createdByUser)
+                .fetchJoin().where(reservation.id.in(latestReservationIds)).orderBy(reservation.createdAt.desc())
+                .offset(pageable.getOffset()).limit(pageable.getPageSize()).fetch();
 
         final var total = jpaQueryFactory.select(reservation.count()).from(reservation)
                 .where(reservation.id.in(latestReservationIds)).fetchOne();

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/AdminCreateReservationService.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/AdminCreateReservationService.java
@@ -1,0 +1,8 @@
+package team.washer.server.v2.domain.reservation.service;
+
+import team.washer.server.v2.domain.reservation.dto.request.AdminCreateReservationReqDto;
+import team.washer.server.v2.domain.reservation.dto.response.AdminReservationResDto;
+
+public interface AdminCreateReservationService {
+    AdminReservationResDto execute(AdminCreateReservationReqDto reqDto);
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/AdminCreateReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/AdminCreateReservationServiceImpl.java
@@ -1,0 +1,81 @@
+package team.washer.server.v2.domain.reservation.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.reservation.dto.request.AdminCreateReservationReqDto;
+import team.washer.server.v2.domain.reservation.dto.response.AdminReservationResDto;
+import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.reservation.service.AdminCreateReservationService;
+import team.washer.server.v2.domain.reservation.support.ReservationCreationSupport;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+/**
+ * 관리자가 특정 사용자를 대신하여 예약을 생성하는 서비스.
+ *
+ * <p>
+ * 예약의 주체는 요청 바디의 {@code userId}이고, 토큰의 관리자는 {@code createdBy}로만 기록된다. 관리자의 현장
+ * 판단을 신뢰하므로 시간대 제한·48시간 호실 차단·5분 쿨다운 같은 정책 검증은 우회하지만, 층 제한·호실 세탁 금지·기기 가용성·중복
+ * 예약 같은 불변식은 그대로 적용한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminCreateReservationServiceImpl implements AdminCreateReservationService {
+
+    private final UserRepository userRepository;
+    private final CurrentUserProvider currentUserProvider;
+    private final ReservationCreationSupport reservationCreationSupport;
+
+    @Override
+    @Transactional
+    public AdminReservationResDto execute(final AdminCreateReservationReqDto reqDto) {
+        final User targetUser = userRepository.findById(reqDto.userId())
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        final var adminId = currentUserProvider.getCurrentUserId();
+        final User adminUser = userRepository.findById(adminId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+
+        reservationCreationSupport.validateRoomConstraints(targetUser);
+
+        // 동일 기기 동시 예약 직렬화를 위해 비관적 쓰기 락으로 조회
+        final Machine machine = reservationCreationSupport.lockMachine(reqDto.machineId());
+
+        reservationCreationSupport.validateMachineAndReservations(targetUser, machine);
+
+        final Reservation saved = reservationCreationSupport.create(targetUser, machine, adminUser);
+        log.info("admin created proxy reservation reservationId={} targetUserId={} adminId={} machineId={}",
+                saved.getId(),
+                reqDto.userId(),
+                adminId,
+                machine.getId());
+
+        return mapToAdminReservationResDto(saved, adminUser);
+    }
+
+    private AdminReservationResDto mapToAdminReservationResDto(final Reservation reservation, final User adminUser) {
+        return new AdminReservationResDto(reservation.getId(),
+                reservation.getUser().getId(),
+                reservation.getUser().getName(),
+                reservation.getUser().getRoomNumber(),
+                reservation.getUser().getStudentId(),
+                reservation.getMachine().getId(),
+                reservation.getMachine().getName(),
+                reservation.getMachine().getAvailability(),
+                reservation.getReservedAt(),
+                reservation.getStartTime(),
+                reservation.getExpectedCompletionTime(),
+                reservation.getActualCompletionTime(),
+                reservation.getStatus(),
+                reservation.getCancelledAt(),
+                adminUser.getName());
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CancelReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CancelReservationServiceImpl.java
@@ -48,20 +48,23 @@ public class CancelReservationServiceImpl implements CancelReservationService {
             throw new ExpectedException("취소할 수 있는 상태의 예약이 아닙니다", HttpStatus.BAD_REQUEST);
         }
 
-        // RESERVED 상태에서 수동 취소 시 패널티 적용
-        final User user = reservation.getUser();
-        penaltyRedisUtil.applyCooldown(userId, reservation.getMachine().getType());
-        penaltyRedisUtil.recordCancellation(userId);
-        user.updateLastCancellationTime();
-        if (penaltyRedisUtil.getCancellationCount(userId) > PenaltyConstants.MAX_CANCELLATIONS_IN_48H) {
-            final boolean wasBlocked = penaltyRedisUtil.isBlocked(user.getRoomNumber());
-            penaltyRedisUtil.applyBlock(user.getRoomNumber());
-            if (!wasBlocked) {
-                reservationNotificationSupport.sendCancellationBlock(user, reservation.getMachine());
+        // 수동 취소 시 패널티 적용. 단, 관리자 대리 예약은 본인이 요청한 것이 아니므로 면제한다
+        final boolean applyPenalty = !reservation.isProxyReservation();
+        if (applyPenalty) {
+            final User user = reservation.getUser();
+            penaltyRedisUtil.applyCooldown(userId, reservation.getMachine().getType());
+            penaltyRedisUtil.recordCancellation(userId);
+            user.updateLastCancellationTime();
+            if (penaltyRedisUtil.getCancellationCount(userId) > PenaltyConstants.MAX_CANCELLATIONS_IN_48H) {
+                final boolean wasBlocked = penaltyRedisUtil.isBlocked(user.getRoomNumber());
+                penaltyRedisUtil.applyBlock(user.getRoomNumber());
+                if (!wasBlocked) {
+                    reservationNotificationSupport.sendCancellationBlock(user, reservation.getMachine());
+                }
+                log.warn("48h block applied roomNumber={}", user.getRoomNumber());
             }
-            log.warn("48h block applied roomNumber={}", user.getRoomNumber());
+            log.info("manual cancel penalty applied userId={} reservationId={}", userId, reservationId);
         }
-        log.info("manual cancel penalty applied userId={} reservationId={}", userId, reservationId);
 
         final var machine = reservation.getMachine();
         reservation.cancel();
@@ -70,10 +73,11 @@ public class CancelReservationServiceImpl implements CancelReservationService {
         machineRepository.save(machine);
         log.info("Cancelled reservation reservationId={} userId={}", reservationId, userId);
 
-        return mapToCancellationResDto();
+        return mapToCancellationResDto(applyPenalty);
     }
 
-    private CancellationResDto mapToCancellationResDto() {
-        return new CancellationResDto(true, "예약이 취소되었습니다. 5분간 동일 종류 기기 재예약이 제한됩니다.", true, null);
+    private CancellationResDto mapToCancellationResDto(final boolean penaltyApplied) {
+        final String message = penaltyApplied ? "예약이 취소되었습니다. 5분간 동일 종류 기기 재예약이 제한됩니다." : "예약이 취소되었습니다.";
+        return new CancellationResDto(true, message, penaltyApplied, null);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
@@ -1,7 +1,5 @@
 package team.washer.server.v2.domain.reservation.service.impl;
 
-import java.util.List;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -9,18 +7,13 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.themoment.sdk.exception.ExpectedException;
-import team.washer.server.v2.domain.admin.repository.WashingBanRepository;
 import team.washer.server.v2.domain.machine.entity.Machine;
-import team.washer.server.v2.domain.machine.enums.MachineAvailability;
-import team.washer.server.v2.domain.machine.enums.MachineStatus;
-import team.washer.server.v2.domain.machine.repository.MachineRepository;
 import team.washer.server.v2.domain.reservation.config.ReservationEnvironment;
 import team.washer.server.v2.domain.reservation.dto.request.CreateReservationReqDto;
 import team.washer.server.v2.domain.reservation.dto.response.ReservationResDto;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
-import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
-import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.reservation.service.CreateReservationService;
+import team.washer.server.v2.domain.reservation.support.ReservationCreationSupport;
 import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
@@ -32,16 +25,11 @@ import team.washer.server.v2.global.util.DateTimeUtil;
 @RequiredArgsConstructor
 public class CreateReservationServiceImpl implements CreateReservationService {
 
-    private static final List<ReservationStatus> ACTIVE_STATUSES = List.of(ReservationStatus.RESERVED,
-            ReservationStatus.RUNNING);
-
-    private final ReservationRepository reservationRepository;
     private final UserRepository userRepository;
-    private final MachineRepository machineRepository;
-    private final WashingBanRepository washingBanRepository;
     private final PenaltyRedisUtil penaltyRedisUtil;
     private final ReservationEnvironment reservationEnvironment;
     private final CurrentUserProvider currentUserProvider;
+    private final ReservationCreationSupport reservationCreationSupport;
 
     @Override
     @Transactional
@@ -50,17 +38,7 @@ public class CreateReservationServiceImpl implements CreateReservationService {
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
-        user.validateFloorRestriction();
-
-        final String roomNumber = user.getRoomNumber();
-        if (roomNumber == null) {
-            throw new ExpectedException("호실 정보가 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
-        }
-
-        // 호실 세탁 강제 금지 검증
-        if (washingBanRepository.existsByRoomNumber(roomNumber)) {
-            throw new ExpectedException("해당 호실은 현재 세탁이 금지된 상태입니다.", HttpStatus.FORBIDDEN);
-        }
+        final String roomNumber = reservationCreationSupport.validateRoomConstraints(user);
 
         // 48시간 차단 검증 (호실 단위)
         if (penaltyRedisUtil.isBlocked(roomNumber)) {
@@ -73,8 +51,7 @@ public class CreateReservationServiceImpl implements CreateReservationService {
         }
 
         // 동일 기기 동시 예약 직렬화를 위해 비관적 쓰기 락으로 조회
-        final Machine machine = machineRepository.findByIdForUpdate(reqDto.machineId())
-                .orElseThrow(() -> new ExpectedException("기기를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+        final Machine machine = reservationCreationSupport.lockMachine(reqDto.machineId());
 
         // 쿨다운 검증 (취소 후 5분, 동일 기기 유형 한정)
         if (penaltyRedisUtil.isInCooldown(userId, machine.getType())) {
@@ -82,43 +59,9 @@ public class CreateReservationServiceImpl implements CreateReservationService {
                     HttpStatus.BAD_REQUEST);
         }
 
-        final var activeMachineReservations = reservationRepository.findByMachineAndStatusIn(machine, ACTIVE_STATUSES);
+        reservationCreationSupport.validateMachineAndReservations(user, machine);
 
-        // 기기 가용성 검증
-        if (machine.getAvailability() != MachineAvailability.AVAILABLE
-                && !canReuseStaleReservedSlot(machine, activeMachineReservations)) {
-            throw new ExpectedException(String.format("해당 기기를 사용할 수 없습니다. 기기: %s", machine.getName()),
-                    HttpStatus.BAD_REQUEST);
-        }
-
-        // 기기 단위 중복 예약 검증 (가용성 플래그 드리프트에 대한 방어 심화)
-        if (hasCurrentActiveReservation(activeMachineReservations)) {
-            throw new ExpectedException(String.format("해당 기기에 이미 진행 중인 예약이 있습니다. 기기: %s", machine.getName()),
-                    HttpStatus.CONFLICT);
-        }
-
-        // 개인 중복 예약 검증 (1인 1예약)
-        final var userActiveReservations = reservationRepository.findByUserAndStatusIn(user, ACTIVE_STATUSES);
-        if (hasCurrentActiveReservation(userActiveReservations)) {
-            throw new ExpectedException("이미 활성 예약이 존재합니다. 1인 1예약만 가능합니다.", HttpStatus.BAD_REQUEST);
-        }
-
-        // 동일 호실의 동일 유형 기기 중복 예약 검증
-        final boolean hasDuplicateTypeReservation = reservationRepository.findActiveReservationsByRoomNumber(roomNumber)
-                .stream().filter(reservation -> reservation.getMachine().getType() == machine.getType())
-                .anyMatch(reservation -> reservation.isActive() && !reservation.isExpired());
-        if (hasDuplicateTypeReservation) {
-            throw new ExpectedException(String.format("해당 호실에 이미 %s 예약이 존재합니다. 동일 유형의 기기는 동시에 두 개 이상 예약할 수 없습니다.",
-                    machine.getType().getDescription()), HttpStatus.BAD_REQUEST);
-        }
-
-        final var now = DateTimeUtil.nowInKorea();
-        final Reservation reservation = Reservation.builder().user(user).machine(machine).reservedAt(now)
-                .dayOfWeek(now.getDayOfWeek()).status(ReservationStatus.RESERVED).build();
-
-        machine.markAsReserved();
-        machineRepository.save(machine);
-        final Reservation saved = reservationRepository.save(reservation);
+        final Reservation saved = reservationCreationSupport.create(user, machine, null);
         log.info("Created reservation {} for user {} on machine {}", saved.getId(), userId, machine.getId());
 
         return new ReservationResDto(saved.getId(),
@@ -137,14 +80,5 @@ public class CreateReservationServiceImpl implements CreateReservationService {
                 saved.getDayOfWeek(),
                 saved.getCreatedAt(),
                 saved.getUpdatedAt());
-    }
-
-    private boolean hasCurrentActiveReservation(List<Reservation> reservations) {
-        return reservations.stream().anyMatch(reservation -> reservation.isActive() && !reservation.isExpired());
-    }
-
-    private boolean canReuseStaleReservedSlot(Machine machine, List<Reservation> activeReservations) {
-        return machine.getStatus() == MachineStatus.NORMAL && machine.getAvailability() == MachineAvailability.RESERVED
-                && !hasCurrentActiveReservation(activeReservations);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/OverdueReservationProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/OverdueReservationProcessor.java
@@ -113,6 +113,12 @@ public class OverdueReservationProcessor {
         reservationRepository.save(reservation);
         machineRepository.save(machine);
 
+        // 관리자 대리 예약은 사용자 본인이 요청한 것이 아니므로 타임아웃 패널티를 부여하지 않는다
+        if (reservation.isProxyReservation()) {
+            log.info("proxy reservation timeout cancelled without penalty reservationId={}", reservationId);
+            return OverdueResult.CANCELLED_WITHOUT_PENALTY;
+        }
+
         applyTimeoutPenalty(reservation.getUser(), machine);
         return OverdueResult.CANCELLED;
     }

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryAllReservationsServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/QueryAllReservationsServiceImpl.java
@@ -55,6 +55,7 @@ public class QueryAllReservationsServiceImpl implements QueryAllReservationsServ
                 reservation.getExpectedCompletionTime(),
                 reservation.getActualCompletionTime(),
                 reservation.getStatus(),
-                reservation.getCancelledAt());
+                reservation.getCancelledAt(),
+                reservation.getCreatedBy() != null ? reservation.getCreatedBy().getName() : null);
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationCreationSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationCreationSupport.java
@@ -1,0 +1,172 @@
+package team.washer.server.v2.domain.reservation.support;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.admin.repository.WashingBanRepository;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.global.util.DateTimeUtil;
+
+/**
+ * 예약 생성 경로가 공유하는 불변식 검증과 엔티티 생성을 담당하는 컴포넌트.
+ *
+ * <p>
+ * 사용자 본인 예약({@code CreateReservationServiceImpl})과 관리자 대리 예약
+ * ({@code AdminCreateReservationServiceImpl})은 "어떤 상태에서 예약이 성립하는가"라는 불변식은
+ * 공유하지만, 정책 검증(시간대 제한·48시간 호실 차단·5분 쿨다운)은 본인 예약 경로에만 적용된다. 따라서 이 컴포넌트는 불변식만 담고
+ * 정책 검증은 각 서비스가 직접 수행한다.
+ *
+ * <p>
+ * 호출 순서는 {@code validateRoomConstraints} → {@code lockMachine} →
+ * {@code validateMachineAndReservations} → {@code create}를 전제로 한다. 특히 기기 비관적 락이
+ * 중복 검증보다 먼저 수행되어야 동일 기기에 대한 동시 예약이 직렬화된다.
+ */
+@Component
+@RequiredArgsConstructor
+public class ReservationCreationSupport {
+
+    private static final List<ReservationStatus> ACTIVE_STATUSES = List.of(ReservationStatus.RESERVED,
+            ReservationStatus.RUNNING);
+
+    private final ReservationRepository reservationRepository;
+    private final MachineRepository machineRepository;
+    private final WashingBanRepository washingBanRepository;
+
+    /**
+     * 사용자의 호실 관련 제약을 검증합니다. 층 제한, 호실 정보 존재 여부, 호실 세탁 강제 금지를 차례로 확인합니다.
+     *
+     * @param user
+     *            예약 주체가 될 사용자
+     * @return 검증을 통과한 사용자의 호실 번호
+     */
+    public String validateRoomConstraints(final User user) {
+        user.validateFloorRestriction();
+
+        final String roomNumber = user.getRoomNumber();
+        if (roomNumber == null) {
+            throw new ExpectedException("호실 정보가 존재하지 않습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        // 호실 세탁 강제 금지 검증
+        if (washingBanRepository.existsByRoomNumber(roomNumber)) {
+            throw new ExpectedException("해당 호실은 현재 세탁이 금지된 상태입니다.", HttpStatus.FORBIDDEN);
+        }
+
+        return roomNumber;
+    }
+
+    /**
+     * 동일 기기 동시 예약을 직렬화하기 위해 기기를 비관적 쓰기 락으로 조회합니다.
+     *
+     * @param machineId
+     *            조회할 기기 ID
+     * @return 락을 획득한 기기
+     */
+    public Machine lockMachine(final Long machineId) {
+        return machineRepository.findByIdForUpdate(machineId)
+                .orElseThrow(() -> new ExpectedException("기기를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
+    }
+
+    /**
+     * 기기 가용성과 중복 예약 불변식을 검증합니다. 기기 가용성 → 기기 단위 중복 → 1인 1예약 → 호실 동일 유형 중복 순으로 확인합니다.
+     *
+     * <p>
+     * 모든 판정은 타임아웃이 지난 예약을 활성으로 세지 않는다. 스케줄러가 아직 정리하지 못한 만료 예약 때문에 새 예약이 막히는 것을 막기
+     * 위함이다.
+     *
+     * @param user
+     *            예약 주체가 될 사용자
+     * @param machine
+     *            락을 획득한 기기
+     */
+    public void validateMachineAndReservations(final User user, final Machine machine) {
+        final var activeMachineReservations = reservationRepository.findByMachineAndStatusIn(machine, ACTIVE_STATUSES);
+
+        // 기기 가용성 검증
+        if (machine.getAvailability() != MachineAvailability.AVAILABLE
+                && !canReuseStaleReservedSlot(machine, activeMachineReservations)) {
+            throw new ExpectedException(String.format("해당 기기를 사용할 수 없습니다. 기기: %s", machine.getName()),
+                    HttpStatus.BAD_REQUEST);
+        }
+
+        // 기기 단위 중복 예약 검증 (가용성 플래그 드리프트에 대한 방어 심화)
+        if (hasCurrentActiveReservation(activeMachineReservations)) {
+            throw new ExpectedException(String.format("해당 기기에 이미 진행 중인 예약이 있습니다. 기기: %s", machine.getName()),
+                    HttpStatus.CONFLICT);
+        }
+
+        // 개인 중복 예약 검증 (1인 1예약)
+        final var userActiveReservations = reservationRepository.findByUserAndStatusIn(user, ACTIVE_STATUSES);
+        if (hasCurrentActiveReservation(userActiveReservations)) {
+            throw new ExpectedException("이미 활성 예약이 존재합니다. 1인 1예약만 가능합니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        // 동일 호실의 동일 유형 기기 중복 예약 검증
+        final boolean hasDuplicateTypeReservation = reservationRepository
+                .findActiveReservationsByRoomNumber(user.getRoomNumber()).stream()
+                .filter(reservation -> reservation.getMachine().getType() == machine.getType())
+                .anyMatch(reservation -> reservation.isActive() && !reservation.isExpired());
+        if (hasDuplicateTypeReservation) {
+            throw new ExpectedException(String.format("해당 호실에 이미 %s 예약이 존재합니다. 동일 유형의 기기는 동시에 두 개 이상 예약할 수 없습니다.",
+                    machine.getType().getDescription()), HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    /**
+     * 타임아웃이 지나지 않은 진짜 활성 예약이 있는지 판정합니다.
+     *
+     * @param reservations
+     *            판정 대상 예약 목록
+     * @return 만료되지 않은 활성 예약 존재 여부
+     */
+    private boolean hasCurrentActiveReservation(final List<Reservation> reservations) {
+        return reservations.stream().anyMatch(reservation -> reservation.isActive() && !reservation.isExpired());
+    }
+
+    /**
+     * 만료된 예약만 남아 RESERVED로 굳어버린 기기를 재사용할 수 있는지 판정합니다.
+     *
+     * @param machine
+     *            락을 획득한 기기
+     * @param activeReservations
+     *            해당 기기의 활성 상태 예약 목록
+     * @return 재사용 가능 여부
+     */
+    private boolean canReuseStaleReservedSlot(final Machine machine, final List<Reservation> activeReservations) {
+        return machine.getStatus() == MachineStatus.NORMAL && machine.getAvailability() == MachineAvailability.RESERVED
+                && !hasCurrentActiveReservation(activeReservations);
+    }
+
+    /**
+     * 예약 엔티티를 생성하고 기기를 예약 상태로 전환합니다.
+     *
+     * @param user
+     *            예약 주체
+     * @param machine
+     *            예약 대상 기기
+     * @param createdBy
+     *            대리 예약을 생성한 관리자. 사용자 본인 예약이면 {@code null}
+     * @return 저장된 예약
+     */
+    public Reservation create(final User user, final Machine machine, final User createdBy) {
+        final var now = DateTimeUtil.nowInKorea();
+        final Reservation reservation = Reservation.builder().user(user).machine(machine).createdBy(createdBy)
+                .reservedAt(now).dayOfWeek(now.getDayOfWeek()).status(ReservationStatus.RESERVED).build();
+
+        machine.markAsReserved();
+        machineRepository.save(machine);
+
+        return reservationRepository.save(reservation);
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/AdminCreateReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/AdminCreateReservationServiceTest.java
@@ -1,0 +1,272 @@
+package team.washer.server.v2.domain.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.admin.repository.WashingBanRepository;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.reservation.dto.request.AdminCreateReservationReqDto;
+import team.washer.server.v2.domain.reservation.entity.Reservation;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.reservation.service.impl.AdminCreateReservationServiceImpl;
+import team.washer.server.v2.domain.reservation.support.ReservationCreationSupport;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+@ExtendWith(MockitoExtension.class)
+class AdminCreateReservationServiceTest {
+
+    private AdminCreateReservationServiceImpl adminCreateReservationService;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private MachineRepository machineRepository;
+    @Mock
+    private WashingBanRepository washingBanRepository;
+    @Mock
+    private CurrentUserProvider currentUserProvider;
+
+    @Mock
+    private User targetUser;
+    @Mock
+    private User adminUser;
+    @Mock
+    private Machine machine;
+    @Mock
+    private Reservation activeReservation;
+
+    private static final Long TARGET_USER_ID = 12L;
+    private static final Long ADMIN_ID = 1L;
+    private static final Long MACHINE_ID = 3L;
+    private static final String ROOM_NUMBER = "301";
+    private static final String ADMIN_NAME = "박관리";
+
+    // 불변식 검증 순서와 에러 메시지를 그대로 검증하기 위해 Support는 실제 구현체를 사용한다
+    @BeforeEach
+    void setUp() {
+        final var reservationCreationSupport = new ReservationCreationSupport(reservationRepository,
+                machineRepository,
+                washingBanRepository);
+        adminCreateReservationService = new AdminCreateReservationServiceImpl(userRepository,
+                currentUserProvider,
+                reservationCreationSupport);
+    }
+
+    private AdminCreateReservationReqDto givenValidRequest() {
+        when(userRepository.findById(TARGET_USER_ID)).thenReturn(Optional.of(targetUser));
+        when(currentUserProvider.getCurrentUserId()).thenReturn(ADMIN_ID);
+        when(userRepository.findById(ADMIN_ID)).thenReturn(Optional.of(adminUser));
+        when(targetUser.getRoomNumber()).thenReturn(ROOM_NUMBER);
+        when(machineRepository.findByIdForUpdate(MACHINE_ID)).thenReturn(Optional.of(machine));
+        when(machine.getAvailability()).thenReturn(MachineAvailability.AVAILABLE);
+        when(reservationRepository.save(any(Reservation.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        return new AdminCreateReservationReqDto(TARGET_USER_ID, MACHINE_ID);
+    }
+
+    @Nested
+    @DisplayName("관리자 대리 예약 생성")
+    class ExecuteTest {
+
+        @Test
+        @DisplayName("관리자가 지정한 사용자 명의로 예약이 생성된다")
+        void execute_ShouldCreateReservationForTargetUser() {
+            // Given
+            final var reqDto = givenValidRequest();
+
+            // When
+            final var result = adminCreateReservationService.execute(reqDto);
+
+            // Then
+            final var captor = ArgumentCaptor.forClass(Reservation.class);
+            verify(reservationRepository).save(captor.capture());
+            assertThat(captor.getValue().getUser()).isSameAs(targetUser);
+            assertThat(result).isNotNull();
+            verify(machine).markAsReserved();
+        }
+
+        @Test
+        @DisplayName("생성된 예약의 createdBy에 관리자가 기록된다")
+        void execute_ShouldRecordAdminAsCreatedBy() {
+            // Given
+            final var reqDto = givenValidRequest();
+            when(adminUser.getName()).thenReturn(ADMIN_NAME);
+
+            // When
+            final var result = adminCreateReservationService.execute(reqDto);
+
+            // Then
+            final var captor = ArgumentCaptor.forClass(Reservation.class);
+            verify(reservationRepository).save(captor.capture());
+            assertThat(captor.getValue().getCreatedBy()).isSameAs(adminUser);
+            assertThat(captor.getValue().isProxyReservation()).isTrue();
+            assertThat(result.createdByAdminName()).isEqualTo(ADMIN_NAME);
+        }
+
+        @Test
+        @DisplayName("시간 제한 시간대에도 대리 예약이 생성된다")
+        void execute_ShouldBypassTimeRestriction() {
+            // Given
+            final var reqDto = givenValidRequest();
+
+            // When
+            adminCreateReservationService.execute(reqDto);
+
+            // Then
+            verify(targetUser, never()).validateTimeRestriction(any());
+            verify(reservationRepository).save(any(Reservation.class));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 사용자면 NOT_FOUND 예외를 발생시킨다")
+        void execute_ShouldThrowNotFound_WhenTargetUserNotFound() {
+            // Given
+            final var reqDto = new AdminCreateReservationReqDto(TARGET_USER_ID, MACHINE_ID);
+            when(userRepository.findById(TARGET_USER_ID)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> adminCreateReservationService.execute(reqDto))
+                    .isInstanceOf(ExpectedException.class).hasMessageContaining("사용자를 찾을 수 없습니다").satisfies(
+                            e -> assertThat(((ExpectedException) e).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 기기면 NOT_FOUND 예외를 발생시킨다")
+        void execute_ShouldThrowNotFound_WhenMachineNotFound() {
+            // Given
+            final var reqDto = new AdminCreateReservationReqDto(TARGET_USER_ID, MACHINE_ID);
+            when(userRepository.findById(TARGET_USER_ID)).thenReturn(Optional.of(targetUser));
+            when(currentUserProvider.getCurrentUserId()).thenReturn(ADMIN_ID);
+            when(userRepository.findById(ADMIN_ID)).thenReturn(Optional.of(adminUser));
+            when(targetUser.getRoomNumber()).thenReturn(ROOM_NUMBER);
+            when(machineRepository.findByIdForUpdate(MACHINE_ID)).thenReturn(Optional.empty());
+
+            // When & Then
+            assertThatThrownBy(() -> adminCreateReservationService.execute(reqDto))
+                    .isInstanceOf(ExpectedException.class).hasMessageContaining("기기를 찾을 수 없습니다").satisfies(
+                            e -> assertThat(((ExpectedException) e).getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("세탁이 금지된 호실이면 FORBIDDEN 예외를 발생시킨다")
+        void execute_ShouldThrowForbidden_WhenRoomIsBanned() {
+            // Given
+            final var reqDto = new AdminCreateReservationReqDto(TARGET_USER_ID, MACHINE_ID);
+            when(userRepository.findById(TARGET_USER_ID)).thenReturn(Optional.of(targetUser));
+            when(currentUserProvider.getCurrentUserId()).thenReturn(ADMIN_ID);
+            when(userRepository.findById(ADMIN_ID)).thenReturn(Optional.of(adminUser));
+            when(targetUser.getRoomNumber()).thenReturn(ROOM_NUMBER);
+            when(washingBanRepository.existsByRoomNumber(ROOM_NUMBER)).thenReturn(true);
+
+            // When & Then
+            assertThatThrownBy(() -> adminCreateReservationService.execute(reqDto))
+                    .isInstanceOf(ExpectedException.class).hasMessageContaining("세탁이 금지된").satisfies(
+                            e -> assertThat(((ExpectedException) e).getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN));
+        }
+
+        @Test
+        @DisplayName("기기가 사용 불가 상태이면 BAD_REQUEST 예외를 발생시킨다")
+        void execute_ShouldThrowBadRequest_WhenMachineNotAvailable() {
+            // Given
+            final var reqDto = new AdminCreateReservationReqDto(TARGET_USER_ID, MACHINE_ID);
+            when(userRepository.findById(TARGET_USER_ID)).thenReturn(Optional.of(targetUser));
+            when(currentUserProvider.getCurrentUserId()).thenReturn(ADMIN_ID);
+            when(userRepository.findById(ADMIN_ID)).thenReturn(Optional.of(adminUser));
+            when(targetUser.getRoomNumber()).thenReturn(ROOM_NUMBER);
+            when(machineRepository.findByIdForUpdate(MACHINE_ID)).thenReturn(Optional.of(machine));
+            when(machine.getAvailability()).thenReturn(MachineAvailability.IN_USE);
+
+            // When & Then
+            assertThatThrownBy(() -> adminCreateReservationService.execute(reqDto))
+                    .isInstanceOf(ExpectedException.class).hasMessageContaining("해당 기기를 사용할 수 없습니다").satisfies(
+                            e -> assertThat(((ExpectedException) e).getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST));
+        }
+
+        @Test
+        @DisplayName("기기에 이미 진행 중인 예약이 있으면 CONFLICT 예외를 발생시킨다")
+        void execute_ShouldThrowConflict_WhenMachineHasActiveReservation() {
+            // Given
+            final var reqDto = new AdminCreateReservationReqDto(TARGET_USER_ID, MACHINE_ID);
+            when(userRepository.findById(TARGET_USER_ID)).thenReturn(Optional.of(targetUser));
+            when(currentUserProvider.getCurrentUserId()).thenReturn(ADMIN_ID);
+            when(userRepository.findById(ADMIN_ID)).thenReturn(Optional.of(adminUser));
+            when(targetUser.getRoomNumber()).thenReturn(ROOM_NUMBER);
+            when(machineRepository.findByIdForUpdate(MACHINE_ID)).thenReturn(Optional.of(machine));
+            when(machine.getAvailability()).thenReturn(MachineAvailability.AVAILABLE);
+            when(activeReservation.isActive()).thenReturn(true);
+            when(reservationRepository.findByMachineAndStatusIn(eq(machine), any()))
+                    .thenReturn(List.of(activeReservation));
+
+            // When & Then
+            assertThatThrownBy(() -> adminCreateReservationService.execute(reqDto))
+                    .isInstanceOf(ExpectedException.class).hasMessageContaining("이미 진행 중인 예약이 있습니다")
+                    .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode()).isEqualTo(HttpStatus.CONFLICT));
+        }
+
+        @Test
+        @DisplayName("대상 사용자에게 이미 활성 예약이 있으면 예외를 발생시킨다")
+        void execute_ShouldThrowBadRequest_WhenTargetUserHasActiveReservation() {
+            // Given
+            final var reqDto = new AdminCreateReservationReqDto(TARGET_USER_ID, MACHINE_ID);
+            when(userRepository.findById(TARGET_USER_ID)).thenReturn(Optional.of(targetUser));
+            when(currentUserProvider.getCurrentUserId()).thenReturn(ADMIN_ID);
+            when(userRepository.findById(ADMIN_ID)).thenReturn(Optional.of(adminUser));
+            when(targetUser.getRoomNumber()).thenReturn(ROOM_NUMBER);
+            when(machineRepository.findByIdForUpdate(MACHINE_ID)).thenReturn(Optional.of(machine));
+            when(machine.getAvailability()).thenReturn(MachineAvailability.AVAILABLE);
+            when(activeReservation.isActive()).thenReturn(true);
+            when(reservationRepository.findByUserAndStatusIn(eq(targetUser), any()))
+                    .thenReturn(List.of(activeReservation));
+
+            // When & Then
+            assertThatThrownBy(() -> adminCreateReservationService.execute(reqDto))
+                    .isInstanceOf(ExpectedException.class).hasMessageContaining("1인 1예약만 가능합니다");
+        }
+
+        @Test
+        @DisplayName("호실에 동일 유형의 활성 예약이 있으면 예외를 발생시킨다")
+        void execute_ShouldThrowBadRequest_WhenRoomHasSameTypeReservation() {
+            // Given
+            final var reqDto = new AdminCreateReservationReqDto(TARGET_USER_ID, MACHINE_ID);
+            when(userRepository.findById(TARGET_USER_ID)).thenReturn(Optional.of(targetUser));
+            when(currentUserProvider.getCurrentUserId()).thenReturn(ADMIN_ID);
+            when(userRepository.findById(ADMIN_ID)).thenReturn(Optional.of(adminUser));
+            when(targetUser.getRoomNumber()).thenReturn(ROOM_NUMBER);
+            when(machineRepository.findByIdForUpdate(MACHINE_ID)).thenReturn(Optional.of(machine));
+            when(machine.getAvailability()).thenReturn(MachineAvailability.AVAILABLE);
+            when(machine.getType()).thenReturn(MachineType.WASHER);
+            when(activeReservation.getMachine()).thenReturn(machine);
+            when(activeReservation.isActive()).thenReturn(true);
+            when(reservationRepository.findActiveReservationsByRoomNumber(ROOM_NUMBER))
+                    .thenReturn(List.of(activeReservation));
+
+            // When & Then
+            assertThatThrownBy(() -> adminCreateReservationService.execute(reqDto))
+                    .isInstanceOf(ExpectedException.class).hasMessageContaining("동일 유형의 기기는 동시에 두 개 이상 예약할 수 없습니다");
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/CancelReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/CancelReservationServiceTest.java
@@ -56,6 +56,9 @@ class CancelReservationServiceTest {
     @Mock
     private User user;
 
+    @Mock
+    private User adminUser;
+
     private Machine createMachine() {
         return Machine.builder().name("W-2F-L1").type(MachineType.WASHER).deviceId("device-1").floor(2)
                 .position(Position.LEFT).number(1).status(MachineStatus.NORMAL)
@@ -104,6 +107,35 @@ class CancelReservationServiceTest {
                 then(penaltyRedisUtil).should(times(1)).recordCancellation(userId);
                 then(reservationRepository).should(times(1)).save(reservation);
                 then(machineRepository).should(times(1)).save(reservation.getMachine());
+            }
+        }
+
+        @Nested
+        @DisplayName("관리자가 대리 생성한 RESERVED 예약을 소유자가 취소할 때")
+        class Context_with_proxy_reservation {
+
+            @Test
+            @DisplayName("패널티 없이 예약만 취소되어야 한다")
+            void it_cancels_without_penalty() {
+                // Given
+                var userId = 1L;
+                var reservationId = 10L;
+                var machine = createMachine();
+                given(user.getId()).willReturn(userId);
+                var reservation = Reservation.builder().user(user).machine(machine).createdBy(adminUser)
+                        .reservedAt(LocalDateTime.now()).status(ReservationStatus.RESERVED).build();
+
+                given(currentUserProvider.getCurrentUserId()).willReturn(userId);
+                given(reservationRepository.findByIdForUpdate(reservationId)).willReturn(Optional.of(reservation));
+
+                // When
+                var result = cancelReservationService.execute(reservationId);
+
+                // Then
+                assertThat(result.penaltyApplied()).isFalse();
+                assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+                assertThat(reservation.getMachine().getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
+                then(penaltyRedisUtil).shouldHaveNoInteractions();
             }
         }
 

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
@@ -9,11 +9,11 @@ import static org.mockito.Mockito.*;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
@@ -32,6 +32,7 @@ import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.reservation.service.impl.CreateReservationServiceImpl;
+import team.washer.server.v2.domain.reservation.support.ReservationCreationSupport;
 import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
@@ -41,7 +42,6 @@ import team.washer.server.v2.global.util.DateTimeUtil;
 @ExtendWith(MockitoExtension.class)
 class CreateReservationServiceTest {
 
-    @InjectMocks
     private CreateReservationServiceImpl createReservationService;
 
     @Mock
@@ -68,6 +68,19 @@ class CreateReservationServiceTest {
 
     private static final Long USER_ID = 1L;
     private static final String ROOM_NUMBER = "101";
+
+    // 검증 순서와 에러 메시지를 그대로 검증하기 위해 Support는 실제 구현체를 사용한다
+    @BeforeEach
+    void setUp() {
+        final var reservationCreationSupport = new ReservationCreationSupport(reservationRepository,
+                machineRepository,
+                washingBanRepository);
+        createReservationService = new CreateReservationServiceImpl(userRepository,
+                penaltyRedisUtil,
+                reservationEnvironment,
+                currentUserProvider,
+                reservationCreationSupport);
+    }
 
     @Nested
     @DisplayName("예약 생성")

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/OverdueReservationProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/OverdueReservationProcessorTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
@@ -208,6 +209,28 @@ class OverdueReservationProcessorTest {
             verify(reservationNotificationSupport, times(1)).sendTimeoutWarning(user, machine);
             verify(reservationNotificationSupport, never()).sendAutoCancellation(any(), any());
             verify(reservation, never()).start(any());
+        }
+
+        @Test
+        @DisplayName("관리자 대리 예약이면 취소와 기기 반납만 수행하고 패널티를 부여하지 않는다")
+        void shouldCancelWithoutPenalty_WhenProxyReservation() {
+            // Given
+            var deviceStatus = buildDeviceStatus(null);
+            givenReservedReservation();
+            when(reservationStartDecisionSupport.decide(any(SmartThingsDeviceStatusResDto.class), anyBoolean()))
+                    .thenReturn(StartDecision.IDLE);
+            when(reservation.isProxyReservation()).thenReturn(true);
+
+            // When
+            var result = overdueReservationProcessor.processOverdue(RESERVATION_ID, deviceStatus);
+
+            // Then
+            assertThat(result).isEqualTo(OverdueResult.CANCELLED_WITHOUT_PENALTY);
+            verify(reservation, times(1)).cancel();
+            verify(machine, times(1)).markAsAvailable();
+            verify(reservationRepository, times(1)).save(reservation);
+            verifyNoInteractions(penaltyRedisUtil);
+            verifyNoInteractions(reservationNotificationSupport);
         }
 
         @Test


### PR DESCRIPTION
## 개요

관리자가 대상 사용자와 기기를 지정하여 그 사용자 명의로 예약을 생성하는 API를 추가하였습니다. 예약 주체는 요청 바디의 `userId`이고, 토큰의 관리자는 `createdBy`로만 기록됩니다. 사용자 본인 예약 경로와 공유하는 검증 로직은 `ReservationCreationSupport`로 분리하였습니다.

## 본문

### API

`POST /api/v2/admin/reservations` 를 추가하였습니다. 요청 바디는 `AdminCreateReservationReqDto`(`userId`, `machineId`)이고 응답은 `AdminReservationResDto`입니다. 권한은 기존 `/api/v2/admin/**` 규칙(`DORMITORY_COUNCIL`, `ADMIN`)을 그대로 따르므로 별도 설정을 추가하지 않았습니다.

### 검증 정책

관리자의 현장 판단을 신뢰하여 정책성 제한은 우회하되, 데이터 정합성 불변식은 그대로 적용하였습니다.

| 검증 | 본인 예약 | 대리 예약 |
|------|:--------:|:--------:|
| 층 제한, 호실 세탁 금지 | O | O |
| 기기 가용성, 기기 중복, 1인 1예약, 호실 동일유형 중복 | O | O |
| 시간대 제한 | O | X |
| 48시간 호실 차단, 5분 쿨다운 | O | X |

### 공통 로직 추출

두 경로가 공유하는 불변식 검증과 엔티티 생성을 `ReservationCreationSupport`로 옮겼습니다. 정책 검증은 경로마다 다르므로 각 서비스가 직접 수행합니다. 기기 비관적 락이 중복 검증보다 먼저 수행되어야 동시 예약이 직렬화되므로 기존 호출 순서를 그대로 유지하였습니다. `CreateReservationServiceImpl`의 외부 동작과 에러 메시지는 변경되지 않았습니다.

`#110`에서 도입된 만료 인지 판정(`hasCurrentActiveReservation`, `canReuseStaleReservedSlot`)도 Support로 함께 옮겨, 대리 예약 경로가 동일한 기준을 물려받도록 하였습니다.

### 패널티 면제

대리 예약은 사용자 본인이 요청한 것이 아니므로 수동 취소와 타임아웃 자동 취소 모두 패널티를 부여하지 않습니다. `CancelReservationServiceImpl`은 `applyPenalty` 플래그로 분기하며 응답 메시지도 함께 달라집니다. `OverdueReservationProcessor`는 `CANCELLED_WITHOUT_PENALTY`를 반환하고, 취소 처리와 기기 반납은 동일하게 수행합니다.

### 감사 추적 및 조회

`Reservation`에 nullable 필드 `createdBy`와 `isProxyReservation()`을 추가하였습니다. 기존 행은 모두 `null`이므로 마이그레이션 스크립트가 필요하지 않습니다. 관리자 예약 목록에는 `createdByAdminName`을 노출하며, N+1을 피하기 위해 `findAllWithFilters`에 `createdBy` fetch join을 추가하였습니다. `QUser` 기본 별칭은 `reservation.user` 조인이 이미 사용하고 있어 별도 별칭을 두었습니다.

사용자용 `ReservationResDto`는 변경하지 않았습니다.

### 테스트

`AdminCreateReservationServiceTest`를 신규 작성하였고(10개 케이스), 리팩터링 영향 경로인 `CreateReservationServiceTest`, `CancelReservationServiceTest`, `OverdueReservationProcessorTest`에 회귀 케이스를 보강하였습니다. 전체 436개 테스트와 `spotlessCheck`가 통과합니다.

설계 근거는 `docs/spec-admin-proxy-reservation.md`에 정리하였습니다.
