### PR TITLE
[smartthings] 주간 통세척 스케줄러 구현

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/machine/entity/Machine.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/entity/Machine.java
@@ -143,6 +143,25 @@ public class Machine extends BaseEntity {
     }
 
     /**
+     * 기기를 통세척 중 상태로 변경합니다.
+     */
+    public void markAsCleaning() {
+        this.availability = MachineAvailability.CLEANING;
+    }
+
+    /**
+     * 통세척 중인 기기를 정상 상태에 맞게 해제합니다.
+     */
+    public void finishCleaning() {
+        if (this.availability != MachineAvailability.CLEANING) {
+            return;
+        }
+        this.availability = this.status == MachineStatus.NORMAL
+                ? MachineAvailability.AVAILABLE
+                : MachineAvailability.UNAVAILABLE;
+    }
+
+    /**
      * 기기 사용 불가 상태로 변경합니다.
      */
     public void markAsUnavailable() {

--- a/src/main/java/team/washer/server/v2/domain/machine/enums/MachineAvailability.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/enums/MachineAvailability.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum MachineAvailability {
-    AVAILABLE("사용 가능"), IN_USE("사용 중"), RESERVED("예약됨"), UNAVAILABLE("사용 불가");
+    AVAILABLE("사용 가능"), IN_USE("사용 중"), RESERVED("예약됨"), CLEANING("통세척 중"), UNAVAILABLE("사용 불가");
 
     private final String description;
 }

--- a/src/main/java/team/washer/server/v2/domain/machine/repository/MachineRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/repository/MachineRepository.java
@@ -38,6 +38,12 @@ public interface MachineRepository extends JpaRepository<Machine, Long>, Machine
 
     List<Machine> findByType(MachineType type);
 
+    List<Machine> findByTypeAndStatusAndAvailability(MachineType type,
+            MachineStatus status,
+            MachineAvailability availability);
+
+    List<Machine> findByTypeAndAvailability(MachineType type, MachineAvailability availability);
+
     List<Machine> findByFloor(Integer floor);
 
     List<Machine> findByStatus(MachineStatus status);

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
@@ -106,7 +106,8 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
 
     /**
      * 예약 정보와 실제 기기 작동 상태를 기반으로 가용성을 동적으로 계산한다. 예약 상태를 유일한 source of truth로 사용하되,
-     * 예약이 없어도 SmartThings에서 실제 작동 중(무단 사용)이면 IN_USE로 표시해 중복 예약을 차단한다.
+     * 예약이 없어도 SmartThings에서 실제 작동 중(무단 사용)이면 IN_USE로 표시해 중복 예약을 차단한다. 사용 불가와 통세척 중
+     * 상태는 DB에 저장된 관리 상태를 우선한다.
      *
      * <p>
      * 완료 여부를 이 API에서 따로 예측하지 않는다. 완료 확정은 라이프사이클 스케줄러가 디바운스와 가드를 거쳐 DB에 반영하며, 목록은 그
@@ -115,8 +116,9 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
     private MachineAvailability computeAvailability(Machine machine,
             Reservation reservation,
             SmartThingsDeviceStatusResDto deviceStatus) {
-        if (machine.getAvailability() == MachineAvailability.UNAVAILABLE) {
-            return MachineAvailability.UNAVAILABLE;
+        if (machine.getAvailability() == MachineAvailability.UNAVAILABLE
+                || machine.getAvailability() == MachineAvailability.CLEANING) {
+            return machine.getAvailability();
         }
         if (reservation == null) {
             return isOperating(machine, deviceStatus) ? MachineAvailability.IN_USE : MachineAvailability.AVAILABLE;

--- a/src/main/java/team/washer/server/v2/domain/smartthings/dto/request/SmartThingsCommandReqDto.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/dto/request/SmartThingsCommandReqDto.java
@@ -25,6 +25,19 @@ public record SmartThingsCommandReqDto(@Schema(description = "명령 목록") Li
     }
 
     /**
+     * 세탁기의 무세제 통세척 코스를 선택하고 실행한다.
+     *
+     * @param cycle
+     *            기기 모델에 맞는 SmartThings 세탁 코스 코드
+     * @return 무세제 통세척 실행 명령
+     */
+    public static SmartThingsCommandReqDto washerTubClean(String cycle) {
+        return new SmartThingsCommandReqDto(
+                List.of(new Command("main", "samsungce.washerCycle", "setWasherCycle", List.of(cycle)),
+                        new Command("main", "washerOperatingState", "setMachineState", List.of("run"))));
+    }
+
+    /**
      * 세탁기를 안전하게 정지시킨다. 전원 차단(switch off)과 달리 사이클을 정상 종료하므로 작동 중 기기에 사용한다. 기기에서 원격
      * 제어(Smart Control)가 활성화되어 있어야 명령이 적용된다.
      */

--- a/src/main/java/team/washer/server/v2/domain/smartthings/scheduler/WasherTubCleanScheduler.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/scheduler/WasherTubCleanScheduler.java
@@ -1,0 +1,43 @@
+package team.washer.server.v2.domain.smartthings.scheduler;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.smartthings.service.ReleaseFinishedWasherTubCleanService;
+import team.washer.server.v2.domain.smartthings.service.RunWasherTubCleanService;
+
+/**
+ * 매주 금요일 오전 10시에 무세제 통세척을 실행하고 완료된 기기의 점유를 해제한다.
+ */
+@Component
+@ConditionalOnProperty(prefix = "third-party.smartthings.tub-clean", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+@Slf4j
+public class WasherTubCleanScheduler {
+
+    private static final long COMPLETION_CHECK_INTERVAL = 60000;
+
+    private final RunWasherTubCleanService runWasherTubCleanService;
+    private final ReleaseFinishedWasherTubCleanService releaseFinishedWasherTubCleanService;
+
+    @Scheduled(cron = "${third-party.smartthings.tub-clean.cron:0 0 10 * * FRI}", zone = "Asia/Seoul")
+    public void runTubClean() {
+        try {
+            runWasherTubCleanService.execute();
+        } catch (Exception e) {
+            log.error("washer tub clean scheduler failed", e);
+        }
+    }
+
+    @Scheduled(fixedDelay = COMPLETION_CHECK_INTERVAL)
+    public void releaseFinishedTubClean() {
+        try {
+            releaseFinishedWasherTubCleanService.execute();
+        } catch (Exception e) {
+            log.error("washer tub clean completion check failed", e);
+        }
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/service/ReleaseFinishedWasherTubCleanService.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/service/ReleaseFinishedWasherTubCleanService.java
@@ -1,0 +1,6 @@
+package team.washer.server.v2.domain.smartthings.service;
+
+public interface ReleaseFinishedWasherTubCleanService {
+
+    void execute();
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/service/RunWasherTubCleanService.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/service/RunWasherTubCleanService.java
@@ -1,0 +1,6 @@
+package team.washer.server.v2.domain.smartthings.service;
+
+public interface RunWasherTubCleanService {
+
+    void execute();
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/ReleaseFinishedWasherTubCleanServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/ReleaseFinishedWasherTubCleanServiceImpl.java
@@ -1,0 +1,74 @@
+package team.washer.server.v2.domain.smartthings.service.impl;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
+import team.washer.server.v2.domain.smartthings.service.ReleaseFinishedWasherTubCleanService;
+import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
+import team.washer.server.v2.domain.smartthings.support.WasherTubCleanMachineGuard;
+import team.washer.server.v2.global.util.DateTimeUtil;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReleaseFinishedWasherTubCleanServiceImpl implements ReleaseFinishedWasherTubCleanService {
+
+    private static final List<ReservationStatus> ACTIVE_STATUSES = List.of(ReservationStatus.RESERVED,
+            ReservationStatus.RUNNING);
+    private static final long COMMAND_START_GRACE_MINUTES = 5;
+
+    private final MachineRepository machineRepository;
+    private final ReservationRepository reservationRepository;
+    private final DeviceStatusQuerySupport deviceStatusQuerySupport;
+    private final WasherTubCleanMachineGuard machineGuard;
+
+    @Override
+    public void execute() {
+        var candidates = findCandidates(DateTimeUtil.nowInKorea());
+        if (candidates.isEmpty()) {
+            return;
+        }
+
+        var statusMap = deviceStatusQuerySupport
+                .queryAllDevicesStatus(candidates.stream().map(Machine::getDeviceId).toList());
+        for (var machine : candidates) {
+            var status = statusMap.get(machine.getDeviceId());
+            if (!isFinished(status)) {
+                continue;
+            }
+            if (machineGuard.releaseIfNoActiveReservation(machine.getId())) {
+                log.info("washer tub clean occupancy released machine={} deviceId={}",
+                        machine.getName(),
+                        machine.getDeviceId());
+            }
+        }
+    }
+
+    private List<Machine> findCandidates(LocalDateTime now) {
+        var activeMachineIds = Set.copyOf(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES));
+        var graceThreshold = now.minusMinutes(COMMAND_START_GRACE_MINUTES);
+        return machineRepository.findByTypeAndAvailability(MachineType.WASHER, MachineAvailability.CLEANING).stream()
+                .filter(machine -> !activeMachineIds.contains(machine.getId()))
+                .filter(machine -> machine.getDeviceId() != null && !machine.getDeviceId().isBlank())
+                .filter(machine -> machine.getUpdatedAt() == null || !machine.getUpdatedAt().isAfter(graceThreshold))
+                .toList();
+    }
+
+    private boolean isFinished(SmartThingsDeviceStatusResDto status) {
+        return status != null && status.getOperatingState(true) == MachineOperatingState.STOP
+                && !status.isJobStateActive(true);
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/RunWasherTubCleanServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/RunWasherTubCleanServiceImpl.java
@@ -1,0 +1,138 @@
+package team.washer.server.v2.domain.smartthings.service.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.smartthings.dto.request.SmartThingsCommandReqDto;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.enums.MachineOperatingState;
+import team.washer.server.v2.domain.smartthings.exception.SmartThingsPermissionException;
+import team.washer.server.v2.domain.smartthings.service.RunWasherTubCleanService;
+import team.washer.server.v2.domain.smartthings.service.SendDeviceCommandService;
+import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
+import team.washer.server.v2.domain.smartthings.support.WasherTubCleanMachineGuard;
+import team.washer.server.v2.global.thirdparty.smartthings.config.SmartThingsTubCleanEnvironment;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RunWasherTubCleanServiceImpl implements RunWasherTubCleanService {
+
+    private static final List<ReservationStatus> ACTIVE_STATUSES = List.of(ReservationStatus.RESERVED,
+            ReservationStatus.RUNNING);
+
+    private final MachineRepository machineRepository;
+    private final ReservationRepository reservationRepository;
+    private final DeviceStatusQuerySupport deviceStatusQuerySupport;
+    private final SendDeviceCommandService sendDeviceCommandService;
+    private final WasherTubCleanMachineGuard machineGuard;
+    private final SmartThingsTubCleanEnvironment tubCleanEnvironment;
+
+    @Override
+    public void execute() {
+        if (!tubCleanEnvironment.hasCycle()) {
+            log.error("washer tub clean skipped because cycle is not configured");
+            return;
+        }
+
+        var candidates = findCandidates();
+        if (candidates.isEmpty()) {
+            log.info("washer tub clean skipped because no washer is available");
+            return;
+        }
+
+        var statusMap = deviceStatusQuerySupport
+                .queryAllDevicesStatus(candidates.stream().map(Machine::getDeviceId).toList());
+        var started = new ArrayList<String>();
+        var skipped = new ArrayList<String>();
+        var failed = new ArrayList<String>();
+
+        for (var machine : candidates) {
+            try {
+                var status = statusMap.get(machine.getDeviceId());
+                if (!canStart(machine, status)) {
+                    skipped.add(machine.getName());
+                    continue;
+                }
+
+                var target = machineGuard.occupyIfAvailable(machine.getId());
+                if (target.isEmpty()) {
+                    skipped.add(machine.getName());
+                    continue;
+                }
+
+                sendCommand(target.get());
+                started.add(target.get().machineName());
+            } catch (SmartThingsPermissionException e) {
+                log.warn("washer tub clean stopped because SmartThings permission is denied machine={} reason={}",
+                        machine.getName(),
+                        e.getMessage());
+                break;
+            } catch (Exception e) {
+                failed.add(machine.getName());
+                log.error("washer tub clean failed machine={} reason={}", machine.getName(), e.getMessage(), e);
+            }
+        }
+
+        log.info("washer tub clean batch completed started={} skipped={} failed={}", started, skipped, failed);
+    }
+
+    private List<Machine> findCandidates() {
+        var activeMachineIds = Set.copyOf(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES));
+        return machineRepository
+                .findByTypeAndStatusAndAvailability(MachineType.WASHER,
+                        MachineStatus.NORMAL,
+                        MachineAvailability.AVAILABLE)
+                .stream().filter(machine -> !activeMachineIds.contains(machine.getId()))
+                .filter(machine -> machine.getDeviceId() != null && !machine.getDeviceId().isBlank()).toList();
+    }
+
+    private boolean canStart(Machine machine, SmartThingsDeviceStatusResDto status) {
+        if (status == null) {
+            log.warn("washer tub clean skipped because device status is unknown machine={} deviceId={}",
+                    machine.getName(),
+                    machine.getDeviceId());
+            return false;
+        }
+        if (!status.isRemoteControlEnabled()) {
+            log.info("washer tub clean skipped because remote control is disabled machine={} deviceId={}",
+                    machine.getName(),
+                    machine.getDeviceId());
+            return false;
+        }
+        if (status.isSwitchOff() || status.getOperatingState(true) != MachineOperatingState.STOP
+                || status.isJobStateActive(true)) {
+            log.info(
+                    "washer tub clean skipped because washer is not idle machine={} deviceId={} machineState={} jobState={}",
+                    machine.getName(),
+                    machine.getDeviceId(),
+                    status.getWasherOperatingState(),
+                    status.getWasherJobState());
+            return false;
+        }
+        return true;
+    }
+
+    private void sendCommand(WasherTubCleanMachineGuard.TubCleanTarget target) {
+        try {
+            sendDeviceCommandService.execute(target.deviceId(),
+                    SmartThingsCommandReqDto.washerTubClean(tubCleanEnvironment.cycle()));
+            log.info("washer tub clean command sent machine={} deviceId={}", target.machineName(), target.deviceId());
+        } catch (Exception e) {
+            machineGuard.releaseIfNoActiveReservation(target.machineId());
+            throw e;
+        }
+    }
+}

--- a/src/main/java/team/washer/server/v2/domain/smartthings/support/WasherTubCleanMachineGuard.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/support/WasherTubCleanMachineGuard.java
@@ -1,0 +1,75 @@
+package team.washer.server.v2.domain.smartthings.support;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+
+/**
+ * 무세제 통세척 실행과 예약 생성이 충돌하지 않도록 기기 점유를 관리한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class WasherTubCleanMachineGuard {
+
+    private static final List<ReservationStatus> ACTIVE_STATUSES = List.of(ReservationStatus.RESERVED,
+            ReservationStatus.RUNNING);
+
+    private final MachineRepository machineRepository;
+    private final ReservationRepository reservationRepository;
+
+    /**
+     * 기기를 잠근 뒤 실행 조건을 다시 확인하고 통세척 실행 중으로 점유한다.
+     *
+     * @param machineId
+     *            점유할 세탁기 ID
+     * @return 점유된 세탁기의 식별 정보. 조건이 맞지 않으면 빈 값
+     */
+    @Transactional
+    public Optional<TubCleanTarget> occupyIfAvailable(Long machineId) {
+        var machine = machineRepository.findByIdForUpdate(machineId).orElse(null);
+        if (machine == null || !machine.isWasher() || !machine.isAvailable() || hasActiveReservation(machine)) {
+            return Optional.empty();
+        }
+
+        machine.markAsCleaning();
+        return Optional.of(new TubCleanTarget(machine.getId(), machine.getName(), machine.getDeviceId()));
+    }
+
+    /**
+     * 활성 예약이 없는 통세척 점유 상태를 해제한다.
+     *
+     * @param machineId
+     *            해제할 세탁기 ID
+     * @return 해제 여부
+     */
+    @Transactional
+    public boolean releaseIfNoActiveReservation(Long machineId) {
+        var machine = machineRepository.findByIdForUpdate(machineId).orElse(null);
+        if (machine == null || !machine.isWasher() || hasActiveReservation(machine)
+                || machine.getAvailability() != MachineAvailability.CLEANING) {
+            return false;
+        }
+
+        machine.finishCleaning();
+        return true;
+    }
+
+    private boolean hasActiveReservation(Machine machine) {
+        return reservationRepository.countActiveReservationsByMachine(machine, ACTIVE_STATUSES) > 0;
+    }
+
+    /**
+     * 트랜잭션 밖에서 SmartThings 명령에 사용할 세탁기 식별 정보.
+     */
+    public record TubCleanTarget(Long machineId, String machineName, String deviceId) {
+    }
+}

--- a/src/main/java/team/washer/server/v2/global/thirdparty/smartthings/config/SmartThingsTubCleanEnvironment.java
+++ b/src/main/java/team/washer/server/v2/global/thirdparty/smartthings/config/SmartThingsTubCleanEnvironment.java
@@ -1,0 +1,24 @@
+package team.washer.server.v2.global.thirdparty.smartthings.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/**
+ * SmartThings 무세제 통세척 자동 실행 설정.
+ *
+ * @param enabled
+ *            자동 실행 활성화 여부
+ * @param cycle
+ *            기기 모델에 맞는 SmartThings 세탁 코스 코드
+ */
+@ConfigurationProperties(prefix = "third-party.smartthings.tub-clean")
+public record SmartThingsTubCleanEnvironment(boolean enabled, String cycle) {
+
+    public SmartThingsTubCleanEnvironment {
+        cycle = cycle == null ? null : cycle.trim();
+    }
+
+    public boolean hasCycle() {
+        return StringUtils.hasText(cycle);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,6 +50,10 @@ third-party:
     client-secret: ${SMARTTHINGS_CLIENT_SECRET:your-client-secret}
     operation-schedule:
       enabled: false
+    tub-clean:
+      enabled: ${SMARTTHINGS_TUB_CLEAN_ENABLED:false}
+      cron: ${SMARTTHINGS_TUB_CLEAN_CRON:0 0 10 * * FRI}
+      cycle: ${SMARTTHINGS_TUB_CLEAN_CYCLE:}
   datagsm:
     client-secret: ${THIRD_PARTY_DATAGSM_CLIENT_SECRET:your-client-secret}
     client-id: ${THIRD_PARTY_DATAGSM_CLIENT_ID:your-client-id}

--- a/src/test/java/team/washer/server/v2/domain/machine/entity/MachineTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/entity/MachineTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import team.washer.server.v2.domain.machine.enums.MachineAvailability;
 import team.washer.server.v2.domain.machine.enums.MachineStatus;
@@ -18,6 +19,55 @@ class MachineTest {
         return Machine.builder().name("W-2F-L1").type(MachineType.WASHER).deviceId("device-1").floor(2)
                 .position(Position.LEFT).number(1).status(MachineStatus.NORMAL)
                 .availability(MachineAvailability.AVAILABLE).build();
+    }
+
+    @Nested
+    @DisplayName("통세척 상태 변경 메서드는")
+    class Describe_cleaning_state {
+
+        @Test
+        @DisplayName("통세척을 시작하면 통세척 중 상태로 변경해야 한다")
+        void it_marks_machine_as_cleaning() {
+            var machine = createMachine();
+
+            machine.markAsCleaning();
+
+            assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.CLEANING);
+        }
+
+        @Test
+        @DisplayName("정상 기기의 통세척이 끝나면 사용 가능 상태로 변경해야 한다")
+        void it_finishes_cleaning_on_normal_machine() {
+            var machine = createMachine();
+            machine.markAsCleaning();
+
+            machine.finishCleaning();
+
+            assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
+        }
+
+        @Test
+        @DisplayName("예약 해제는 통세척 중 상태를 변경하지 않아야 한다")
+        void it_keeps_cleaning_state_when_reservation_is_released() {
+            var machine = createMachine();
+            machine.markAsCleaning();
+
+            machine.releaseIfHeld();
+
+            assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.CLEANING);
+        }
+
+        @Test
+        @DisplayName("고장난 기기의 통세척 점유를 해제하면 사용 불가 상태를 유지해야 한다")
+        void it_keeps_malfunction_machine_unavailable_after_cleaning() {
+            var machine = createMachine();
+            machine.markAsCleaning();
+            ReflectionTestUtils.setField(machine, "status", MachineStatus.MALFUNCTION);
+
+            machine.finishCleaning();
+
+            assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.UNAVAILABLE);
+        }
     }
 
     @Nested

--- a/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
@@ -348,5 +348,19 @@ class QueryAllMachinesStatusServiceTest {
             // Then
             assertThat(result.getFirst().availability()).isEqualTo(MachineAvailability.UNAVAILABLE);
         }
+
+        @Test
+        @DisplayName("기기가 통세척 중이면 예약과 무관하게 CLEANING을 반환한다")
+        void computeAvailability_ShouldReturnCleaning_WhenMachineIsCleaning() {
+            // Given
+            when(reservation.getUser()).thenReturn(user);
+            givenMachineWithReservation(buildMachine(MachineAvailability.CLEANING), reservation);
+
+            // When
+            var result = queryAllMachinesStatusService.execute(USER_ID, true);
+
+            // Then
+            assertThat(result.getFirst().availability()).isEqualTo(MachineAvailability.CLEANING);
+        }
     }
 }

--- a/src/test/java/team/washer/server/v2/domain/smartthings/scheduler/WasherTubCleanSchedulerTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/scheduler/WasherTubCleanSchedulerTest.java
@@ -1,0 +1,66 @@
+package team.washer.server.v2.domain.smartthings.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.times;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import team.washer.server.v2.domain.smartthings.service.ReleaseFinishedWasherTubCleanService;
+import team.washer.server.v2.domain.smartthings.service.RunWasherTubCleanService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WasherTubCleanScheduler 클래스의")
+class WasherTubCleanSchedulerTest {
+
+    @InjectMocks
+    private WasherTubCleanScheduler scheduler;
+
+    @Mock
+    private RunWasherTubCleanService runWasherTubCleanService;
+
+    @Mock
+    private ReleaseFinishedWasherTubCleanService releaseFinishedWasherTubCleanService;
+
+    @Test
+    @DisplayName("통세척 예약 시각에 실행 서비스를 호출해야 한다")
+    void it_runs_tub_clean_service() {
+        scheduler.runTubClean();
+
+        then(runWasherTubCleanService).should(times(1)).execute();
+    }
+
+    @Test
+    @DisplayName("통세척 실행 시각은 매주 금요일 오전 10시와 서울 시간대여야 한다")
+    void it_schedules_friday_at_ten_in_seoul() throws NoSuchMethodException {
+        var annotation = WasherTubCleanScheduler.class.getMethod("runTubClean").getAnnotation(Scheduled.class);
+
+        assertThat(annotation.cron()).isEqualTo("${third-party.smartthings.tub-clean.cron:0 0 10 * * FRI}");
+        assertThat(annotation.zone()).isEqualTo("Asia/Seoul");
+    }
+
+    @Test
+    @DisplayName("한 번의 실행 실패가 다음 스케줄 실행을 막지 않아야 한다")
+    void it_handles_run_failure() {
+        willThrow(new RuntimeException("실행 실패")).given(runWasherTubCleanService).execute();
+
+        scheduler.runTubClean();
+
+        then(runWasherTubCleanService).should(times(1)).execute();
+    }
+
+    @Test
+    @DisplayName("완료된 통세척 점유 해제 서비스를 호출해야 한다")
+    void it_releases_finished_tub_clean() {
+        scheduler.releaseFinishedTubClean();
+
+        then(releaseFinishedWasherTubCleanService).should(times(1)).execute();
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/smartthings/service/ReleaseFinishedWasherTubCleanServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/service/ReleaseFinishedWasherTubCleanServiceTest.java
@@ -1,0 +1,109 @@
+package team.washer.server.v2.domain.smartthings.service;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.enums.Position;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.AttributeState;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.ComponentStatus;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.WasherOperatingState;
+import team.washer.server.v2.domain.smartthings.service.impl.ReleaseFinishedWasherTubCleanServiceImpl;
+import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
+import team.washer.server.v2.domain.smartthings.support.WasherTubCleanMachineGuard;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReleaseFinishedWasherTubCleanServiceImpl 클래스의")
+class ReleaseFinishedWasherTubCleanServiceTest {
+
+    private static final List<ReservationStatus> ACTIVE_STATUSES = List.of(ReservationStatus.RESERVED,
+            ReservationStatus.RUNNING);
+
+    @InjectMocks
+    private ReleaseFinishedWasherTubCleanServiceImpl releaseService;
+
+    @Mock
+    private MachineRepository machineRepository;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private DeviceStatusQuerySupport deviceStatusQuerySupport;
+
+    @Mock
+    private WasherTubCleanMachineGuard machineGuard;
+
+    private Machine createMachine(LocalDateTime updatedAt) {
+        var machine = Machine.builder().name("W-2F-L1").type(MachineType.WASHER).deviceId("device-1").floor(2)
+                .position(Position.LEFT).number(1).status(MachineStatus.NORMAL)
+                .availability(MachineAvailability.CLEANING).build();
+        ReflectionTestUtils.setField(machine, "id", 1L);
+        ReflectionTestUtils.setField(machine, "updatedAt", updatedAt);
+        return machine;
+    }
+
+    private SmartThingsDeviceStatusResDto stoppedStatus() {
+        var washerState = new WasherOperatingState(new AttributeState("stop", null, null),
+                new AttributeState("finish", null, null),
+                null);
+        return new SmartThingsDeviceStatusResDto(Map.of("main", new ComponentStatus(washerState, null, null, null)));
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Test
+        @DisplayName("완료된 통세척 세탁기의 점유를 해제해야 한다")
+        void it_releases_finished_tub_clean() {
+            var machine = createMachine(LocalDateTime.now().minusMinutes(10));
+            given(machineRepository.findByTypeAndAvailability(MachineType.WASHER, MachineAvailability.CLEANING))
+                    .willReturn(List.of(machine));
+            given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of());
+            given(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1")))
+                    .willReturn(Map.of("device-1", stoppedStatus()));
+            given(machineGuard.releaseIfNoActiveReservation(1L)).willReturn(true);
+
+            releaseService.execute();
+
+            then(machineGuard).should(times(1)).releaseIfNoActiveReservation(1L);
+        }
+
+        @Test
+        @DisplayName("명령 전송 직후에는 정지 상태가 조회되어도 점유를 해제하지 않아야 한다")
+        void it_keeps_occupancy_during_command_start_grace_period() {
+            var machine = createMachine(LocalDateTime.now());
+            given(machineRepository.findByTypeAndAvailability(MachineType.WASHER, MachineAvailability.CLEANING))
+                    .willReturn(List.of(machine));
+            given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of());
+
+            releaseService.execute();
+
+            then(deviceStatusQuerySupport).shouldHaveNoInteractions();
+            then(machineGuard).should(never()).releaseIfNoActiveReservation(1L);
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/smartthings/service/ReleaseFinishedWasherTubCleanServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/service/ReleaseFinishedWasherTubCleanServiceTest.java
@@ -33,6 +33,7 @@ import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceSt
 import team.washer.server.v2.domain.smartthings.service.impl.ReleaseFinishedWasherTubCleanServiceImpl;
 import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
 import team.washer.server.v2.domain.smartthings.support.WasherTubCleanMachineGuard;
+import team.washer.server.v2.global.util.DateTimeUtil;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ReleaseFinishedWasherTubCleanServiceImpl 클래스의")
@@ -79,7 +80,7 @@ class ReleaseFinishedWasherTubCleanServiceTest {
         @Test
         @DisplayName("완료된 통세척 세탁기의 점유를 해제해야 한다")
         void it_releases_finished_tub_clean() {
-            var machine = createMachine(LocalDateTime.now().minusMinutes(10));
+            var machine = createMachine(DateTimeUtil.nowInKorea().minusMinutes(10));
             given(machineRepository.findByTypeAndAvailability(MachineType.WASHER, MachineAvailability.CLEANING))
                     .willReturn(List.of(machine));
             given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of());
@@ -95,7 +96,7 @@ class ReleaseFinishedWasherTubCleanServiceTest {
         @Test
         @DisplayName("명령 전송 직후에는 정지 상태가 조회되어도 점유를 해제하지 않아야 한다")
         void it_keeps_occupancy_during_command_start_grace_period() {
-            var machine = createMachine(LocalDateTime.now());
+            var machine = createMachine(DateTimeUtil.nowInKorea());
             given(machineRepository.findByTypeAndAvailability(MachineType.WASHER, MachineAvailability.CLEANING))
                     .willReturn(List.of(machine));
             given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of());

--- a/src/test/java/team/washer/server/v2/domain/smartthings/service/RunWasherTubCleanServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/service/RunWasherTubCleanServiceTest.java
@@ -1,0 +1,188 @@
+package team.washer.server.v2.domain.smartthings.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.enums.Position;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.smartthings.dto.request.SmartThingsCommandReqDto;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.AttributeState;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.ComponentStatus;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.RemoteControlStatus;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.SwitchCapability;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto.WasherOperatingState;
+import team.washer.server.v2.domain.smartthings.service.impl.RunWasherTubCleanServiceImpl;
+import team.washer.server.v2.domain.smartthings.support.DeviceStatusQuerySupport;
+import team.washer.server.v2.domain.smartthings.support.WasherTubCleanMachineGuard;
+import team.washer.server.v2.domain.smartthings.support.WasherTubCleanMachineGuard.TubCleanTarget;
+import team.washer.server.v2.global.thirdparty.smartthings.config.SmartThingsTubCleanEnvironment;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RunWasherTubCleanServiceImpl 클래스의")
+class RunWasherTubCleanServiceTest {
+
+    private static final List<ReservationStatus> ACTIVE_STATUSES = List.of(ReservationStatus.RESERVED,
+            ReservationStatus.RUNNING);
+
+    @InjectMocks
+    private RunWasherTubCleanServiceImpl runWasherTubCleanService;
+
+    @Mock
+    private MachineRepository machineRepository;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    @Mock
+    private DeviceStatusQuerySupport deviceStatusQuerySupport;
+
+    @Mock
+    private SendDeviceCommandService sendDeviceCommandService;
+
+    @Mock
+    private WasherTubCleanMachineGuard machineGuard;
+
+    @Mock
+    private SmartThingsTubCleanEnvironment tubCleanEnvironment;
+
+    private Machine createMachine() {
+        var machine = Machine.builder().name("W-2F-L1").type(MachineType.WASHER).deviceId("device-1").floor(2)
+                .position(Position.LEFT).number(1).status(MachineStatus.NORMAL)
+                .availability(MachineAvailability.AVAILABLE).build();
+        ReflectionTestUtils.setField(machine, "id", 1L);
+        return machine;
+    }
+
+    private SmartThingsDeviceStatusResDto idleStatus(boolean remoteEnabled) {
+        var washerState = new WasherOperatingState(new AttributeState("stop", null, null),
+                new AttributeState("none", null, null),
+                null);
+        var remoteControl = new RemoteControlStatus(new AttributeState(String.valueOf(remoteEnabled), null, null));
+        var switchCapability = new SwitchCapability(new AttributeState("on", null, null));
+        return new SmartThingsDeviceStatusResDto(
+                Map.of("main", new ComponentStatus(washerState, null, switchCapability, remoteControl)));
+    }
+
+    @Nested
+    @DisplayName("execute 메서드는")
+    class Describe_execute {
+
+        @Test
+        @DisplayName("통세척 코스가 설정되지 않으면 기기를 조회하지 않아야 한다")
+        void it_skips_when_cycle_is_not_configured() {
+            given(tubCleanEnvironment.hasCycle()).willReturn(false);
+
+            runWasherTubCleanService.execute();
+
+            then(machineRepository).shouldHaveNoInteractions();
+            then(sendDeviceCommandService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("유휴 세탁기를 점유하고 통세척 코스와 실행 명령을 전송해야 한다")
+        void it_starts_tub_clean_on_idle_washer() {
+            var machine = createMachine();
+            given(tubCleanEnvironment.hasCycle()).willReturn(true);
+            given(tubCleanEnvironment.cycle()).willReturn("Course_82");
+            given(machineRepository.findByTypeAndStatusAndAvailability(MachineType.WASHER,
+                    MachineStatus.NORMAL,
+                    MachineAvailability.AVAILABLE)).willReturn(List.of(machine));
+            given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of());
+            given(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1")))
+                    .willReturn(Map.of("device-1", idleStatus(true)));
+            given(machineGuard.occupyIfAvailable(1L))
+                    .willReturn(Optional.of(new TubCleanTarget(1L, "W-2F-L1", "device-1")));
+
+            runWasherTubCleanService.execute();
+
+            var commandCaptor = ArgumentCaptor.forClass(SmartThingsCommandReqDto.class);
+            then(sendDeviceCommandService).should(times(1)).execute(eq("device-1"), commandCaptor.capture());
+            assertThat(commandCaptor.getValue().commands()).hasSize(2);
+            assertThat(commandCaptor.getValue().commands().get(0).capability()).isEqualTo("samsungce.washerCycle");
+            assertThat(commandCaptor.getValue().commands().get(0).arguments()).containsExactly("Course_82");
+            assertThat(commandCaptor.getValue().commands().get(1).command()).isEqualTo("setMachineState");
+        }
+
+        @Test
+        @DisplayName("활성 예약이 있는 세탁기는 상태 조회와 실행에서 제외해야 한다")
+        void it_skips_reserved_washer() {
+            var machine = createMachine();
+            given(tubCleanEnvironment.hasCycle()).willReturn(true);
+            given(machineRepository.findByTypeAndStatusAndAvailability(MachineType.WASHER,
+                    MachineStatus.NORMAL,
+                    MachineAvailability.AVAILABLE)).willReturn(List.of(machine));
+            given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of(1L));
+
+            runWasherTubCleanService.execute();
+
+            then(deviceStatusQuerySupport).shouldHaveNoInteractions();
+            then(sendDeviceCommandService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("원격 제어가 꺼진 세탁기는 실행하지 않아야 한다")
+        void it_skips_washer_with_remote_control_disabled() {
+            var machine = createMachine();
+            given(tubCleanEnvironment.hasCycle()).willReturn(true);
+            given(machineRepository.findByTypeAndStatusAndAvailability(MachineType.WASHER,
+                    MachineStatus.NORMAL,
+                    MachineAvailability.AVAILABLE)).willReturn(List.of(machine));
+            given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of());
+            given(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1")))
+                    .willReturn(Map.of("device-1", idleStatus(false)));
+
+            runWasherTubCleanService.execute();
+
+            then(machineGuard).should(never()).occupyIfAvailable(any());
+            then(sendDeviceCommandService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("명령 전송에 실패하면 세탁기 점유를 해제해야 한다")
+        void it_releases_occupancy_when_command_fails() {
+            var machine = createMachine();
+            given(tubCleanEnvironment.hasCycle()).willReturn(true);
+            given(tubCleanEnvironment.cycle()).willReturn("Course_82");
+            given(machineRepository.findByTypeAndStatusAndAvailability(MachineType.WASHER,
+                    MachineStatus.NORMAL,
+                    MachineAvailability.AVAILABLE)).willReturn(List.of(machine));
+            given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of());
+            given(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1")))
+                    .willReturn(Map.of("device-1", idleStatus(true)));
+            given(machineGuard.occupyIfAvailable(1L))
+                    .willReturn(Optional.of(new TubCleanTarget(1L, "W-2F-L1", "device-1")));
+            willThrow(new RuntimeException("명령 전송 실패")).given(sendDeviceCommandService).execute(eq("device-1"), any());
+
+            runWasherTubCleanService.execute();
+
+            then(machineGuard).should(times(1)).releaseIfNoActiveReservation(1L);
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/domain/smartthings/support/WasherTubCleanMachineGuardTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/support/WasherTubCleanMachineGuardTest.java
@@ -1,0 +1,101 @@
+package team.washer.server.v2.domain.smartthings.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineAvailability;
+import team.washer.server.v2.domain.machine.enums.MachineStatus;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.enums.Position;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("WasherTubCleanMachineGuard 클래스의")
+class WasherTubCleanMachineGuardTest {
+
+    private static final List<ReservationStatus> ACTIVE_STATUSES = List.of(ReservationStatus.RESERVED,
+            ReservationStatus.RUNNING);
+
+    @InjectMocks
+    private WasherTubCleanMachineGuard machineGuard;
+
+    @Mock
+    private MachineRepository machineRepository;
+
+    @Mock
+    private ReservationRepository reservationRepository;
+
+    private Machine createMachine() {
+        var machine = Machine.builder().name("W-2F-L1").type(MachineType.WASHER).deviceId("device-1").floor(2)
+                .position(Position.LEFT).number(1).status(MachineStatus.NORMAL)
+                .availability(MachineAvailability.AVAILABLE).build();
+        ReflectionTestUtils.setField(machine, "id", 1L);
+        return machine;
+    }
+
+    @Nested
+    @DisplayName("occupyIfAvailable 메서드는")
+    class Describe_occupyIfAvailable {
+
+        @Test
+        @DisplayName("사용 가능한 세탁기를 통세척 중 상태로 점유해야 한다")
+        void it_occupies_available_washer() {
+            var machine = createMachine();
+            given(machineRepository.findByIdForUpdate(1L)).willReturn(Optional.of(machine));
+            given(reservationRepository.countActiveReservationsByMachine(machine, ACTIVE_STATUSES)).willReturn(0L);
+
+            var result = machineGuard.occupyIfAvailable(1L);
+
+            assertThat(result).isPresent();
+            assertThat(result.get().deviceId()).isEqualTo("device-1");
+            assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.CLEANING);
+        }
+
+        @Test
+        @DisplayName("활성 예약이 생긴 세탁기는 점유하지 않아야 한다")
+        void it_skips_washer_with_active_reservation() {
+            var machine = createMachine();
+            given(machineRepository.findByIdForUpdate(1L)).willReturn(Optional.of(machine));
+            given(reservationRepository.countActiveReservationsByMachine(machine, ACTIVE_STATUSES)).willReturn(1L);
+
+            var result = machineGuard.occupyIfAvailable(1L);
+
+            assertThat(result).isEmpty();
+            assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
+        }
+    }
+
+    @Nested
+    @DisplayName("releaseIfNoActiveReservation 메서드는")
+    class Describe_releaseIfNoActiveReservation {
+
+        @Test
+        @DisplayName("활성 예약이 없는 통세척 중 세탁기의 점유를 해제해야 한다")
+        void it_releases_unreserved_washer() {
+            var machine = createMachine();
+            machine.markAsCleaning();
+            given(machineRepository.findByIdForUpdate(1L)).willReturn(Optional.of(machine));
+            given(reservationRepository.countActiveReservationsByMachine(machine, ACTIVE_STATUSES)).willReturn(0L);
+
+            var released = machineGuard.releaseIfNoActiveReservation(1L);
+
+            assertThat(released).isTrue();
+            assertThat(machine.getAvailability()).isEqualTo(MachineAvailability.AVAILABLE);
+        }
+    }
+}


### PR DESCRIPTION
## 개요

매주 금요일 오전 10시(Asia/Seoul)에 예약이 없는 유휴 세탁기를 대상으로 SmartThings 무세제 통세척을 실행합니다.
실행 중에는 별도 가용 상태로 기기를 점유하고, 완료가 확인되면 자동으로 점유를 해제합니다.

## 본문

- `WasherTubCleanScheduler`를 추가하여 `third-party.smartthings.tub-clean.cron` 일정에 통세척을 실행하고 1분마다 완료 상태를 확인하도록 구성했습니다.
- 실행 직전에 활성 예약, 기기 고장 여부, DB 가용 상태, SmartThings 원격 제어 상태, 실제 작동 상태를 확인합니다.
- `WasherTubCleanMachineGuard`에서 비관적 락으로 기기를 다시 확인한 뒤 `CLEANING` 상태로 전환하여 동시 예약 생성을 차단합니다.
- SmartThings 명령 실패 시 즉시 점유를 해제하고, 명령 수락 직후 상태 반영 지연을 고려해 완료 판정에 5분 유예 시간을 적용했습니다.
- `MachineAvailability.CLEANING`을 추가하여 일반 사용 중 상태와 통세척 상태를 구분하고 기기 목록 API에서도 해당 상태를 유지합니다.
- 무세제 통세척 코스는 모델별 코드가 달라 `SMARTTHINGS_TUB_CLEAN_CYCLE`로 주입하며, `SMARTTHINGS_TUB_CLEAN_ENABLED=true`일 때 스케줄러가 활성화됩니다.
- 전체 476개 테스트와 `spotlessCheck`를 통과했습니다.
