### PR TITLE
[smartthings] 완료 판정 반환 타입을 신호 객체로 교체

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationCompletionDecisionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationCompletionDecisionSupport.java
@@ -2,7 +2,9 @@ package team.washer.server.v2.domain.reservation.support;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import org.springframework.stereotype.Component;
 
@@ -10,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
-import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
+import team.washer.server.v2.domain.smartthings.support.MachineCompletionSignal;
 import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 import team.washer.server.v2.global.util.DateTimeUtil;
 
@@ -91,10 +93,11 @@ public class ReservationCompletionDecisionSupport {
     private Optional<CompletionCandidate> findCompletionCandidate(Reservation reservation,
             SmartThingsDeviceStatusResDto status,
             boolean isWasher) {
-        var detected = machineStateDetectionSupport.isCompleted(status, isWasher);
-        if (detected.isPresent()) {
-            return Optional.of(new CompletionCandidate(detected.get(), REASON_SMARTTHINGS_COMPLETED));
+        var signal = machineStateDetectionSupport.detectCompletion(status, isWasher);
+        if (signal.isCompleted()) {
+            return Optional.of(new CompletionCandidate(signal.completionTime(), REASON_SMARTTHINGS_COMPLETED));
         }
+
         var nearCompletion = findNearCompletionStopTime(reservation, status, isWasher)
                 .filter(completionTime -> !completionTime.isAfter(DateTimeUtil.nowInKorea()))
                 .map(completionTime -> new CompletionCandidate(completionTime, REASON_STOPPED_NEAR_COMPLETION));
@@ -102,7 +105,7 @@ public class ReservationCompletionDecisionSupport {
             return nearCompletion;
         }
 
-        return findStoppedResetCompletionTime(reservation, status, isWasher)
+        return findStoppedResetCompletionTime(reservation, status, isWasher, signal)
                 .map(completionTime -> new CompletionCandidate(completionTime, REASON_STOPPED_RESET_COMPLETION));
     }
 
@@ -111,52 +114,35 @@ public class ReservationCompletionDecisionSupport {
      * 판정한다.
      *
      * <p>
-     * 이 경우 보고된 완료 예정 시각은 이번 사이클의 종료 시각이 아니므로 완료 시각으로 쓸 수 없고, 미래 값이라
-     * {@code isCompleted} 와 {@code stopped_near_completion} 어느 경로에도 걸리지 않는다. 그대로 두면
-     * 사이클이 끝났는데도 예약이 RUNNING 으로 남아 기기가 계속 IN_USE로 표시되므로, 이번 사이클에서 갱신된 상태 타임스탬프를 근거로
-     * 완료 후보로 잡고 완료 시각은 현재 시각으로 본다.
+     * 이 상태의 감지 자체는 {@link MachineStateDetectionSupport#detectCompletion}가
+     * {@code JOB_RESET_WITH_FUTURE_COMPLETION} 신호로 알려준다. 보고된 완료 예정 시각은 이번 사이클의 종료
+     * 시각이 아니므로 완료 시각으로 쓸 수 없고, 그대로 두면 사이클이 끝났는데도 예약이 RUNNING 으로 남아 기기가 계속 IN_USE로
+     * 표시된다. 여기서는 이번 사이클에서 실제로 상태가 갱신됐는지를 예약 시작 시각과 대조해 확인한 뒤 완료 시각을 현재 시각으로 본다.
      *
      * <p>
      * 전원이 꺼진 정지는 완료가 아니라 중단이므로 여기서 제외한다.
      */
     private Optional<LocalDateTime> findStoppedResetCompletionTime(Reservation reservation,
             SmartThingsDeviceStatusResDto status,
-            boolean isWasher) {
-        if (status == null || machineStateDetectionSupport.isPoweredOff(status)) {
-            return Optional.empty();
-        }
-        if (!isStopped(status, isWasher) || !status.isJobStateReset(isWasher)) {
-            return Optional.empty();
-        }
-
-        var completionTime = DateTimeUtil.parseAndConvertToKoreaTime(getCompletionTime(status, isWasher));
-        var now = DateTimeUtil.nowInKorea();
-        if (completionTime == null || !completionTime.isAfter(now)) {
+            boolean isWasher,
+            MachineCompletionSignal signal) {
+        if (!signal.isJobResetWithFutureCompletion() || machineStateDetectionSupport.isPoweredOff(status)) {
             return Optional.empty();
         }
 
         var startTime = reservation.getStartTime();
-        if (startTime == null || completionTime.isBefore(startTime)) {
+        if (startTime == null || signal.completionTime().isBefore(startTime)) {
             return Optional.empty();
         }
         // 이번 사이클에서 실제로 상태가 갱신됐다는 근거가 없으면 이전 사이클의 잔재로 본다.
-        if (!isTimestampAtOrAfterStart(resolveOperatingStateTimestamp(status, isWasher), startTime)
-                && !isTimestampAtOrAfterStart(resolveJobStateTimestamp(status, isWasher), startTime)) {
+        if (!hasStateTimestampAtOrAfter(status, isWasher, startTime)) {
             return Optional.empty();
         }
 
         log.debug("device stopped with job reset and future completion time completionTime={} startTime={}",
-                completionTime,
+                signal.completionTime(),
                 startTime);
-        return Optional.of(now);
-    }
-
-    private boolean isTimestampAtOrAfterStart(String timestamp, LocalDateTime startTime) {
-        if (timestamp == null || timestamp.isBlank()) {
-            return false;
-        }
-        var updatedAt = DateTimeUtil.parseAndConvertToKoreaTime(timestamp);
-        return updatedAt != null && !updatedAt.isBefore(startTime);
+        return Optional.of(DateTimeUtil.nowInKorea());
     }
 
     /**
@@ -165,11 +151,11 @@ public class ReservationCompletionDecisionSupport {
     private Optional<LocalDateTime> findNearCompletionStopTime(Reservation reservation,
             SmartThingsDeviceStatusResDto status,
             boolean isWasher) {
-        if (!isStopped(status, isWasher)) {
+        if (!machineStateDetectionSupport.isStopped(status, isWasher)) {
             return Optional.empty();
         }
 
-        var completionTime = DateTimeUtil.parseAndConvertToKoreaTime(getCompletionTime(status, isWasher));
+        var completionTime = machineStateDetectionSupport.resolveCompletionTime(status, isWasher).orElse(null);
         if (completionTime == null) {
             return Optional.empty();
         }
@@ -202,8 +188,7 @@ public class ReservationCompletionDecisionSupport {
         if (completionTime.isBefore(startTime)) {
             return true;
         }
-        return isTimestampBeforeStart(resolveOperatingStateTimestamp(status, isWasher), startTime)
-                || isTimestampBeforeStart(resolveJobStateTimestamp(status, isWasher), startTime);
+        return stateTimestamps(status, isWasher).anyMatch(updatedAt -> updatedAt.isBefore(startTime));
     }
 
     /**
@@ -218,31 +203,25 @@ public class ReservationCompletionDecisionSupport {
         return completionTime.isBefore(expectedCompletionTime.minusMinutes(COMPLETION_EARLY_TOLERANCE_MINUTES));
     }
 
-    private boolean isTimestampBeforeStart(String timestamp, LocalDateTime startTime) {
-        if (timestamp == null || timestamp.isBlank()) {
-            return false;
-        }
-        var updatedAt = DateTimeUtil.parseAndConvertToKoreaTime(timestamp);
-        return updatedAt != null && updatedAt.isBefore(startTime);
+    /**
+     * 이번 사이클에서 상태가 갱신됐다는 근거가 하나라도 있는지 판정한다.
+     */
+    private boolean hasStateTimestampAtOrAfter(SmartThingsDeviceStatusResDto status,
+            boolean isWasher,
+            LocalDateTime startTime) {
+        return stateTimestamps(status, isWasher).anyMatch(updatedAt -> !updatedAt.isBefore(startTime));
     }
 
     /**
-     * 기기가 물리적으로 정지(machineState=stop) 상태인지 판정한다.
+     * 기기가 보고한 machineState·jobState 갱신 시각 중 해석 가능한 값만 흘려보낸다.
      */
-    private boolean isStopped(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        return status != null && status.getOperatingState(isWasher) == MachineOperatingState.STOP;
-    }
-
-    private String getCompletionTime(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        return status == null ? null : status.getCompletionTime(isWasher);
-    }
-
-    private String resolveOperatingStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        return status == null ? null : status.getOperatingStateTimestamp(isWasher);
-    }
-
-    private String resolveJobStateTimestamp(SmartThingsDeviceStatusResDto status, boolean isWasher) {
-        return status == null ? null : status.getJobStateTimestamp(isWasher);
+    private Stream<LocalDateTime> stateTimestamps(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+        if (status == null) {
+            return Stream.empty();
+        }
+        return Stream.of(status.getOperatingStateTimestamp(isWasher), status.getJobStateTimestamp(isWasher))
+                .filter(timestamp -> timestamp != null && !timestamp.isBlank())
+                .map(DateTimeUtil::parseAndConvertToKoreaTime).filter(Objects::nonNull);
     }
 
     private record CompletionCandidate(LocalDateTime completionTime, String reason) {

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineCompletionSignal.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineCompletionSignal.java
@@ -1,0 +1,52 @@
+package team.washer.server.v2.domain.smartthings.support;
+
+import java.time.LocalDateTime;
+
+/**
+ * 기기 상태 스냅샷에서 읽어낸 사이클 완료 신호.
+ *
+ * <p>
+ * {@code machineState=stop} 이면서 jobState가 리셋된 상태는 사이클이 끝났다는 신호이지만, 기기가 보고하는 완료
+ * 예정 시각이 이번 사이클의 종료 시각일 수도 있고 다음 사이클 기준의 미래 값으로 되돌아간 값일 수도 있다. 후자는 그 시각을 완료
+ * 시각으로 쓸 수 없어 예약 컨텍스트(시작 시각·상태 갱신 시각)로 한 번 더 검증해야 하므로,
+ * {@link Kind#JOB_RESET_WITH_FUTURE_COMPLETION}으로 구분해 호출 측에 넘긴다.
+ *
+ * @param kind
+ *            완료 신호의 종류
+ * @param completionTime
+ *            기기가 보고한 완료 시각. {@link Kind#NONE}이면 {@code null}
+ */
+public record MachineCompletionSignal(Kind kind, LocalDateTime completionTime) {
+
+    /**
+     * 완료 신호의 종류.
+     */
+    public enum Kind {
+        /** 완료 신호가 없다. */
+        NONE,
+        /** 완료가 확인됐고 {@code completionTime}을 완료 시각으로 쓸 수 있다. */
+        COMPLETED,
+        /** 정지·jobState 리셋으로 사이클은 끝났으나, 보고된 완료 시각이 미래라 그대로 쓸 수 없다. */
+        JOB_RESET_WITH_FUTURE_COMPLETION
+    }
+
+    public static MachineCompletionSignal none() {
+        return new MachineCompletionSignal(Kind.NONE, null);
+    }
+
+    public static MachineCompletionSignal completed(LocalDateTime completionTime) {
+        return new MachineCompletionSignal(Kind.COMPLETED, completionTime);
+    }
+
+    public static MachineCompletionSignal jobResetWithFutureCompletion(LocalDateTime completionTime) {
+        return new MachineCompletionSignal(Kind.JOB_RESET_WITH_FUTURE_COMPLETION, completionTime);
+    }
+
+    public boolean isCompleted() {
+        return this.kind == Kind.COMPLETED;
+    }
+
+    public boolean isJobResetWithFutureCompletion() {
+        return this.kind == Kind.JOB_RESET_WITH_FUTURE_COMPLETION;
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupport.java
@@ -63,17 +63,23 @@ public class MachineStateDetectionSupport {
     }
 
     /**
-     * 기기 작업이 완료되었는지 감지하고, 완료된 경우 완료 시각을 반환한다.
+     * 기기 작업이 완료되었는지 감지한다.
      *
      * <p>
      * SmartThings 기기는 메인 사이클이 끝나면 냉각(cooling)·구김방지(wrinklePrevent) 등 잔여 단계가 남아 있어도
      * jobState를 finish/finished로 먼저 보고하는 경우가 있다. 반대로 완료 직후 jobState가 none/null로 빠르게
      * 리셋될 수 있으므로, machineState=stop(물리적 정지)와 completionTime이 현재 시각을 지났는지(잔여시간 0)를
      * 함께 확인한다.
+     *
+     * <p>
+     * jobState가 리셋된 정지에서 보고된 완료 시각이 미래이면 다음 사이클 기준으로 되돌아간 값이므로 완료 시각으로 쓸 수 없다. 이 경우
+     * 예약 컨텍스트로 한 번 더 검증해야 하므로 완료로 확정하지 않고
+     * {@link MachineCompletionSignal.Kind#JOB_RESET_WITH_FUTURE_COMPLETION} 신호로
+     * 넘긴다.
      */
-    public Optional<LocalDateTime> isCompleted(SmartThingsDeviceStatusResDto status, boolean isWasher) {
+    public MachineCompletionSignal detectCompletion(SmartThingsDeviceStatusResDto status, boolean isWasher) {
         if (status == null) {
-            return Optional.empty();
+            return MachineCompletionSignal.none();
         }
         var now = DateTimeUtil.nowInKorea();
         if (!isStopped(status, isWasher)) {
@@ -82,7 +88,7 @@ public class MachineStateDetectionSupport {
                         status.getOperatingState(isWasher),
                         status.getJobState(isWasher));
             }
-            return Optional.empty();
+            return MachineCompletionSignal.none();
         }
 
         var completionTime = resolveCompletionTime(status, isWasher).orElse(null);
@@ -90,24 +96,30 @@ public class MachineStateDetectionSupport {
             log.debug("device job is completed jobState={} completionTime={}",
                     status.getJobState(isWasher),
                     completionTime);
-            return Optional.of(completionTime != null && !completionTime.isAfter(now) ? completionTime : now);
+            return MachineCompletionSignal
+                    .completed(completionTime != null && !completionTime.isAfter(now) ? completionTime : now);
         }
 
-        if (completionTime != null && completionTime.isAfter(now)) {
-            log.debug("device stopped but completion time still in future completionTime={} jobState={}",
+        if (!status.isJobStateReset(isWasher) || completionTime == null) {
+            if (completionTime != null && completionTime.isAfter(now)) {
+                log.debug("device stopped but completion time still in future completionTime={} jobState={}",
+                        completionTime,
+                        status.getJobState(isWasher));
+            }
+            return MachineCompletionSignal.none();
+        }
+
+        if (completionTime.isAfter(now)) {
+            log.debug("device stopped with job reset and future completion time completionTime={} jobState={}",
                     completionTime,
                     status.getJobState(isWasher));
-            return Optional.empty();
+            return MachineCompletionSignal.jobResetWithFutureCompletion(completionTime);
         }
 
-        if (status.isJobStateReset(isWasher) && completionTime != null) {
-            log.debug("device job is completed after job reset jobState={} completionTime={}",
-                    status.getJobState(isWasher),
-                    completionTime);
-            return Optional.of(completionTime);
-        }
-
-        return Optional.empty();
+        log.debug("device job is completed after job reset jobState={} completionTime={}",
+                status.getJobState(isWasher),
+                completionTime);
+        return MachineCompletionSignal.completed(completionTime);
     }
 
     /**
@@ -145,7 +157,7 @@ public class MachineStateDetectionSupport {
             return true;
         }
 
-        if (status.getOperatingState(isWasher) != MachineOperatingState.STOP) {
+        if (!isStopped(status, isWasher)) {
             return false;
         }
         if (status.isJobStateFinished(isWasher)) {

--- a/src/test/java/team/washer/server/v2/domain/reservation/support/ReservationCompletionDecisionSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/support/ReservationCompletionDecisionSupportTest.java
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.support.MachineCompletionSignal;
 import team.washer.server.v2.domain.smartthings.support.MachineStateDetectionSupport;
 
 @ExtendWith(MockitoExtension.class)
@@ -77,12 +78,36 @@ class ReservationCompletionDecisionSupportTest {
         return koreaTime.atZone(KOREA_ZONE).withZoneSameInstant(ZoneId.of("UTC")).toLocalDateTime().toString() + "Z";
     }
 
+    /**
+     * 기기 상태 해석은 {@code MachineStateDetectionSupportTest}가 담당하므로, 여기서는 감지 결과인
+     * {@link MachineCompletionSignal}만 주입하여 판정 로직에 집중한다.
+     */
     private void givenDetectedCompletion(LocalDateTime completionTime) {
-        when(machineStateDetectionSupport.isCompleted(any(), anyBoolean())).thenReturn(Optional.of(completionTime));
+        when(machineStateDetectionSupport.detectCompletion(any(), anyBoolean()))
+                .thenReturn(MachineCompletionSignal.completed(completionTime));
     }
 
     private void givenNoDetectedCompletion() {
-        when(machineStateDetectionSupport.isCompleted(any(), anyBoolean())).thenReturn(Optional.empty());
+        when(machineStateDetectionSupport.detectCompletion(any(), anyBoolean()))
+                .thenReturn(MachineCompletionSignal.none());
+    }
+
+    private void givenJobResetWithFutureCompletion(LocalDateTime completionTime) {
+        when(machineStateDetectionSupport.detectCompletion(any(), anyBoolean()))
+                .thenReturn(MachineCompletionSignal.jobResetWithFutureCompletion(completionTime));
+    }
+
+    /**
+     * 기기가 정지 상태이고 지정한 완료 예정 시각을 보고하는 상황을 만든다.
+     */
+    private void givenStoppedAt(LocalDateTime completionTime) {
+        when(machineStateDetectionSupport.isStopped(any(), anyBoolean())).thenReturn(true);
+        when(machineStateDetectionSupport.resolveCompletionTime(any(), anyBoolean()))
+                .thenReturn(Optional.of(completionTime));
+    }
+
+    private void givenNotStopped() {
+        when(machineStateDetectionSupport.isStopped(any(), anyBoolean())).thenReturn(false);
     }
 
     @Nested
@@ -194,6 +219,7 @@ class ReservationCompletionDecisionSupportTest {
             when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(40));
             when(reservation.getExpectedCompletionTime()).thenReturn(completionTime);
             givenNoDetectedCompletion();
+            givenStoppedAt(completionTime);
 
             // When
             var decision = completionDecisionSupport.decide(reservation, status, true);
@@ -213,6 +239,7 @@ class ReservationCompletionDecisionSupportTest {
             when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(40));
             when(reservation.getExpectedCompletionTime()).thenReturn(completionTime);
             givenNoDetectedCompletion();
+            givenStoppedAt(completionTime);
 
             // When
             var decision = completionDecisionSupport.decide(reservation, status, false);
@@ -232,6 +259,7 @@ class ReservationCompletionDecisionSupportTest {
             when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(10));
             when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.plusMinutes(50));
             givenNoDetectedCompletion();
+            givenStoppedAt(reportedCompletionTime);
 
             // When
             var decision = completionDecisionSupport.decide(reservation, status, true);
@@ -249,6 +277,7 @@ class ReservationCompletionDecisionSupportTest {
             var status = buildWasherStatus("stop", "spin", isoUtc(nowKst.plusMinutes(3)));
             when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(40));
             givenNoDetectedCompletion();
+            givenStoppedAt(nowKst.plusMinutes(3));
 
             // When
             var decision = completionDecisionSupport.decide(reservation, status, true);
@@ -266,6 +295,7 @@ class ReservationCompletionDecisionSupportTest {
             var status = buildWasherStatus("stop", "wash", isoUtc(nowKst.plusMinutes(30)));
             when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(10));
             givenNoDetectedCompletion();
+            givenStoppedAt(nowKst.plusMinutes(30));
 
             // When
             var decision = completionDecisionSupport.decide(reservation, status, true);
@@ -287,6 +317,7 @@ class ReservationCompletionDecisionSupportTest {
             var nowKst = LocalDateTime.now(KOREA_ZONE);
             var status = buildWasherStatus("stop", "spin", isoUtc(nowKst.plusMinutes(3)));
             when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(40));
+            givenStoppedAt(nowKst.plusMinutes(3));
 
             // When
             var result = completionDecisionSupport.isStoppedNearCompletion(reservation, status, true);
@@ -301,6 +332,7 @@ class ReservationCompletionDecisionSupportTest {
             // Given
             var nowKst = LocalDateTime.now(KOREA_ZONE);
             var status = buildWasherStatus("run", "spin", isoUtc(nowKst.plusMinutes(3)));
+            givenNotStopped();
 
             // When
             var result = completionDecisionSupport.isStoppedNearCompletion(reservation, status, true);
@@ -316,6 +348,7 @@ class ReservationCompletionDecisionSupportTest {
             var nowKst = LocalDateTime.now(KOREA_ZONE);
             var status = buildWasherStatus("stop", "wash", isoUtc(nowKst.plusMinutes(30)));
             when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(10));
+            givenStoppedAt(nowKst.plusMinutes(30));
 
             // When
             var result = completionDecisionSupport.isStoppedNearCompletion(reservation, status, true);
@@ -330,15 +363,21 @@ class ReservationCompletionDecisionSupportTest {
     class StoppedResetCompletionPathTest {
 
         @Test
-        @DisplayName("정지 상태에서 jobState가 리셋되고 완료 예정 시각이 미래로 되돌아가면 현재 시각으로 완료 판정한다")
+        @DisplayName("jobState 리셋 정지 신호가 오면 현재 시각으로 완료 판정한다")
         void shouldReturnCompleted_WhenStoppedWithJobResetAndFutureCompletionTime() {
             // Given
             var nowKst = LocalDateTime.now(KOREA_ZONE);
             var startTime = nowKst.minusMinutes(60);
-            var status = buildWasherStatus("stop", isoUtc(nowKst), "none", isoUtc(nowKst), isoUtc(nowKst.plusHours(1)));
+            var futureCompletionTime = nowKst.plusHours(1);
+            var status = buildWasherStatus("stop",
+                    isoUtc(nowKst),
+                    "none",
+                    isoUtc(nowKst),
+                    isoUtc(futureCompletionTime));
             when(reservation.getStartTime()).thenReturn(startTime);
             when(reservation.getExpectedCompletionTime()).thenReturn(nowKst.minusMinutes(1));
-            givenNoDetectedCompletion();
+            givenJobResetWithFutureCompletion(futureCompletionTime);
+            givenStoppedAt(futureCompletionTime);
 
             // When
             var decision = completionDecisionSupport.decide(reservation, status, true);
@@ -354,10 +393,16 @@ class ReservationCompletionDecisionSupportTest {
         void shouldReturnNotCompleted_WhenPoweredOff() {
             // Given
             var nowKst = LocalDateTime.now(KOREA_ZONE);
-            var status = buildWasherStatus("stop", isoUtc(nowKst), "none", isoUtc(nowKst), isoUtc(nowKst.plusHours(1)));
+            var futureCompletionTime = nowKst.plusHours(1);
+            var status = buildWasherStatus("stop",
+                    isoUtc(nowKst),
+                    "none",
+                    isoUtc(nowKst),
+                    isoUtc(futureCompletionTime));
             when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(60));
             when(machineStateDetectionSupport.isPoweredOff(status)).thenReturn(true);
-            givenNoDetectedCompletion();
+            givenJobResetWithFutureCompletion(futureCompletionTime);
+            givenStoppedAt(futureCompletionTime);
 
             // When
             var decision = completionDecisionSupport.decide(reservation, status, true);
@@ -374,9 +419,15 @@ class ReservationCompletionDecisionSupportTest {
             var nowKst = LocalDateTime.now(KOREA_ZONE);
             var startTime = nowKst.minusMinutes(10);
             var staleTimestamp = isoUtc(startTime.minusMinutes(5));
-            var status = buildWasherStatus("stop", staleTimestamp, "none", staleTimestamp, isoUtc(nowKst.plusHours(1)));
+            var futureCompletionTime = nowKst.plusHours(1);
+            var status = buildWasherStatus("stop",
+                    staleTimestamp,
+                    "none",
+                    staleTimestamp,
+                    isoUtc(futureCompletionTime));
             when(reservation.getStartTime()).thenReturn(startTime);
-            givenNoDetectedCompletion();
+            givenJobResetWithFutureCompletion(futureCompletionTime);
+            givenStoppedAt(futureCompletionTime);
 
             // When
             var decision = completionDecisionSupport.decide(reservation, status, true);
@@ -387,13 +438,19 @@ class ReservationCompletionDecisionSupportTest {
         }
 
         @Test
-        @DisplayName("jobState가 사이클 진행 중이면 완료 후보로 보지 않는다")
-        void shouldReturnNotCompleted_WhenJobStateStillRunning() {
+        @DisplayName("완료 신호가 없으면 정지 상태여도 완료 후보로 보지 않는다")
+        void shouldReturnNotCompleted_WhenNoCompletionSignal() {
             // Given
             var nowKst = LocalDateTime.now(KOREA_ZONE);
-            var status = buildWasherStatus("stop", isoUtc(nowKst), "spin", isoUtc(nowKst), isoUtc(nowKst.plusHours(1)));
+            var futureCompletionTime = nowKst.plusHours(1);
+            var status = buildWasherStatus("stop",
+                    isoUtc(nowKst),
+                    "spin",
+                    isoUtc(nowKst),
+                    isoUtc(futureCompletionTime));
             when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(10));
             givenNoDetectedCompletion();
+            givenStoppedAt(futureCompletionTime);
 
             // When
             var decision = completionDecisionSupport.decide(reservation, status, true);
@@ -404,24 +461,25 @@ class ReservationCompletionDecisionSupportTest {
         }
 
         @Test
-        @DisplayName("완료 예정 시각이 이미 지난 경우는 이 경로가 아니라 근처 정지 경로가 처리한다")
-        void shouldReturnNotCompleted_WhenCompletionTimeAlreadyPassedOutsideGrace() {
+        @DisplayName("완료 예정 시각이 이미 지난 리셋 정지는 이 경로가 아니라 SmartThings 완료 보고 경로가 처리한다")
+        void shouldUseSmartThingsPath_WhenCompletionTimeAlreadyPassed() {
             // Given
             var nowKst = LocalDateTime.now(KOREA_ZONE);
+            var passedCompletionTime = nowKst.minusMinutes(30);
             var status = buildWasherStatus("stop",
                     isoUtc(nowKst),
                     "none",
                     isoUtc(nowKst),
-                    isoUtc(nowKst.minusMinutes(30)));
+                    isoUtc(passedCompletionTime));
             when(reservation.getStartTime()).thenReturn(nowKst.minusMinutes(60));
-            givenNoDetectedCompletion();
+            givenDetectedCompletion(passedCompletionTime);
 
             // When
             var decision = completionDecisionSupport.decide(reservation, status, true);
 
             // Then
-            assertThat(decision.isCompleted()).isFalse();
-            assertThat(decision.isDeferred()).isFalse();
+            assertThat(decision.isCompleted()).isTrue();
+            assertThat(decision.reason()).isEqualTo("smartthings_completed");
         }
     }
 }

--- a/src/test/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupportTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/support/MachineStateDetectionSupportTest.java
@@ -16,6 +16,8 @@ import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceSt
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.DryerOperatingState;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.SwitchCapability;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.WasherOperatingState;
+import team.washer.server.v2.domain.smartthings.support.MachineCompletionSignal.Kind;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @DisplayName("MachineStateDetectionSupport 상태 판정")
 class MachineStateDetectionSupportTest {
@@ -66,9 +68,9 @@ class MachineStateDetectionSupportTest {
             var past = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(1);
             var status = washerStatus("stop", "finish", isoUtc(past));
 
-            var result = machineStateDetectionSupport.isCompleted(status, WASHER);
+            var result = machineStateDetectionSupport.detectCompletion(status, WASHER);
 
-            assertThat(result).isPresent();
+            assertThat(result.isCompleted()).isTrue();
         }
 
         @Test
@@ -77,9 +79,9 @@ class MachineStateDetectionSupportTest {
             var past = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(1);
             var status = washerStatus("run", "finish", isoUtc(past));
 
-            var result = machineStateDetectionSupport.isCompleted(status, WASHER);
+            var result = machineStateDetectionSupport.detectCompletion(status, WASHER);
 
-            assertThat(result).isEmpty();
+            assertThat(result.kind()).isEqualTo(Kind.NONE);
         }
 
         @Test
@@ -88,9 +90,9 @@ class MachineStateDetectionSupportTest {
             var future = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(3);
             var status = washerStatus("stop", "finish", isoUtc(future));
 
-            var result = machineStateDetectionSupport.isCompleted(status, WASHER);
+            var result = machineStateDetectionSupport.detectCompletion(status, WASHER);
 
-            assertThat(result).isPresent();
+            assertThat(result.isCompleted()).isTrue();
         }
 
         @Test
@@ -98,9 +100,9 @@ class MachineStateDetectionSupportTest {
         void shouldNotComplete_WhenJobStateNotFinished() {
             var status = washerStatus("run", "spin", null);
 
-            var result = machineStateDetectionSupport.isCompleted(status, WASHER);
+            var result = machineStateDetectionSupport.detectCompletion(status, WASHER);
 
-            assertThat(result).isEmpty();
+            assertThat(result.kind()).isEqualTo(Kind.NONE);
         }
 
         @Test
@@ -108,9 +110,9 @@ class MachineStateDetectionSupportTest {
         void shouldComplete_WhenCompletionTimeNull() {
             var status = washerStatus("stop", "finish", null);
 
-            var result = machineStateDetectionSupport.isCompleted(status, WASHER);
+            var result = machineStateDetectionSupport.detectCompletion(status, WASHER);
 
-            assertThat(result).isPresent();
+            assertThat(result.isCompleted()).isTrue();
         }
 
         @Test
@@ -119,20 +121,21 @@ class MachineStateDetectionSupportTest {
             var past = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(1);
             var status = washerStatus("stop", "none", isoUtc(past));
 
-            var result = machineStateDetectionSupport.isCompleted(status, WASHER);
+            var result = machineStateDetectionSupport.detectCompletion(status, WASHER);
 
-            assertThat(result).isPresent();
+            assertThat(result.isCompleted()).isTrue();
         }
 
         @Test
-        @DisplayName("jobState가 none으로 리셋되어도 완료 시각이 미래이면 완료로 판정하지 않는다")
-        void shouldNotComplete_WhenJobStateResetAndCompletionTimeInFuture() {
+        @DisplayName("jobState가 none으로 리셋되어도 완료 시각이 미래이면 완료 시각을 쓸 수 없는 jobState 리셋 신호로 판정한다")
+        void shouldSignalJobReset_WhenJobStateResetAndCompletionTimeInFuture() {
             var future = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusHours(1);
             var status = washerStatus("stop", "none", isoUtc(future));
 
-            var result = machineStateDetectionSupport.isCompleted(status, WASHER);
+            var result = machineStateDetectionSupport.detectCompletion(status, WASHER);
 
-            assertThat(result).isEmpty();
+            assertThat(result.kind()).isEqualTo(Kind.JOB_RESET_WITH_FUTURE_COMPLETION);
+            assertThat(result.completionTime()).isAfter(DateTimeUtil.nowInKorea());
         }
 
         @Test
@@ -140,9 +143,9 @@ class MachineStateDetectionSupportTest {
         void shouldNotComplete_WhenJobStateResetAndCompletionTimeNull() {
             var status = washerStatus("stop", "none", null);
 
-            var result = machineStateDetectionSupport.isCompleted(status, WASHER);
+            var result = machineStateDetectionSupport.detectCompletion(status, WASHER);
 
-            assertThat(result).isEmpty();
+            assertThat(result.kind()).isEqualTo(Kind.NONE);
         }
     }
 
@@ -156,9 +159,9 @@ class MachineStateDetectionSupportTest {
             var past = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(1);
             var status = dryerStatus("stop", "finished", isoUtc(past));
 
-            var result = machineStateDetectionSupport.isCompleted(status, DRYER);
+            var result = machineStateDetectionSupport.detectCompletion(status, DRYER);
 
-            assertThat(result).isPresent();
+            assertThat(result.isCompleted()).isTrue();
         }
 
         @Test
@@ -167,9 +170,9 @@ class MachineStateDetectionSupportTest {
             var future = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(3);
             var status = dryerStatus("stop", "finished", isoUtc(future));
 
-            var result = machineStateDetectionSupport.isCompleted(status, DRYER);
+            var result = machineStateDetectionSupport.detectCompletion(status, DRYER);
 
-            assertThat(result).isPresent();
+            assertThat(result.isCompleted()).isTrue();
         }
 
         @Test
@@ -178,9 +181,9 @@ class MachineStateDetectionSupportTest {
             var future = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(2);
             var status = dryerStatus("run", "cooling", isoUtc(future));
 
-            var result = machineStateDetectionSupport.isCompleted(status, DRYER);
+            var result = machineStateDetectionSupport.detectCompletion(status, DRYER);
 
-            assertThat(result).isEmpty();
+            assertThat(result.kind()).isEqualTo(Kind.NONE);
         }
 
         @Test
@@ -189,20 +192,21 @@ class MachineStateDetectionSupportTest {
             var past = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(1);
             var status = dryerStatus("stop", "none", isoUtc(past));
 
-            var result = machineStateDetectionSupport.isCompleted(status, DRYER);
+            var result = machineStateDetectionSupport.detectCompletion(status, DRYER);
 
-            assertThat(result).isPresent();
+            assertThat(result.isCompleted()).isTrue();
         }
 
         @Test
-        @DisplayName("건조 jobState가 none으로 리셋되어도 완료 시각이 미래이면 완료로 판정하지 않는다")
-        void shouldNotComplete_WhenDryerJobStateResetAndCompletionTimeInFuture() {
+        @DisplayName("건조 jobState가 none으로 리셋되어도 완료 시각이 미래이면 완료 시각을 쓸 수 없는 jobState 리셋 신호로 판정한다")
+        void shouldSignalJobReset_WhenDryerJobStateResetAndCompletionTimeInFuture() {
             var future = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusHours(1);
             var status = dryerStatus("stop", "none", isoUtc(future));
 
-            var result = machineStateDetectionSupport.isCompleted(status, DRYER);
+            var result = machineStateDetectionSupport.detectCompletion(status, DRYER);
 
-            assertThat(result).isEmpty();
+            assertThat(result.kind()).isEqualTo(Kind.JOB_RESET_WITH_FUTURE_COMPLETION);
+            assertThat(result.completionTime()).isAfter(DateTimeUtil.nowInKorea());
         }
     }
 


### PR DESCRIPTION
## 개요

`MachineStateDetectionSupport.isCompleted`가 반환하던 `Optional<LocalDateTime>`을 `MachineCompletionSignal`로 대체하여, 호출 측이 완료 신호의 종류를 구분할 수 있도록 하였습니다.

## 본문

### 배경

이 변경은 8월 27일 `develop` 작업 트리에 커밋되지 않은 채 방치되어 있던 것을 브랜치로 옮겨 보존한 것입니다. 두 가지 문제를 함께 정리하기 위해 PR로 올립니다.

첫째, 당시 `ReservationCompletionDecisionSupportTest`를 함께 갱신하지 않아 그 시점부터 `compileTestJava`가 깨진 상태였고, 커밋되지 않았던 탓에 나흘간 발견되지 않았습니다.

둘째, 같은 리팩터링의 앞부분인 `isStopped`, `resolveCompletionTime` 추출이 이후 `#109`에서 별도로 다시 작성되어 머지되었습니다. 두 구현은 완전히 동일합니다. 이 브랜치를 `develop` 위로 rebase하여 중복분은 upstream 것으로 정리하였으므로, 현재 diff에는 완료 신호 관련 변경만 남아 있습니다.

### 변경 내용

`MachineCompletionSignal` 레코드를 추가하였습니다. 완료 신호를 세 가지로 구분합니다.

- `NONE` — 완료 신호가 없습니다.
- `COMPLETED` — 완료가 확인되었고 `completionTime`을 그대로 완료 시각으로 사용할 수 있습니다.
- `JOB_RESET_WITH_FUTURE_COMPLETION` — 정지와 jobState 리셋으로 사이클은 끝났으나, 기기가 보고한 완료 시각이 미래여서 그대로 쓸 수 없습니다.

기존 `Optional<LocalDateTime>`은 세 번째 경우를 표현하지 못해 호출 측에서 완료 시각의 신뢰도를 판단할 수 없었습니다. `isCompleted`를 `detectCompletion`으로 바꾸고 반환 타입을 교체하였습니다.

`ReservationCompletionDecisionSupport`는 새 신호를 받아 분기하도록 조정하였고, `MachineStateDetectionSupport`로 옮겨간 판정과 중복되던 private 헬퍼(`isStopped`, `getCompletionTime`, `resolveOperatingStateTimestamp`, `resolveJobStateTimestamp`, `isTimestampBeforeStart`, `isTimestampAtOrAfterStart`)를 제거하고 `stateTimestamps`, `hasStateTimestampAtOrAfter`로 통합하였습니다.

### 테스트

`ReservationCompletionDecisionSupportTest`를 새 신호 계약에 맞게 재작성하였습니다.

기기 상태 문자열의 해석은 `MachineStateDetectionSupportTest`가 담당하므로, 이 테스트는 감지 결과인 `MachineCompletionSignal`을 주입하고 예약 컨텍스트 판정(`stale_completion`, `too_early_completion`, 세 가지 완료 경로 분기)에만 집중하도록 하였습니다. 신호별 헬퍼 `givenDetectedCompletion`, `givenNoDetectedCompletion`, `givenJobResetWithFutureCompletion`을 두었고, 판정 측에서 `MachineStateDetectionSupport`로 위임이 옮겨간 `isStopped`와 `resolveCompletionTime`은 `givenStoppedAt`, `givenNotStopped`로 함께 스텁하였습니다.

`jobState 리셋 정지 경로`의 케이스 두 건은 신호 설계가 바뀌면서 전제가 달라져 다시 작성하였습니다. jobState가 사이클 진행 중인 경우는 이제 `MachineStateDetectionSupport`가 `NONE`으로 걸러내므로 "완료 신호가 없으면 정지 상태여도 완료 후보로 보지 않는다"로 바꾸었고, 완료 예정 시각이 이미 지난 리셋 정지는 `COMPLETED` 신호로 들어오므로 `smartthings_completed` 경로가 처리한다는 것을 검증하도록 바꾸었습니다.

전체 424건이 통과하며 `spotlessCheck`도 통과합니다.

### 재발 방지

작업을 중단할 때 브랜치를 만들어 커밋해두면 이번처럼 미커밋 변경이 방치되거나 같은 작업이 중복 수행되는 일을 막을 수 있습니다.
