### PR TITLE
[reservation] 미사용 리포지토리 메서드 제거

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/ReservationRepository.java
@@ -71,6 +71,10 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
                 List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING)));
     }
 
+    @Query("SELECT COUNT(r) FROM Reservation r WHERE r.machine = :machine AND r.status IN :statuses")
+    long countActiveReservationsByMachine(@Param("machine") Machine machine,
+            @Param("statuses") List<ReservationStatus> statuses);
+
     @Query("SELECT r FROM Reservation r WHERE r.user = :user ORDER BY r.createdAt DESC")
     List<Reservation> findReservationHistoryByUser(@Param("user") User user);
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/ReservationRepository.java
@@ -1,6 +1,5 @@
 package team.washer.server.v2.domain.reservation.repository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -71,14 +70,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
         return ActiveReservationSelector.selectPrimary(findFirstActiveReservationByMachineId(machineId,
                 List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING)));
     }
-
-    @Query("SELECT r FROM Reservation r WHERE r.status = :status AND r.startTime < :threshold")
-    List<Reservation> findExpiredReservedReservations(@Param("status") ReservationStatus status,
-            @Param("threshold") LocalDateTime threshold);
-
-    @Query("SELECT COUNT(r) FROM Reservation r WHERE r.machine = :machine AND r.status IN :statuses")
-    long countActiveReservationsByMachine(@Param("machine") Machine machine,
-            @Param("statuses") List<ReservationStatus> statuses);
 
     @Query("SELECT r FROM Reservation r WHERE r.user = :user ORDER BY r.createdAt DESC")
     List<Reservation> findReservationHistoryByUser(@Param("user") User user);


### PR DESCRIPTION
## 개요

`ReservationRepository`에 남아 있던 죽은 쿼리 메서드 `findExpiredReservedReservations`를 제거하고, 사용처가 사라진 `java.time.LocalDateTime` import를 정리하였습니다.

closes #113

## 본문

### 제거 근거

`findExpiredReservedReservations`는 단순 미사용이 아니라 조건 자체가 잘못된 죽은 쿼리였습니다. RESERVED 예약은 `startTime`이 `null`이라 `r.startTime < :threshold` 조건은 어떤 행도 반환하지 못합니다. 실제 만료 판정은 `reservedAt` 기준의 `ReservationRepositoryCustomImpl.findExpiredReservations()`가 담당하므로, 잘못된 기준으로 재사용될 위험을 없애기 위해 삭제하였습니다.

### 이슈 체크리스트 대비 범위 축소

- `countActiveReservationsByMachine`: **제거하지 않습니다.** 이슈 작성 이후 열린 PR #123의 `WasherTubCleanMachineGuard.hasActiveReservation()`이 통세척 시작·종료 직전 활성 예약 재확인에 이 메서드를 사용하게 되어, 삭제 시 머지 순서와 무관하게 컴파일이 실패합니다. (리뷰 지적 반영, dfe939b)
- `existsByMachineAndStatusIn`, `ReservationRepositoryCustom.existsActiveReservationByRoomAndMachineType`: #110 머지 시점에 이미 제거되어 있어 이번 PR에서는 변경 사항이 없습니다.
- 테스트 스텁: 예약 관련 테스트가 모두 Mockito 목 기반이라 제거된 메서드를 참조하는 스텁이 없어 정리 대상이 없었습니다.

### 검증

`./gradlew spotlessApply compileJava test` 전부 통과하였습니다.

https://claude.ai/code/session_01VVnM26TwXTAKPNa7HxHCJP
