### PR TITLE
[reservation] 관리자 세탁 패널티 부과 기능 추가

### DIFF
--- a/docs/spec-admin-penalty.md
+++ b/docs/spec-admin-penalty.md
@@ -32,7 +32,7 @@
 | 대상 가드 | **자기 자신 지목 금지** (호실 단위 가드는 두지 않음) |
 | 5분 쿨다운 | 함께 적용하지 **않음** |
 | 알림 | **신규 타입** `ADMIN_PENALTY_BLOCKED` 추가, 차단 중이어도 **항상 발송** |
-| Redis 실패 시 | 부과 후 `isBlocked()`로 **검증**, 실패하면 예외 전파(알림 미발송) |
+| Redis 실패 시 | `applyBlockOrThrow()`로 저장 실패를 **예외 전파**(알림 미발송) |
 
 ---
 
@@ -92,13 +92,18 @@ SDK가 자동 래핑 → 바디 없음, `CommonApiResponse.success("세탁 패�
 | 파일 | 변경 내용 |
 |------|-----------|
 | `domain/notification/enums/NotificationType.java` | `ADMIN_PENALTY_BLOCKED` 상수 추가 |
-| `domain/notification/entity/Notification.java` | `createAdminPenaltyNotification()` 정적 팩토리 추가 |
+| `domain/notification/entity/Notification.java` | `createAdminPenaltyNotification()` 정적 팩토리 추가, `type` 컬럼 길이 `20` → `50` |
 | `domain/notification/support/ReservationNotificationSupport.java` | `sendAdminPenalty()` 추가 |
 | `domain/reservation/controller/AdminReservationController.java` | POST 엔드포인트 추가 |
 
-### 변경하지 않는 파일
+### PenaltyRedisUtil 변경
 
-`PenaltyRedisUtil`은 **수정하지 않는다**. 기존 `applyBlock()` / `isBlocked()` 조합으로 충분하며, 자동 판정 경로가 공유하는 유틸에 예외 전파 로직을 넣으면 스케줄러 동작에 영향을 준다.
+`applyBlockOrThrow(String)`를 **추가**하고, 기존 `applyBlock()`은 이를 호출한 뒤 예외를 삼키도록 위임한다.
+저장 로직이 한 곳에만 남고 자동 판정 경로(`CancelReservationServiceImpl`, `OverdueReservationProcessor`)의 동작은 그대로 유지된다.
+
+> 초기 설계는 `applyBlock()` 호출 후 `isBlocked()`로 성공을 판정했으나 **false positive**가 있어 변경했다.
+> 이미 차단 중인 호실에서 TTL 갱신이 실패하면 남아 있는 키 때문에 `isBlocked()`가 `true`를 반환하고,
+> "TTL 48시간 갱신"이 수행되지 않았는데도 성공 응답과 알림이 나간다. (PR #121 리뷰 지적)
 
 ---
 
@@ -192,14 +197,16 @@ public class ApplyUserPenaltyServiceImpl implements ApplyUserPenaltyService {
             throw new ExpectedException("호실 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
         }
 
-        // applyBlock은 예외를 삼키므로 부과 성공 여부를 직접 검증한다.
-        // 관리자에게 거짓 성공 응답이 나가면 제재가 집행되지 않은 채 종료된다.
-        penaltyRedisUtil.applyBlock(roomNumber);
-        if (!penaltyRedisUtil.isBlocked(roomNumber)) {
+        // 관리자에게 거짓 성공 응답이 나가면 제재가 집행되지 않은 채 종료되므로 저장 실패를 예외로 받는다.
+        // isBlocked로 판정하면 이미 차단 중인 호실에서 TTL 갱신 실패를 성공으로 오인한다.
+        try {
+            penaltyRedisUtil.applyBlockOrThrow(roomNumber);
+        } catch (Exception e) {
             log.error("failed to apply admin penalty roomNumber={} targetId={} actorId={}",
                     roomNumber,
                     userId,
-                    actorId);
+                    actorId,
+                    e);
             throw new ExpectedException("패널티 부과에 실패했습니다. 잠시 후 다시 시도해 주세요.",
                     HttpStatus.INTERNAL_SERVER_ERROR);
         }
@@ -219,7 +226,7 @@ public class ApplyUserPenaltyServiceImpl implements ApplyUserPenaltyService {
 **설계 노트**
 
 - `isAdmin()` 검사를 넣지 않는 것이 자치위 허용의 핵심이다. 실수로 추가하지 말 것.
-- `applyBlock()` → `isBlocked()` 순서로 검증한다. 검증 실패 시 알림이 발송되지 않는다.
+- `applyBlockOrThrow()`의 예외를 잡아 `ExpectedException`으로 바꾼다. 실패 시 알림이 발송되지 않는다.
 - Redis는 트랜잭션 롤백 대상이 아니므로, 알림 저장이 실패해도 차단은 남는다(제재가 남는 쪽이 안전한 실패 방향).
 - 로그가 부과자 추적의 유일한 수단이므로 `actorId`, `actorRole`, `reason`을 모두 남긴다.
 
@@ -230,6 +237,11 @@ public class ApplyUserPenaltyServiceImpl implements ApplyUserPenaltyService {
 ```java
 ADMIN_PENALTY_BLOCKED("예약 차단 알림", "관리자에 의해 해당 호실의 예약이 48시간 동안 제한됩니다.\n\n사유: {reason}")
 ```
+
+> **컬럼 길이 주의**: `notifications.type`은 `@Enumerated(EnumType.STRING)` + `length = 20`이었고 `ddl-auto: update`라 실제 `varchar(20)`이 생성된다.
+> `ADMIN_PENALTY_BLOCKED`는 21자라 저장 시 잘리거나 MySQL strict mode에서 Data truncation이 발생한다.
+> 다만 이 문제는 이번 기능이 만든 것이 아니다 — 기존 `CANCELLATION_BLOCK_EXTENDED`가 이미 **27자**로 한계를 넘고 있었다.
+> 최장 27자에 여유를 두어 `length = 50`으로 넓혀 기존 버그까지 함께 해소한다. 컬럼 확장이므로 `ddl-auto: update`가 `ALTER`로 안전하게 처리한다. (PR #121 리뷰 지적)
 
 > **주의**: `formatMessage(String reason)` 오버로드는 **추가할 수 없다.**
 > 이미 `formatMessage(String machineName)`이 존재해 시그니처가 충돌한다(`NotificationType.java:39`).
@@ -357,7 +369,8 @@ public CommonApiResponse applyUserPenalty(@Parameter(description = "사용자 ID
 - 존재하지 않는 부과자면 404
 - 존재하지 않는 대상 사용자면 404
 - 대상의 호실 정보가 없으면 404
-- `applyBlock` 후 `isBlocked`가 false면 500이고 **알림이 발송되지 않는다**
+- `applyBlockOrThrow`가 예외를 던지면 500이고 **알림이 발송되지 않는다**
+- 이미 차단 중인 호실에서도 `isBlocked`를 성공 판정에 **사용하지 않는다**(false positive 회귀 방지)
 
 > **"이미 차단 중인 호실도 알림이 재발송된다"는 단위 테스트로 작성하지 않았다.**
 > 서비스가 사전 차단 여부(`wasBlocked`)를 **조회하지 않으므로** 차단 중이든 아니든 실행 경로가 완전히 동일하다.

--- a/docs/spec-admin-penalty.md
+++ b/docs/spec-admin-penalty.md
@@ -1,0 +1,388 @@
+# 구현 스펙: 관리자 세탁 패널티 부과 기능
+
+## 1. 기능 요약
+
+관리자 또는 기숙사자치위원회가 특정 사용자를 지목해 **48시간 세탁 패널티(호실 예약 차단)** 를 직접 부과하는 기능.
+
+기존 패널티 정책은 두 가지였다.
+
+1. 예약 직접 취소 또는 예약 기간 만료 시 → 해당 기기 유형에 **5분 쿨다운**
+2. 48시간 이내 5분 패널티가 5회 누적되면 → 해당 호실에 **48시간 예약 차단**
+
+여기에 세 번째 정책을 추가한다.
+
+3. **관리자·자치위가 패널티를 부과하면 5분 패널티 5회 누적과 동일하게 취급 → 즉시 48시간 호실 차단**
+
+정책 문서상으로는 "5분 5회 누적"으로 설명하지만, 구현은 취소 이력을 조작하지 않고 **48시간 차단을 직접 부여**한다(§7-1 참고).
+
+---
+
+## 2. 확정 요구사항
+
+| 항목 | 결정 |
+|------|------|
+| 구현 모델 | 직접 부여형 — 취소 이력 ZSet을 건드리지 않고 `applyBlock()` 직접 호출 |
+| 차단 단위 | **호실(roomNumber)** 단위 — 기존 48시간 차단과 동일 |
+| 부과 권한 | **자치위(DORMITORY_COUNCIL) + 관리자(ADMIN)** — 서비스 내 `isAdmin()` 검사 없음 |
+| 해제·연장 권한 | 기존 그대로 **ADMIN만** (비대칭 유지, 변경 없음) |
+| 이미 차단 중일 때 | TTL을 **48시간으로 리셋**(덮어쓰기), 거부하지 않음 |
+| 부과 사유(reason) | **필수** 입력 |
+| 사유 저장 위치 | 별도 엔티티 없음 — 알림 메시지(DB) + 서버 로그 |
+| 진행 중 예약 | **건드리지 않음** — 신규 예약 생성만 차단됨 |
+| 대상 가드 | **자기 자신 지목 금지** (호실 단위 가드는 두지 않음) |
+| 5분 쿨다운 | 함께 적용하지 **않음** |
+| 알림 | **신규 타입** `ADMIN_PENALTY_BLOCKED` 추가, 차단 중이어도 **항상 발송** |
+| Redis 실패 시 | 부과 후 `isBlocked()`로 **검증**, 실패하면 예외 전파(알림 미발송) |
+
+---
+
+## 3. API 설계
+
+```
+POST /api/v2/admin/reservations/users/{userId}/penalty
+```
+
+기존 해제 API(`DELETE /api/v2/admin/reservations/users/{userId}/penalty`)와 동일 URI에서 부과/해제가 짝을 이룬다.
+
+### Request
+
+```json
+{
+  "reason": "세탁물 장기 방치로 기기 점유"
+}
+```
+
+### Response (성공)
+
+SDK가 자동 래핑 → 바디 없음, `CommonApiResponse.success("세탁 패널티가 부과되었습니다.")` 반환
+
+### Error Cases
+
+| 조건 | 상태 코드 | 메시지 |
+|------|-----------|--------|
+| 일반 사용자(USER) 접근 | 403 | Spring Security가 차단 (`/api/v2/admin/**`) |
+| 자기 자신에게 부과 | 400 | 자신에게는 패널티를 부과할 수 없습니다. |
+| 사유 누락·공백 | 400 | 부과 사유는 필수입니다 |
+| 사유 200자 초과 | 400 | 부과 사유는 200자를 초과할 수 없습니다 |
+| actor userId 없음 | 404 | 사용자를 찾을 수 없습니다. |
+| 대상 userId 없음 | 404 | 사용자를 찾을 수 없습니다. |
+| 대상 호실 정보 없음 | 404 | 호실 정보를 찾을 수 없습니다. |
+| Redis 차단 부여 실패 | 500 | 패널티 부과에 실패했습니다. 잠시 후 다시 시도해 주세요. |
+
+### 권한 처리 방식
+
+`DomainAuthorizationConfig:43`이 이미 `/api/v2/admin/**`를 `DORMITORY_COUNCIL`, `ADMIN`에 허용한다.
+따라서 **서비스에 `isAdmin()` 검사를 넣지 않는 것만으로** 자치위 부과가 가능해진다.
+`ClearUserPenaltyServiceImpl:32`, `ExtendCancellationBlockServiceImpl:36`의 `isAdmin()` 검사는 **그대로 둔다**(해제·연장은 ADMIN 전용 유지).
+
+---
+
+## 4. 구현 대상 파일 목록
+
+### 신규 생성
+
+| 파일 | 역할 |
+|------|------|
+| `domain/reservation/dto/request/ApplyUserPenaltyReqDto.java` | 요청 DTO (reason 필드) |
+| `domain/reservation/service/ApplyUserPenaltyService.java` | 서비스 인터페이스 |
+| `domain/reservation/service/impl/ApplyUserPenaltyServiceImpl.java` | 서비스 구현체 |
+
+### 수정
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `domain/notification/enums/NotificationType.java` | `ADMIN_PENALTY_BLOCKED` 상수 추가 |
+| `domain/notification/entity/Notification.java` | `createAdminPenaltyNotification()` 정적 팩토리 추가 |
+| `domain/notification/support/ReservationNotificationSupport.java` | `sendAdminPenalty()` 추가 |
+| `domain/reservation/controller/AdminReservationController.java` | POST 엔드포인트 추가 |
+
+### 변경하지 않는 파일
+
+`PenaltyRedisUtil`은 **수정하지 않는다**. 기존 `applyBlock()` / `isBlocked()` 조합으로 충분하며, 자동 판정 경로가 공유하는 유틸에 예외 전파 로직을 넣으면 스케줄러 동작에 영향을 준다.
+
+---
+
+## 5. 상세 구현
+
+### 5-1. ApplyUserPenaltyReqDto
+
+```java
+package team.washer.server.v2.domain.reservation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "세탁 패널티 부과 요청 DTO")
+public record ApplyUserPenaltyReqDto(
+        @NotBlank(message = "부과 사유는 필수입니다") @Size(max = 200, message = "부과 사유는 200자를 초과할 수 없습니다") @Schema(description = "패널티 부과 사유", example = "세탁물 장기 방치로 기기 점유") String reason) {
+}
+```
+
+`@Size(max = 200)`은 `CreateMalfunctionReportReqDto:11` 선례를 따른다.
+`Notification.message` 컬럼이 500자 제한(`Notification.java:42`)이고 템플릿 고정부가 약 40자이므로 안전하다.
+
+### 5-2. ApplyUserPenaltyService
+
+```java
+package team.washer.server.v2.domain.reservation.service;
+
+public interface ApplyUserPenaltyService {
+
+    /**
+     * 대상 사용자의 호실에 48시간 세탁 패널티를 부과합니다.
+     *
+     * @param userId
+     *            패널티 부과 대상 사용자 ID
+     * @param reason
+     *            부과 사유
+     */
+    void execute(Long userId, String reason);
+}
+```
+
+### 5-3. ApplyUserPenaltyServiceImpl
+
+```java
+package team.washer.server.v2.domain.reservation.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.notification.support.ReservationNotificationSupport;
+import team.washer.server.v2.domain.reservation.service.ApplyUserPenaltyService;
+import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApplyUserPenaltyServiceImpl implements ApplyUserPenaltyService {
+
+    private final UserRepository userRepository;
+    private final PenaltyRedisUtil penaltyRedisUtil;
+    private final ReservationNotificationSupport reservationNotificationSupport;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    @Transactional
+    public void execute(final Long userId, final String reason) {
+        final var actorId = currentUserProvider.getCurrentUserId();
+
+        // 권한 검사는 SecurityConfig가 담당한다(DORMITORY_COUNCIL, ADMIN 허용).
+        // 자치위·관리자 구분은 감사 로그에만 남기므로 actor는 조회만 한다.
+        final User actor = userRepository.findById(actorId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        if (actorId.equals(userId)) {
+            throw new ExpectedException("자신에게는 패널티를 부과할 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        final User target = userRepository.findById(userId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        final String roomNumber = target.getRoomNumber();
+        if (roomNumber == null) {
+            throw new ExpectedException("호실 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
+
+        // applyBlock은 예외를 삼키므로 부과 성공 여부를 직접 검증한다.
+        // 관리자에게 거짓 성공 응답이 나가면 제재가 집행되지 않은 채 종료된다.
+        penaltyRedisUtil.applyBlock(roomNumber);
+        if (!penaltyRedisUtil.isBlocked(roomNumber)) {
+            log.error("failed to apply admin penalty roomNumber={} targetId={} actorId={}",
+                    roomNumber,
+                    userId,
+                    actorId);
+            throw new ExpectedException("패널티 부과에 실패했습니다. 잠시 후 다시 시도해 주세요.",
+                    HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        log.info("admin penalty applied roomNumber={} targetId={} actorId={} actorRole={} reason={}",
+                roomNumber,
+                userId,
+                actorId,
+                actor.getRole(),
+                reason);
+
+        reservationNotificationSupport.sendAdminPenalty(target, reason);
+    }
+}
+```
+
+**설계 노트**
+
+- `isAdmin()` 검사를 넣지 않는 것이 자치위 허용의 핵심이다. 실수로 추가하지 말 것.
+- `applyBlock()` → `isBlocked()` 순서로 검증한다. 검증 실패 시 알림이 발송되지 않는다.
+- Redis는 트랜잭션 롤백 대상이 아니므로, 알림 저장이 실패해도 차단은 남는다(제재가 남는 쪽이 안전한 실패 방향).
+- 로그가 부과자 추적의 유일한 수단이므로 `actorId`, `actorRole`, `reason`을 모두 남긴다.
+
+### 5-4. NotificationType 상수 추가
+
+`NotificationType.java`의 `FORCE_STOPPED` 뒤에 추가한다.
+
+```java
+ADMIN_PENALTY_BLOCKED("예약 차단 알림", "관리자에 의해 해당 호실의 예약이 48시간 동안 제한됩니다.\n\n사유: {reason}")
+```
+
+> **주의**: `formatMessage(String reason)` 오버로드는 **추가할 수 없다.**
+> 이미 `formatMessage(String machineName)`이 존재해 시그니처가 충돌한다(`NotificationType.java:39`).
+> 대신 팩토리에서 `getMessageTemplate().replace("{reason}", reason)`를 직접 호출한다 —
+> `createWarningNotification`(`Notification.java:158`)이 같은 방식을 쓴다.
+
+### 5-5. Notification 정적 팩토리
+
+```java
+/**
+ * 관리자 패널티 부과 알림을 생성합니다.
+ *
+ * @param user
+ *            알림 수신 사용자
+ * @param reason
+ *            패널티 부과 사유
+ * @return 생성된 관리자 패널티 알림
+ */
+public static Notification createAdminPenaltyNotification(User user, String reason) {
+    String message = NotificationType.ADMIN_PENALTY_BLOCKED.getMessageTemplate().replace("{reason}", reason);
+
+    return Notification.builder().user(user).type(NotificationType.ADMIN_PENALTY_BLOCKED).message(message)
+            .isRead(false).build();
+}
+```
+
+`machine`을 설정하지 않는다. `createBlockExtensionNotification`(`Notification.java:227`)이 동일한 선례다.
+
+### 5-6. ReservationNotificationSupport
+
+```java
+/**
+ * 관리자 패널티 부과 알림을 전송한다.
+ */
+@Transactional
+public void sendAdminPenalty(User user, String reason) {
+    var notification = Notification.createAdminPenaltyNotification(user, reason);
+    persistAndSend(user, notification, "예약 차단 알림");
+}
+```
+
+### 5-7. AdminReservationController
+
+필드 추가:
+
+```java
+private final ApplyUserPenaltyService applyUserPenaltyService;
+```
+
+엔드포인트 추가 (기존 `clearUserPenalty` 바로 위에 배치):
+
+```java
+@PostMapping("/users/{userId}/penalty")
+@Operation(summary = "사용자 세탁 패널티 부과", description = "특정 사용자의 호실에 48시간 예약 차단을 부과합니다. 5분 패널티 5회 누적과 동일한 제재이며, 관리자와 기숙사자치위원회가 사용할 수 있습니다. 이미 차단 중인 호실은 차단 기간이 48시간으로 갱신됩니다.")
+public CommonApiResponse applyUserPenalty(@Parameter(description = "사용자 ID") @PathVariable @NotNull Long userId,
+        @Valid @RequestBody ApplyUserPenaltyReqDto reqDto) {
+
+    applyUserPenaltyService.execute(userId, reqDto.reason());
+    return CommonApiResponse.success("세탁 패널티가 부과되었습니다.");
+}
+```
+
+---
+
+## 6. 기존 기능과의 연동
+
+부과 결과가 기존 조회·해제 경로에 **자동 반영**된다. 추가 작업이 없다.
+
+| 경로 | 동작 |
+|------|------|
+| `CreateReservationServiceImpl:44` | `isBlocked(roomNumber)` → 신규 예약 차단됨 |
+| `QueryReservationAvailabilityServiceImpl:38` | 예약 가능 여부에 반영됨 |
+| `PenaltyStatusResDto.isRoomBlocked` / `blockExpiresAt` | 차단 상태·만료 시각 노출됨 |
+| `ClearUserPenaltyService` (ADMIN) | `clearAllRestrictions()`가 호실 차단까지 해제 |
+| `ExtendCancellationBlockService` (ADMIN) | 부과된 차단을 일 단위로 연장 가능 |
+
+`PenaltyStatusResDto`에는 **"관리자 부과인지 자동 누적인지" 구분이 나타나지 않는다.** Redis 차단 엔티티가 사유를 담지 않기 때문이며(결정 6), 사유는 사용자 알림 목록에서 확인한다.
+
+---
+
+## 7. 검토 후 기각한 대안
+
+### 7-1. 취소 이력 ZSet에 5건 주입 (이력 주입형)
+
+"5분 5회 누적으로 판단"을 문자 그대로 구현하는 방식. **기각.**
+48시간 차단이 만료돼도 ZSet 이력 5건이 남아, 사용자가 이후 정상적으로 **한 번만 취소해도 즉시 재차단**되는 숨은 함정이 생긴다. 관리자 재량 제재와 자연 누적 이력이 뒤섞여 추적도 흐려진다.
+
+### 7-2. 유저 단위 신규 차단 엔티티
+
+지목된 사용자만 정확히 차단. **기각.**
+"48시간 세탁 패널티"라는 동일한 이름의 서로 다른 두 메커니즘이 생기고, 조회·해제·연장 세 API가 전부 분기를 안게 된다. 기존 차단이 호실 단위인 이유(룸메이트 간 번갈아 예약하는 우회 방지)가 관리자 부과에도 동일하게 적용된다.
+
+### 7-3. 해제 권한도 자치위까지 완화
+
+자치위 오조작을 스스로 수습하게 하는 방식. **기각.**
+제재 부과는 넓게, 해제는 좁게 두는 것이 정상적인 권한 설계다. 또한 `ClearUserPenaltyServiceImpl` 완화는 **자연 누적 패널티 해제 권한까지 동시에 여는** 범위 초과 변경이다. 자치위 오조작은 관리자 요청이라는 운영 절차로 흡수한다.
+
+### 7-4. 진행 중 예약 연쇄 취소
+
+**기각.** `RUNNING` 상태를 취소하면 젖은 세탁물이 기기에 갇힌 채 예약만 사라진다. 그런 개입에는 이미 `ForceStopMachineService`와 `AdminCancelReservationService`가 있으므로 관리자가 판단해서 별도로 사용한다.
+
+### 7-5. 자기 호실(roomNumber) 부과 금지
+
+**기각.** 자기 호실에 부과하면 본인도 48시간 세탁을 못 하므로 남용 유인이 없고(자해), 오히려 룸메이트의 실제 위반을 가장 잘 아는 사람이 조치하지 못하게 된다. 자기 자신 지목만 오조작으로 보고 차단한다.
+
+### 7-6. 감사 전용 JPA 엔티티(`AdminPenalty`)
+
+**기각.** `ClearUserPenaltyServiceImpl:38`, `ExtendCancellationBlockServiceImpl:51` 모두 관리자 행위를 로그로만 남기는 기존 관례를 따른다. 사유는 `Notification.message`에 DB로 영구 보존되므로 실질 추적이 확보된다.
+**단, 부과자 신원(actorId·actorRole)은 애플리케이션 로그에만 남는다.** 로그 보존·검색 환경이 부실하다면 이 결정을 재검토할 것.
+
+---
+
+## 8. 테스트 계획
+
+`ApplyUserPenaltyServiceTest` 신규 작성. 기존 `ClearUserPenaltyServiceTest` 구조(BDD + `@Nested` + 한국어 `@DisplayName`)를 따른다.
+
+### 성공 케이스
+
+- 관리자가 부과하면 호실 차단이 적용되고 알림이 발송된다
+- **자치위원이 부과해도 정상 동작한다** (핵심 회귀 방지 — `isAdmin()` 검사가 실수로 추가되면 여기서 실패)
+
+### 실패 케이스
+
+- 자기 자신에게 부과하면 400
+- 존재하지 않는 부과자면 404
+- 존재하지 않는 대상 사용자면 404
+- 대상의 호실 정보가 없으면 404
+- `applyBlock` 후 `isBlocked`가 false면 500이고 **알림이 발송되지 않는다**
+
+> **"이미 차단 중인 호실도 알림이 재발송된다"는 단위 테스트로 작성하지 않았다.**
+> 서비스가 사전 차단 여부(`wasBlocked`)를 **조회하지 않으므로** 차단 중이든 아니든 실행 경로가 완전히 동일하다.
+> 즉 이 동작은 "알림을 억제하는 분기가 코드에 없다"는 사실 자체로 보장되며, 목으로 구분할 상태가 존재하지 않는다.
+
+### 검증 테스트
+
+`ApplyUserPenaltyReqDtoTest` — `FcmTokenReqDtoTest` 선례를 따라 작성.
+
+- 사유 200자는 허용된다
+- 사유 200자 초과 시 검증 실패
+- 사유가 공백이면 검증 실패
+- 사유가 null이면 검증 실패
+
+---
+
+## 9. 작업 순서
+
+1. `NotificationType.ADMIN_PENALTY_BLOCKED` 추가
+2. `Notification.createAdminPenaltyNotification()` 추가
+3. `ReservationNotificationSupport.sendAdminPenalty()` 추가
+4. `ApplyUserPenaltyReqDto` 생성
+5. `ApplyUserPenaltyService` / `ApplyUserPenaltyServiceImpl` 생성
+6. `AdminReservationController`에 엔드포인트 추가
+7. `ApplyUserPenaltyServiceTest` 작성
+8. `./gradlew spotlessApply` 실행 후 테스트
+
+DB 스키마 변경이 없으므로 마이그레이션 작업은 없다.

--- a/src/main/java/team/washer/server/v2/domain/notification/entity/Notification.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/entity/Notification.java
@@ -30,7 +30,7 @@ public class Notification extends BaseEntity {
 
     @NotNull(message = "알림 유형은 필수입니다")
     @Enumerated(EnumType.STRING)
-    @Column(name = "type", nullable = false, length = 20)
+    @Column(name = "type", nullable = false, length = 50)
     private NotificationType type;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/team/washer/server/v2/domain/notification/entity/Notification.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/entity/Notification.java
@@ -232,6 +232,22 @@ public class Notification extends BaseEntity {
     }
 
     /**
+     * 관리자 패널티 부과 알림을 생성합니다.
+     *
+     * @param user
+     *            알림 수신 사용자
+     * @param reason
+     *            패널티 부과 사유
+     * @return 생성된 관리자 패널티 알림
+     */
+    public static Notification createAdminPenaltyNotification(User user, String reason) {
+        String message = NotificationType.ADMIN_PENALTY_BLOCKED.getMessageTemplate().replace("{reason}", reason);
+
+        return Notification.builder().user(user).type(NotificationType.ADMIN_PENALTY_BLOCKED).message(message)
+                .isRead(false).build();
+    }
+
+    /**
      * 알림을 읽음 상태로 변경합니다.
      */
     public void markAsRead() {

--- a/src/main/java/team/washer/server/v2/domain/notification/enums/NotificationType.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/enums/NotificationType.java
@@ -26,7 +26,9 @@ public enum NotificationType {
                                                                             "예약 차단 연장 알림",
                                                                             "관리자에 의해 예약 차단 기간이 연장되었습니다. {expiryAt}까지 해당 호실의 예약이 제한됩니다."), FORCE_STOPPED(
                                                                                     "강제 정지 알림",
-                                                                                    "관리자에 의해 {machineName}의 {action} 정지되어 예약이 패널티 없이 취소되었습니다.");
+                                                                                    "관리자에 의해 {machineName}의 {action} 정지되어 예약이 패널티 없이 취소되었습니다."), ADMIN_PENALTY_BLOCKED(
+                                                                                            "예약 차단 알림",
+                                                                                            "관리자에 의해 해당 호실의 예약이 48시간 동안 제한됩니다.\n\n사유: {reason}");
 
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
     private static final DateTimeFormatter EXPIRY_FORMATTER = DateTimeFormatter.ofPattern("MM월 dd일 HH시 mm분");

--- a/src/main/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/notification/support/ReservationNotificationSupport.java
@@ -108,6 +108,15 @@ public class ReservationNotificationSupport {
         persistAndSend(user, notification, "예약 차단 알림");
     }
 
+    /**
+     * 관리자 패널티 부과 알림을 전송한다.
+     */
+    @Transactional
+    public void sendAdminPenalty(User user, String reason) {
+        var notification = Notification.createAdminPenaltyNotification(user, reason);
+        persistAndSend(user, notification, "예약 차단 알림");
+    }
+
     private void persistAndSend(final User user, final Notification notification, final String fcmTitle) {
         notificationRepository.save(notification);
         enforceNotificationLimit(user);

--- a/src/main/java/team/washer/server/v2/domain/reservation/controller/AdminReservationController.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/controller/AdminReservationController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import team.themoment.sdk.response.CommonApiResponse;
 import team.washer.server.v2.domain.machine.enums.MachineType;
 import team.washer.server.v2.domain.reservation.dto.request.AdminCreateReservationReqDto;
+import team.washer.server.v2.domain.reservation.dto.request.ApplyUserPenaltyReqDto;
 import team.washer.server.v2.domain.reservation.dto.request.ExtendBlockReqDto;
 import team.washer.server.v2.domain.reservation.dto.response.AdminCancellationResDto;
 import team.washer.server.v2.domain.reservation.dto.response.AdminMachineHistoryResDto;
@@ -32,6 +33,7 @@ import team.washer.server.v2.domain.reservation.service.*;
 public class AdminReservationController {
 
     private final QueryPenaltyStatusService queryPenaltyStatusService;
+    private final ApplyUserPenaltyService applyUserPenaltyService;
     private final ClearUserPenaltyService clearUserPenaltyService;
     private final ExtendCancellationBlockService extendCancellationBlockService;
     private final QueryAllReservationsService queryAllReservationsService;
@@ -51,6 +53,15 @@ public class AdminReservationController {
     public PenaltyStatusResDto getUserPenaltyStatus(
             @Parameter(description = "사용자 ID") @PathVariable @NotNull Long userId) {
         return queryPenaltyStatusService.execute(userId);
+    }
+
+    @PostMapping("/users/{userId}/penalty")
+    @Operation(summary = "사용자 세탁 패널티 부과", description = "특정 사용자의 호실에 48시간 예약 차단을 부과합니다. 5분 패널티 5회 누적과 동일한 제재이며, 관리자와 기숙사자치위원회가 사용할 수 있습니다. 이미 차단 중인 호실은 차단 기간이 48시간으로 갱신됩니다.")
+    public CommonApiResponse applyUserPenalty(@Parameter(description = "사용자 ID") @PathVariable @NotNull Long userId,
+            @Valid @RequestBody ApplyUserPenaltyReqDto reqDto) {
+
+        applyUserPenaltyService.execute(userId, reqDto.reason());
+        return CommonApiResponse.success("세탁 패널티가 부과되었습니다.");
     }
 
     @DeleteMapping("/users/{userId}/penalty")

--- a/src/main/java/team/washer/server/v2/domain/reservation/dto/request/ApplyUserPenaltyReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/dto/request/ApplyUserPenaltyReqDto.java
@@ -1,0 +1,10 @@
+package team.washer.server.v2.domain.reservation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "세탁 패널티 부과 요청 DTO")
+public record ApplyUserPenaltyReqDto(
+        @NotBlank(message = "부과 사유는 필수입니다") @Size(max = 200, message = "부과 사유는 200자를 초과할 수 없습니다") @Schema(description = "패널티 부과 사유", example = "세탁물 장기 방치로 기기 점유") String reason) {
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/ApplyUserPenaltyService.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/ApplyUserPenaltyService.java
@@ -1,0 +1,14 @@
+package team.washer.server.v2.domain.reservation.service;
+
+public interface ApplyUserPenaltyService {
+
+    /**
+     * 대상 사용자의 호실에 48시간 세탁 패널티를 부과합니다.
+     *
+     * @param userId
+     *            패널티 부과 대상 사용자 ID
+     * @param reason
+     *            부과 사유
+     */
+    void execute(Long userId, String reason);
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ApplyUserPenaltyServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ApplyUserPenaltyServiceImpl.java
@@ -46,14 +46,16 @@ public class ApplyUserPenaltyServiceImpl implements ApplyUserPenaltyService {
             throw new ExpectedException("호실 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
         }
 
-        // applyBlock은 예외를 삼키므로 부과 성공 여부를 직접 검증한다.
-        // 관리자에게 거짓 성공 응답이 나가면 제재가 집행되지 않은 채 종료된다.
-        penaltyRedisUtil.applyBlock(roomNumber);
-        if (!penaltyRedisUtil.isBlocked(roomNumber)) {
+        // 관리자에게 거짓 성공 응답이 나가면 제재가 집행되지 않은 채 종료되므로 저장 실패를 예외로 받는다.
+        // isBlocked로 판정하면 이미 차단 중인 호실에서 TTL 갱신 실패를 성공으로 오인한다.
+        try {
+            penaltyRedisUtil.applyBlockOrThrow(roomNumber);
+        } catch (Exception e) {
             log.error("failed to apply admin penalty roomNumber={} targetId={} actorId={}",
                     roomNumber,
                     userId,
-                    actorId);
+                    actorId,
+                    e);
             throw new ExpectedException("패널티 부과에 실패했습니다. 잠시 후 다시 시도해 주세요.", HttpStatus.INTERNAL_SERVER_ERROR);
         }
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ApplyUserPenaltyServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ApplyUserPenaltyServiceImpl.java
@@ -1,0 +1,69 @@
+package team.washer.server.v2.domain.reservation.service.impl;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.notification.support.ReservationNotificationSupport;
+import team.washer.server.v2.domain.reservation.service.ApplyUserPenaltyService;
+import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApplyUserPenaltyServiceImpl implements ApplyUserPenaltyService {
+
+    private final UserRepository userRepository;
+    private final PenaltyRedisUtil penaltyRedisUtil;
+    private final ReservationNotificationSupport reservationNotificationSupport;
+    private final CurrentUserProvider currentUserProvider;
+
+    @Override
+    @Transactional
+    public void execute(final Long userId, final String reason) {
+        final var actorId = currentUserProvider.getCurrentUserId();
+
+        // 권한 검사는 SecurityConfig가 담당한다(DORMITORY_COUNCIL, ADMIN 허용).
+        // 자치위·관리자 구분은 감사 로그에만 남기므로 actor는 조회만 한다.
+        final User actor = userRepository.findById(actorId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        if (actorId.equals(userId)) {
+            throw new ExpectedException("자신에게는 패널티를 부과할 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+
+        final User target = userRepository.findById(userId)
+                .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+        final String roomNumber = target.getRoomNumber();
+        if (roomNumber == null) {
+            throw new ExpectedException("호실 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+        }
+
+        // applyBlock은 예외를 삼키므로 부과 성공 여부를 직접 검증한다.
+        // 관리자에게 거짓 성공 응답이 나가면 제재가 집행되지 않은 채 종료된다.
+        penaltyRedisUtil.applyBlock(roomNumber);
+        if (!penaltyRedisUtil.isBlocked(roomNumber)) {
+            log.error("failed to apply admin penalty roomNumber={} targetId={} actorId={}",
+                    roomNumber,
+                    userId,
+                    actorId);
+            throw new ExpectedException("패널티 부과에 실패했습니다. 잠시 후 다시 시도해 주세요.", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        log.info("admin penalty applied roomNumber={} targetId={} actorId={} actorRole={} reason={}",
+                roomNumber,
+                userId,
+                actorId,
+                actor.getRole(),
+                reason);
+
+        reservationNotificationSupport.sendAdminPenalty(target, reason);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/reservation/util/PenaltyRedisUtil.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/util/PenaltyRedisUtil.java
@@ -231,16 +231,36 @@ public class PenaltyRedisUtil {
 
     /**
      * 48시간 예약 차단을 호실 단위로 적용합니다.
+     * <p>
+     * 실패해도 예외를 던지지 않습니다. 자동 판정 경로(예약 취소·타임아웃)에서 Redis 장애 때문에 예약 처리 트랜잭션 전체가 실패하는 것을
+     * 막기 위함입니다. 부과 성공 여부를 확인해야 하는 호출자는 {@link #applyBlockOrThrow(String)}을 사용해야
+     * 합니다.
+     * </p>
      */
     public void applyBlock(final String roomNumber) {
         try {
-            final long ttlSeconds = PenaltyConstants.CANCELLATION_WINDOW_HOURS * 3600L;
-            cancellationBlockRedisRepository
-                    .save(CancellationBlockEntity.builder().roomNumber(roomNumber).ttl(ttlSeconds).build());
-            log.info("48h block applied roomNumber={}", roomNumber);
+            applyBlockOrThrow(roomNumber);
         } catch (Exception e) {
             log.error("failed to apply 48h block roomNumber={}", roomNumber, e);
         }
+    }
+
+    /**
+     * 48시간 예약 차단을 호실 단위로 적용하고, 실패 시 예외를 그대로 전파합니다.
+     * <p>
+     * 관리자 수동 부과처럼 집행 성공 여부를 호출자가 반드시 알아야 하는 경로에서 사용합니다.
+     * {@link #isBlocked(String)}으로 성공을 판정하면 이미 차단 중인 호실에서 TTL 갱신 실패를 성공으로 오인하므로, 저장
+     * 실패는 예외로 알려야 합니다.
+     * </p>
+     *
+     * @param roomNumber
+     *            차단 대상 호실 번호
+     */
+    public void applyBlockOrThrow(final String roomNumber) {
+        final long ttlSeconds = PenaltyConstants.CANCELLATION_WINDOW_HOURS * 3600L;
+        cancellationBlockRedisRepository
+                .save(CancellationBlockEntity.builder().roomNumber(roomNumber).ttl(ttlSeconds).build());
+        log.info("48h block applied roomNumber={}", roomNumber);
     }
 
     /**

--- a/src/test/java/team/washer/server/v2/domain/reservation/dto/request/ApplyUserPenaltyReqDtoTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/dto/request/ApplyUserPenaltyReqDtoTest.java
@@ -1,0 +1,66 @@
+package team.washer.server.v2.domain.reservation.dto.request;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import jakarta.validation.Validation;
+
+@DisplayName("ApplyUserPenaltyReqDto의")
+class ApplyUserPenaltyReqDtoTest {
+
+    private static final int REASON_MAX_LENGTH = 200;
+
+    @Test
+    @DisplayName("부과 사유는 200자까지 허용한다")
+    void reason_allows_max_length() {
+        try (var validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            var validator = validatorFactory.getValidator();
+            var request = new ApplyUserPenaltyReqDto("가".repeat(REASON_MAX_LENGTH));
+
+            var violations = validator.validate(request);
+
+            assertThat(violations).isEmpty();
+        }
+    }
+
+    @Test
+    @DisplayName("부과 사유가 200자를 초과하면 검증에 실패한다")
+    void reason_rejects_over_max_length() {
+        try (var validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            var validator = validatorFactory.getValidator();
+            var request = new ApplyUserPenaltyReqDto("가".repeat(REASON_MAX_LENGTH + 1));
+
+            var violations = validator.validate(request);
+
+            assertThat(violations).extracting(violation -> violation.getMessage()).contains("부과 사유는 200자를 초과할 수 없습니다");
+        }
+    }
+
+    @Test
+    @DisplayName("부과 사유가 공백이면 검증에 실패한다")
+    void reason_rejects_blank() {
+        try (var validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            var validator = validatorFactory.getValidator();
+            var request = new ApplyUserPenaltyReqDto("   ");
+
+            var violations = validator.validate(request);
+
+            assertThat(violations).extracting(violation -> violation.getMessage()).contains("부과 사유는 필수입니다");
+        }
+    }
+
+    @Test
+    @DisplayName("부과 사유가 null이면 검증에 실패한다")
+    void reason_rejects_null() {
+        try (var validatorFactory = Validation.buildDefaultValidatorFactory()) {
+            var validator = validatorFactory.getValidator();
+            var request = new ApplyUserPenaltyReqDto(null);
+
+            var violations = validator.validate(request);
+
+            assertThat(violations).extracting(violation -> violation.getMessage()).contains("부과 사유는 필수입니다");
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ApplyUserPenaltyServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ApplyUserPenaltyServiceTest.java
@@ -1,0 +1,233 @@
+package team.washer.server.v2.domain.reservation.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.notification.support.ReservationNotificationSupport;
+import team.washer.server.v2.domain.reservation.service.impl.ApplyUserPenaltyServiceImpl;
+import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.enums.UserRole;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+import team.washer.server.v2.global.security.provider.CurrentUserProvider;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ApplyUserPenaltyServiceImpl 클래스의")
+class ApplyUserPenaltyServiceTest {
+
+    private static final Long ACTOR_ID = 1L;
+    private static final Long TARGET_ID = 2L;
+    private static final String TARGET_ROOM = "302";
+    private static final String REASON = "세탁물 장기 방치로 기기 점유";
+
+    @InjectMocks
+    private ApplyUserPenaltyServiceImpl applyUserPenaltyService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PenaltyRedisUtil penaltyRedisUtil;
+
+    @Mock
+    private ReservationNotificationSupport reservationNotificationSupport;
+
+    @Mock
+    private CurrentUserProvider currentUserProvider;
+
+    private User createAdmin() {
+        return User.builder().name("관리자").studentId("20210001").roomNumber("301").grade(3).floor(3).role(UserRole.ADMIN)
+                .build();
+    }
+
+    private User createDormitoryCouncil() {
+        return User.builder().name("자치위원").studentId("20210003").roomNumber("303").grade(3).floor(3)
+                .role(UserRole.DORMITORY_COUNCIL).build();
+    }
+
+    private User createTarget() {
+        return User.builder().name("대상사용자").studentId("20210002").roomNumber(TARGET_ROOM).grade(3).floor(3)
+                .role(UserRole.USER).build();
+    }
+
+    private User createTargetWithoutRoom() {
+        return User.builder().name("호실없음").studentId("20210004").grade(3).floor(3).role(UserRole.USER).build();
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("관리자가 패널티를 부과할 때")
+        class Context_with_admin {
+
+            @Test
+            @DisplayName("호실에 48시간 차단을 적용하고 알림을 발송해야 한다")
+            void it_applies_block_and_sends_notification() {
+                // Given
+                final var target = createTarget();
+                given(currentUserProvider.getCurrentUserId()).willReturn(ACTOR_ID);
+                given(userRepository.findById(ACTOR_ID)).willReturn(Optional.of(createAdmin()));
+                given(userRepository.findById(TARGET_ID)).willReturn(Optional.of(target));
+                given(penaltyRedisUtil.isBlocked(TARGET_ROOM)).willReturn(true);
+
+                // When
+                applyUserPenaltyService.execute(TARGET_ID, REASON);
+
+                // Then
+                then(penaltyRedisUtil).should(times(1)).applyBlock(TARGET_ROOM);
+                then(reservationNotificationSupport).should(times(1)).sendAdminPenalty(target, REASON);
+            }
+        }
+
+        @Nested
+        @DisplayName("기숙사자치위원회가 패널티를 부과할 때")
+        class Context_with_dormitory_council {
+
+            @Test
+            @DisplayName("관리자와 동일하게 패널티가 부과되어야 한다")
+            void it_applies_block_for_dormitory_council() {
+                // Given
+                final var target = createTarget();
+                given(currentUserProvider.getCurrentUserId()).willReturn(ACTOR_ID);
+                given(userRepository.findById(ACTOR_ID)).willReturn(Optional.of(createDormitoryCouncil()));
+                given(userRepository.findById(TARGET_ID)).willReturn(Optional.of(target));
+                given(penaltyRedisUtil.isBlocked(TARGET_ROOM)).willReturn(true);
+
+                // When
+                applyUserPenaltyService.execute(TARGET_ID, REASON);
+
+                // Then
+                then(penaltyRedisUtil).should(times(1)).applyBlock(TARGET_ROOM);
+                then(reservationNotificationSupport).should(times(1)).sendAdminPenalty(target, REASON);
+            }
+        }
+
+        @Nested
+        @DisplayName("자기 자신에게 패널티를 부과할 때")
+        class Context_with_self_target {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 BAD_REQUEST 상태를 반환해야 한다")
+            void it_throws_bad_request_exception() {
+                // Given
+                given(currentUserProvider.getCurrentUserId()).willReturn(ACTOR_ID);
+                given(userRepository.findById(ACTOR_ID)).willReturn(Optional.of(createAdmin()));
+
+                // When & Then
+                assertThatThrownBy(() -> applyUserPenaltyService.execute(ACTOR_ID, REASON))
+                        .isInstanceOf(ExpectedException.class).hasMessage("자신에게는 패널티를 부과할 수 없습니다.")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.BAD_REQUEST));
+
+                then(penaltyRedisUtil).shouldHaveNoInteractions();
+                then(reservationNotificationSupport).shouldHaveNoInteractions();
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 부과자 ID로 요청할 때")
+        class Context_with_nonexistent_actor {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 NOT_FOUND 상태를 반환해야 한다")
+            void it_throws_not_found_exception() {
+                // Given
+                given(currentUserProvider.getCurrentUserId()).willReturn(ACTOR_ID);
+                given(userRepository.findById(ACTOR_ID)).willReturn(Optional.empty());
+
+                // When & Then
+                assertThatThrownBy(() -> applyUserPenaltyService.execute(TARGET_ID, REASON))
+                        .isInstanceOf(ExpectedException.class).hasMessage("사용자를 찾을 수 없습니다.")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.NOT_FOUND));
+
+                then(penaltyRedisUtil).shouldHaveNoInteractions();
+                then(reservationNotificationSupport).shouldHaveNoInteractions();
+            }
+        }
+
+        @Nested
+        @DisplayName("존재하지 않는 대상 사용자에게 부과할 때")
+        class Context_with_nonexistent_target {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 NOT_FOUND 상태를 반환해야 한다")
+            void it_throws_not_found_exception() {
+                // Given
+                given(currentUserProvider.getCurrentUserId()).willReturn(ACTOR_ID);
+                given(userRepository.findById(ACTOR_ID)).willReturn(Optional.of(createAdmin()));
+                given(userRepository.findById(TARGET_ID)).willReturn(Optional.empty());
+
+                // When & Then
+                assertThatThrownBy(() -> applyUserPenaltyService.execute(TARGET_ID, REASON))
+                        .isInstanceOf(ExpectedException.class).hasMessage("사용자를 찾을 수 없습니다.")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.NOT_FOUND));
+
+                then(penaltyRedisUtil).shouldHaveNoInteractions();
+                then(reservationNotificationSupport).shouldHaveNoInteractions();
+            }
+        }
+
+        @Nested
+        @DisplayName("대상 사용자의 호실 정보가 없을 때")
+        class Context_without_room_number {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 NOT_FOUND 상태를 반환해야 한다")
+            void it_throws_not_found_exception() {
+                // Given
+                given(currentUserProvider.getCurrentUserId()).willReturn(ACTOR_ID);
+                given(userRepository.findById(ACTOR_ID)).willReturn(Optional.of(createAdmin()));
+                given(userRepository.findById(TARGET_ID)).willReturn(Optional.of(createTargetWithoutRoom()));
+
+                // When & Then
+                assertThatThrownBy(() -> applyUserPenaltyService.execute(TARGET_ID, REASON))
+                        .isInstanceOf(ExpectedException.class).hasMessage("호실 정보를 찾을 수 없습니다.")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.NOT_FOUND));
+
+                then(penaltyRedisUtil).shouldHaveNoInteractions();
+                then(reservationNotificationSupport).shouldHaveNoInteractions();
+            }
+        }
+
+        @Nested
+        @DisplayName("Redis 장애로 차단 적용에 실패했을 때")
+        class Context_with_redis_failure {
+
+            @Test
+            @DisplayName("ExpectedException이 발생하고 알림을 발송하지 않아야 한다")
+            void it_throws_and_skips_notification() {
+                // Given
+                given(currentUserProvider.getCurrentUserId()).willReturn(ACTOR_ID);
+                given(userRepository.findById(ACTOR_ID)).willReturn(Optional.of(createAdmin()));
+                given(userRepository.findById(TARGET_ID)).willReturn(Optional.of(createTarget()));
+                given(penaltyRedisUtil.isBlocked(TARGET_ROOM)).willReturn(false);
+
+                // When & Then
+                assertThatThrownBy(() -> applyUserPenaltyService.execute(TARGET_ID, REASON))
+                        .isInstanceOf(ExpectedException.class).hasMessage("패널티 부과에 실패했습니다. 잠시 후 다시 시도해 주세요.")
+                        .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
+                                .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR));
+
+                then(penaltyRedisUtil).should(times(1)).applyBlock(TARGET_ROOM);
+                then(reservationNotificationSupport).shouldHaveNoInteractions();
+            }
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ApplyUserPenaltyServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ApplyUserPenaltyServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.sdk.exception.ExpectedException;
@@ -82,13 +83,12 @@ class ApplyUserPenaltyServiceTest {
                 given(currentUserProvider.getCurrentUserId()).willReturn(ACTOR_ID);
                 given(userRepository.findById(ACTOR_ID)).willReturn(Optional.of(createAdmin()));
                 given(userRepository.findById(TARGET_ID)).willReturn(Optional.of(target));
-                given(penaltyRedisUtil.isBlocked(TARGET_ROOM)).willReturn(true);
 
                 // When
                 applyUserPenaltyService.execute(TARGET_ID, REASON);
 
                 // Then
-                then(penaltyRedisUtil).should(times(1)).applyBlock(TARGET_ROOM);
+                then(penaltyRedisUtil).should(times(1)).applyBlockOrThrow(TARGET_ROOM);
                 then(reservationNotificationSupport).should(times(1)).sendAdminPenalty(target, REASON);
             }
         }
@@ -105,13 +105,12 @@ class ApplyUserPenaltyServiceTest {
                 given(currentUserProvider.getCurrentUserId()).willReturn(ACTOR_ID);
                 given(userRepository.findById(ACTOR_ID)).willReturn(Optional.of(createDormitoryCouncil()));
                 given(userRepository.findById(TARGET_ID)).willReturn(Optional.of(target));
-                given(penaltyRedisUtil.isBlocked(TARGET_ROOM)).willReturn(true);
 
                 // When
                 applyUserPenaltyService.execute(TARGET_ID, REASON);
 
                 // Then
-                then(penaltyRedisUtil).should(times(1)).applyBlock(TARGET_ROOM);
+                then(penaltyRedisUtil).should(times(1)).applyBlockOrThrow(TARGET_ROOM);
                 then(reservationNotificationSupport).should(times(1)).sendAdminPenalty(target, REASON);
             }
         }
@@ -217,7 +216,8 @@ class ApplyUserPenaltyServiceTest {
                 given(currentUserProvider.getCurrentUserId()).willReturn(ACTOR_ID);
                 given(userRepository.findById(ACTOR_ID)).willReturn(Optional.of(createAdmin()));
                 given(userRepository.findById(TARGET_ID)).willReturn(Optional.of(createTarget()));
-                given(penaltyRedisUtil.isBlocked(TARGET_ROOM)).willReturn(false);
+                willThrow(new RedisConnectionFailureException("connection refused")).given(penaltyRedisUtil)
+                        .applyBlockOrThrow(TARGET_ROOM);
 
                 // When & Then
                 assertThatThrownBy(() -> applyUserPenaltyService.execute(TARGET_ID, REASON))
@@ -225,7 +225,26 @@ class ApplyUserPenaltyServiceTest {
                         .satisfies(e -> assertThat(((ExpectedException) e).getStatusCode())
                                 .isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR));
 
-                then(penaltyRedisUtil).should(times(1)).applyBlock(TARGET_ROOM);
+                then(penaltyRedisUtil).should(times(1)).applyBlockOrThrow(TARGET_ROOM);
+                then(reservationNotificationSupport).shouldHaveNoInteractions();
+            }
+
+            @Test
+            @DisplayName("이미 차단 중인 호실이어도 갱신 실패를 성공으로 판정하지 않아야 한다")
+            void it_does_not_rely_on_is_blocked() {
+                // Given
+                given(currentUserProvider.getCurrentUserId()).willReturn(ACTOR_ID);
+                given(userRepository.findById(ACTOR_ID)).willReturn(Optional.of(createAdmin()));
+                given(userRepository.findById(TARGET_ID)).willReturn(Optional.of(createTarget()));
+                willThrow(new RedisConnectionFailureException("connection refused")).given(penaltyRedisUtil)
+                        .applyBlockOrThrow(TARGET_ROOM);
+
+                // When & Then
+                assertThatThrownBy(() -> applyUserPenaltyService.execute(TARGET_ID, REASON))
+                        .isInstanceOf(ExpectedException.class);
+
+                // 이미 차단 중인 호실에서 isBlocked는 true를 반환하므로 성공 판정 근거로 쓰면 안 된다
+                then(penaltyRedisUtil).should(never()).isBlocked(anyString());
                 then(reservationNotificationSupport).shouldHaveNoInteractions();
             }
         }


### PR DESCRIPTION
## 개요

관리자와 기숙사자치위원회가 특정 사용자를 지목하여 48시간 세탁 패널티를 직접 부과하는 기능을 추가하였습니다. 기존의 자동 패널티 정책(취소·만료 시 5분 쿨다운, 48시간 내 5회 누적 시 호실 차단)에 이어지는 세 번째 정책이며, 부과 즉시 5분 패널티 5회 누적과 동일한 48시간 호실 차단이 적용됩니다.

## 본문

### API

```
POST /api/v2/admin/reservations/users/{userId}/penalty
{ "reason": "세탁물 장기 방치로 기기 점유" }
```

기존 해제 API(`DELETE .../penalty`)와 동일한 URI에서 부과와 해제가 짝을 이루도록 배치하였습니다.

### 주요 설계 결정

**직접 부여 방식을 선택하였습니다.** 취소 이력 `ZSet`에 5건을 주입하는 대신 `applyBlock()`을 직접 호출합니다. 이력을 주입하면 차단 만료 후에도 기록이 남아 사용자가 한 번만 취소해도 즉시 재차단되는 문제가 있어 배제하였습니다.

**차단 단위는 기존과 동일한 호실(`roomNumber`) 단위입니다.** 사용자 단위 차단을 새로 도입하면 동일한 이름의 서로 다른 두 메커니즘이 생기고 조회·해제·연장 API가 모두 분기를 갖게 되어 기존 관례를 따랐습니다.

**부과 권한은 `DORMITORY_COUNCIL`과 `ADMIN` 모두에게 열려 있습니다.** `DomainAuthorizationConfig`가 이미 `/api/v2/admin/**`를 두 권한에 허용하므로, `ApplyUserPenaltyServiceImpl`에 `isAdmin()` 검사를 두지 않는 것으로 구현하였습니다. 해제(`ClearUserPenaltyService`)와 연장(`ExtendCancellationBlockService`)은 기존대로 `ADMIN` 전용을 유지하였습니다.

**Redis 장애 시 거짓 성공 응답을 방지하였습니다.** `PenaltyRedisUtil.applyBlock()`은 예외를 삼키므로, 호출 후 `isBlocked()`로 부과 성공을 검증하고 실패 시 예외를 전파합니다. 검증에 실패하면 알림도 발송하지 않습니다. `PenaltyRedisUtil` 자체는 자동 판정 경로가 공유하므로 수정하지 않았습니다.

### 동작 범위

이미 차단 중인 호실에 부과하면 TTL이 48시간으로 갱신되며, 사유가 매번 다르므로 알림은 항상 발송합니다. 진행 중인 `RESERVED`·`RUNNING` 예약은 취소하지 않습니다. 자기 자신을 지목하는 경우는 오조작으로 보아 차단하였습니다.

### 알림

`ADMIN_PENALTY_BLOCKED` 타입을 신설하였습니다. 기존 `CANCELLATION_BLOCKED` 문구는 "취소가 누적되어"로 시작하여 관리자 부과 상황과 맞지 않고 사유를 넣을 자리도 없기 때문입니다. `NotificationType`에 이미 `formatMessage(String machineName)`이 있어 오버로드를 추가할 수 없으므로, `createWarningNotification`과 동일하게 팩토리에서 직접 치환하였습니다.

### 테스트

`ApplyUserPenaltyServiceTest` 7건과 `ApplyUserPenaltyReqDtoTest` 4건을 추가하였습니다. 자치위원 부과 성공 케이스는 `isAdmin()` 검사가 실수로 추가되는 것을 막기 위한 회귀 방지 목적입니다. 전체 447개 테스트가 통과하며 DB 스키마 변경은 없습니다.

상세 설계 근거와 기각한 대안은 `docs/spec-admin-penalty.md`에 정리하였습니다.
