### PR TITLE
[machine] 고장 기기가 예약 해제 시 복구되는 문제 수정

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/machine/entity/Machine.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/entity/Machine.java
@@ -110,10 +110,19 @@ public class Machine extends BaseEntity {
      * 예약 또는 사용 중으로 점유되어 있던 경우에만 기기를 사용 가능 상태로 해제합니다.
      *
      * <p>
-     * 고장 등으로 사용 불가 처리된 기기는 상태를 그대로 유지합니다. {@code status}가 {@code MALFUNCTION}인 기기는
-     * {@code availability}도 {@code UNAVAILABLE}이어야 한다는 불변식을 예약 해제 경로에서 지키기 위함입니다.
+     * 고장난 기기는 해제하지 않고 {@code UNAVAILABLE}로 되돌립니다. {@code status}가
+     * {@code MALFUNCTION}이면 {@code availability}도 {@code UNAVAILABLE}이어야 한다는 불변식을
+     * 예약 해제 경로에서 보장하기 위함입니다. 고장 처리 시점에 이미 진행 중이던 예약이 스케줄러에 의해 {@code IN_USE}로 전환되는
+     * 등, 다른 경로에서 어긋난 상태로 들어오더라도 이 지점에서 불변식이 복원됩니다.
+     *
+     * <p>
+     * 고장이 아닌데 {@code UNAVAILABLE}로 차단된 기기는 관리자가 의도적으로 내린 상태이므로 그대로 유지합니다.
      */
     public void releaseIfHeld() {
+        if (this.status == MachineStatus.MALFUNCTION) {
+            this.availability = MachineAvailability.UNAVAILABLE;
+            return;
+        }
         if (this.availability == MachineAvailability.RESERVED || this.availability == MachineAvailability.IN_USE) {
             this.availability = MachineAvailability.AVAILABLE;
         }

--- a/src/main/java/team/washer/server/v2/domain/machine/entity/Machine.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/entity/Machine.java
@@ -107,6 +107,19 @@ public class Machine extends BaseEntity {
     }
 
     /**
+     * 예약 또는 사용 중으로 점유되어 있던 경우에만 기기를 사용 가능 상태로 해제합니다.
+     *
+     * <p>
+     * 고장 등으로 사용 불가 처리된 기기는 상태를 그대로 유지합니다. {@code status}가 {@code MALFUNCTION}인 기기는
+     * {@code availability}도 {@code UNAVAILABLE}이어야 한다는 불변식을 예약 해제 경로에서 지키기 위함입니다.
+     */
+    public void releaseIfHeld() {
+        if (this.availability == MachineAvailability.RESERVED || this.availability == MachineAvailability.IN_USE) {
+            this.availability = MachineAvailability.AVAILABLE;
+        }
+    }
+
+    /**
      * 기기 사용 중 상태로 변경합니다.
      */
     public void markAsInUse() {

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/AdminCancelReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/AdminCancelReservationServiceImpl.java
@@ -30,7 +30,7 @@ public class AdminCancelReservationServiceImpl implements AdminCancelReservation
         }
         reservation.cancel();
         final var machine = reservation.getMachine();
-        machine.markAsAvailable();
+        machine.releaseIfHeld();
         final var savedReservation = reservationRepository.save(reservation);
         return new AdminCancellationResDto(savedReservation.getId(),
                 savedReservation.getUser().getName(),

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CancelReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CancelReservationServiceImpl.java
@@ -68,7 +68,7 @@ public class CancelReservationServiceImpl implements CancelReservationService {
 
         final var machine = reservation.getMachine();
         reservation.cancel();
-        machine.markAsAvailable();
+        machine.releaseIfHeld();
         reservationRepository.save(reservation);
         machineRepository.save(machine);
         log.info("Cancelled reservation reservationId={} userId={}", reservationId, userId);

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/OverdueReservationProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/OverdueReservationProcessor.java
@@ -97,7 +97,7 @@ public class OverdueReservationProcessor {
         if (startDecision == StartDecision.UNKNOWN) {
             if (canCancelUnknownReservation(reservation)) {
                 reservation.cancel();
-                machine.markAsAvailable();
+                machine.releaseIfHeld();
                 reservationRepository.save(reservation);
                 machineRepository.save(machine);
                 log.warn("reservation timeout cancelled without penalty due to unknown start state reservationId={}",
@@ -109,7 +109,7 @@ public class OverdueReservationProcessor {
         }
 
         reservation.cancel();
-        machine.markAsAvailable();
+        machine.releaseIfHeld();
         reservationRepository.save(reservation);
         machineRepository.save(machine);
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/ReservationLifecycleProcessor.java
@@ -185,7 +185,7 @@ public class ReservationLifecycleProcessor {
 
         reservation.cancel();
         reservation.clearInterruptionCount();
-        machine.markAsAvailable();
+        machine.releaseIfHeld();
         reservationRepository.save(reservation);
         machineRepository.save(machine);
 
@@ -214,7 +214,7 @@ public class ReservationLifecycleProcessor {
 
         reservation.cancel();
         reservation.clearPausedAt();
-        machine.markAsAvailable();
+        machine.releaseIfHeld();
         reservationRepository.save(reservation);
         machineRepository.save(machine);
 
@@ -276,7 +276,7 @@ public class ReservationLifecycleProcessor {
         reservation.clearCompletionCount();
         reservation.clearInterruptionCount();
         reservation.clearPausedAt();
-        machine.markAsAvailable();
+        machine.releaseIfHeld();
         reservationRepository.save(reservation);
         machineRepository.save(machine);
 

--- a/src/main/java/team/washer/server/v2/domain/user/service/impl/WithdrawUserServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/impl/WithdrawUserServiceImpl.java
@@ -48,7 +48,7 @@ public class WithdrawUserServiceImpl implements WithdrawUserService {
         for (final var reservation : activeReservations) {
             final var machine = reservation.getMachine();
             reservation.cancel();
-            machine.markAsAvailable();
+            machine.releaseIfHeld();
             machinesToUpdate.add(machine);
         }
         machineRepository.saveAll(machinesToUpdate);

--- a/src/test/java/team/washer/server/v2/domain/machine/entity/MachineTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/entity/MachineTest.java
@@ -1,0 +1,98 @@
+package team.washer.server.v2.domain.machine.entity;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.enums.Position;
+
+@DisplayName("Machine 클래스의")
+class MachineTest {
+
+    private Machine createMachine() {
+        return Machine.builder().name("W-2F-L1").type(MachineType.WASHER).deviceId("device-1").floor(2)
+                .position(Position.LEFT).number(1).status(MachineStatus.NORMAL)
+                .availability(MachineAvailability.AVAILABLE).build();
+    }
+
+    @Nested
+    @DisplayName("releaseIfHeld 메서드는")
+    class Describe_releaseIfHeld {
+
+        @Test
+        @DisplayName("예약됨 상태의 기기를 사용 가능 상태로 해제해야 한다")
+        void it_releases_reserved_machine() {
+            // Given
+            final var machine = createMachine();
+            machine.markAsReserved();
+
+            // When
+            machine.releaseIfHeld();
+
+            // Then
+            assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
+        }
+
+        @Test
+        @DisplayName("사용 중 상태의 기기를 사용 가능 상태로 해제해야 한다")
+        void it_releases_in_use_machine() {
+            // Given
+            final var machine = createMachine();
+            machine.markAsInUse();
+
+            // When
+            machine.releaseIfHeld();
+
+            // Then
+            assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
+        }
+
+        @Test
+        @DisplayName("고장 처리된 기기의 상태를 그대로 유지해야 한다")
+        void it_keeps_malfunction_machine_unavailable() {
+            // Given
+            final var machine = createMachine();
+            machine.markAsMalfunction();
+
+            // When
+            machine.releaseIfHeld();
+
+            // Then
+            assertThat(machine.getStatus()).isEqualTo(MachineStatus.MALFUNCTION);
+            assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.UNAVAILABLE);
+        }
+
+        @Test
+        @DisplayName("사용 불가로 처리된 정상 기기의 상태를 그대로 유지해야 한다")
+        void it_keeps_unavailable_normal_machine_unavailable() {
+            // Given
+            final var machine = createMachine();
+            machine.markAsUnavailable();
+
+            // When
+            machine.releaseIfHeld();
+
+            // Then
+            assertThat(machine.getStatus()).isEqualTo(MachineStatus.NORMAL);
+            assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.UNAVAILABLE);
+        }
+
+        @Test
+        @DisplayName("이미 사용 가능한 기기의 상태를 그대로 유지해야 한다")
+        void it_keeps_available_machine_available() {
+            // Given
+            final var machine = createMachine();
+
+            // When
+            machine.releaseIfHeld();
+
+            // Then
+            assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/machine/entity/MachineTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/entity/MachineTest.java
@@ -68,6 +68,54 @@ class MachineTest {
         }
 
         @Test
+        @DisplayName("고장난 기기가 예약됨 상태로 어긋나 있어도 사용 불가로 되돌려야 한다")
+        void it_restores_unavailable_when_malfunction_machine_is_reserved() {
+            // Given
+            final var machine = createMachine();
+            machine.markAsMalfunction();
+            machine.markAsReserved();
+
+            // When
+            machine.releaseIfHeld();
+
+            // Then
+            assertThat(machine.getStatus()).isEqualTo(MachineStatus.MALFUNCTION);
+            assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.UNAVAILABLE);
+        }
+
+        @Test
+        @DisplayName("고장난 기기가 사용 중 상태로 어긋나 있어도 사용 불가로 되돌려야 한다")
+        void it_restores_unavailable_when_malfunction_machine_is_in_use() {
+            // Given
+            final var machine = createMachine();
+            machine.markAsMalfunction();
+            machine.markAsInUse();
+
+            // When
+            machine.releaseIfHeld();
+
+            // Then
+            assertThat(machine.getStatus()).isEqualTo(MachineStatus.MALFUNCTION);
+            assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.UNAVAILABLE);
+        }
+
+        @Test
+        @DisplayName("고장난 기기가 사용 가능 상태로 어긋나 있어도 사용 불가로 되돌려야 한다")
+        void it_restores_unavailable_when_malfunction_machine_is_available() {
+            // Given
+            final var machine = createMachine();
+            machine.markAsMalfunction();
+            machine.markAsAvailable();
+
+            // When
+            machine.releaseIfHeld();
+
+            // Then
+            assertThat(machine.getStatus()).isEqualTo(MachineStatus.MALFUNCTION);
+            assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.UNAVAILABLE);
+        }
+
+        @Test
         @DisplayName("사용 불가로 처리된 정상 기기의 상태를 그대로 유지해야 한다")
         void it_keeps_unavailable_normal_machine_unavailable() {
             // Given

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/OverdueReservationProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/OverdueReservationProcessorTest.java
@@ -227,7 +227,7 @@ class OverdueReservationProcessorTest {
             // Then
             assertThat(result).isEqualTo(OverdueResult.CANCELLED_WITHOUT_PENALTY);
             verify(reservation, times(1)).cancel();
-            verify(machine, times(1)).markAsAvailable();
+            verify(machine, times(1)).releaseIfHeld();
             verify(reservationRepository, times(1)).save(reservation);
             verifyNoInteractions(penaltyRedisUtil);
             verifyNoInteractions(reservationNotificationSupport);
@@ -327,7 +327,7 @@ class OverdueReservationProcessorTest {
             // Then
             assertThat(result).isEqualTo(OverdueResult.CANCELLED_WITHOUT_PENALTY);
             verify(reservation, times(1)).cancel();
-            verify(machine, times(1)).markAsAvailable();
+            verify(machine, times(1)).releaseIfHeld();
             verify(reservationRepository, times(1)).save(reservation);
             verify(machineRepository, times(1)).save(machine);
             verify(penaltyRedisUtil, never()).applyCooldown(any(), any());

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationLifecycleProcessorTest.java
@@ -258,7 +258,7 @@ class ReservationLifecycleProcessorTest {
             verify(reservation, times(1)).clearCompletionCount();
             verify(reservation, times(1)).clearInterruptionCount();
             verify(reservation, times(1)).clearPausedAt();
-            verify(machine, times(1)).markAsAvailable();
+            verify(machine, times(1)).releaseIfHeld();
             verify(reservationRepository, times(1)).save(reservation);
             verify(machineRepository, times(1)).save(machine);
             verify(reservationNotificationSupport, times(1)).sendCompletion(user, machine);
@@ -280,7 +280,7 @@ class ReservationLifecycleProcessorTest {
             // Then
             verify(reservation, times(1)).incrementCompletionCount();
             verify(reservation, never()).complete();
-            verify(machine, never()).markAsAvailable();
+            verify(machine, never()).releaseIfHeld();
             verify(reservationRepository, times(1)).save(reservation);
             verify(machineRepository, never()).save(machine);
             verify(reservationNotificationSupport, never()).sendCompletion(any(), any());
@@ -396,7 +396,7 @@ class ReservationLifecycleProcessorTest {
             verify(reservation, times(1)).incrementInterruptionCount();
             verify(reservation, times(1)).cancel();
             verify(reservation, times(1)).clearInterruptionCount();
-            verify(machine, times(1)).markAsAvailable();
+            verify(machine, times(1)).releaseIfHeld();
             verify(reservationRepository, times(1)).save(reservation);
             verify(machineRepository, times(1)).save(machine);
             verify(reservationNotificationSupport, times(1)).sendInterruption(user, machine);
@@ -451,7 +451,7 @@ class ReservationLifecycleProcessorTest {
             // Then
             verify(reservation, times(1)).cancel();
             verify(reservation, times(1)).clearPausedAt();
-            verify(machine, times(1)).markAsAvailable();
+            verify(machine, times(1)).releaseIfHeld();
             verify(reservationRepository, times(1)).save(reservation);
             verify(machineRepository, times(1)).save(machine);
             verify(reservationNotificationSupport, times(1)).sendPauseTimeout(user, machine);

--- a/src/test/java/team/washer/server/v2/domain/user/service/WithdrawUserServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/service/WithdrawUserServiceTest.java
@@ -144,6 +144,36 @@ class WithdrawUserServiceTest {
         }
 
         @Nested
+        @DisplayName("고장 처리된 기기를 예약 중이던 사용자가 탈퇴하면")
+        class Context_with_reservation_on_malfunction_machine {
+
+            @Test
+            @DisplayName("예약만 취소하고 기기는 사용 불가 상태로 유지해야 한다")
+            void it_cancels_reservation_and_keeps_machine_unavailable() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+                Machine machine = createMachine();
+                machine.markAsMalfunction();
+                Reservation reservation = createReservation(ReservationStatus.RESERVED, user, machine);
+
+                given(currentUserProvider.getCurrentUserId()).willReturn(userId);
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(reservationRepository.findByUserAndStatusInForUpdate(user, ACTIVE_STATUSES))
+                        .willReturn(List.of(reservation));
+
+                // When
+                withdrawUserService.execute();
+
+                // Then
+                assertThat(reservation.getStatus()).isEqualTo(ReservationStatus.CANCELLED);
+                assertThat(machine.getStatus()).isEqualTo(MachineStatus.MALFUNCTION);
+                assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.UNAVAILABLE);
+                then(userRepository).should(times(1)).delete(user);
+            }
+        }
+
+        @Nested
         @DisplayName("RUNNING 상태의 예약이 있는 사용자가 탈퇴하면")
         class Context_with_running_reservation {
 


### PR DESCRIPTION
## 개요

`Machine.markAsAvailable()`이 `availability`만 무조건 덮어쓰는 탓에, 고장 처리된 기기에 물린 예약이 해제될 때 기기가 사용 가능 상태로 되살아나는 문제가 있었습니다. 점유 상태에서만 해제하는 `releaseIfHeld()`를 추가하고 예약 해제 경로 여덟 곳을 교체하였습니다.

closes #112

## 본문

### 문제와 영향

고장 상태는 `status`와 `availability`의 조합으로 표현되며 `markAsMalfunction()`이 `MALFUNCTION`과 `UNAVAILABLE`을 함께 설정합니다. 그러나 `markAsAvailable()`은 `availability`만 덮어쓰므로 두 필드가 어긋났습니다.

단순한 표시 불일치에 그치지 않습니다. `ReservationCreationSupport`의 예약 생성 가드가 `status`를 확인하지 않고 `availability`만 검사하므로, 되살아난 고장 기기에 새 예약이 실제로 접수되었습니다.

### 변경 사항

`Machine`에 `releaseIfHeld()`를 추가하였습니다. `availability`가 `RESERVED` 또는 `IN_USE`인 경우에만 해제하고, `UNAVAILABLE`인 기기는 상태를 유지합니다.

이슈에는 두 곳이 언급되었으나 동일한 결함을 가진 호출부가 여덟 곳이었으며 모두 교체하였습니다.

| 위치 | 상황 |
| --- | --- |
| `AdminCancelReservationServiceImpl` | 관리자 예약 취소 |
| `CancelReservationServiceImpl` | 사용자 예약 취소 |
| `OverdueReservationProcessor` | 시작 상태 불명 취소, 타임아웃 취소 |
| `ReservationLifecycleProcessor` | 중단 확정, 일시정지 타임아웃, 완료 |
| `WithdrawUserServiceImpl` | 탈퇴 시 활성 예약 취소 |

`ForceStopMachineServiceImpl`의 `syncMachineAvailability()`는 진입부에서 이미 `status`를 검사하므로 제외하였습니다. 교체하면 수동으로 사용 불가 처리한 정상 기기가 복구되지 않는 동작 변경이 발생합니다.

### 테스트

수정 전에 재현 테스트를 작성하여 `expected: UNAVAILABLE but was: AVAILABLE` 실패를 확인한 뒤 수정하였습니다.

- `MachineTest`를 신설하여 `releaseIfHeld()`의 다섯 가지 상태를 검증하였습니다.
- `WithdrawUserServiceTest`에 고장 기기 예약자의 탈퇴 시나리오를 추가하였습니다.
- 기존 목 검증 여섯 곳을 갱신하였습니다.

전체 454개 테스트가 통과하며 `spotlessApply`를 적용하였습니다.

https://claude.ai/code/session_01VVnM26TwXTAKPNa7HxHCJP
