### PR TITLE
[global] PR 라벨 참조 문서를 실제 라벨에 맞게 갱신

### DIFF
--- a/.claude/skills/write-pr/references/labels.md
+++ b/.claude/skills/write-pr/references/labels.md
@@ -1,33 +1,35 @@
 # GitHub Labels Reference
 
 Select **1–2 labels** from the PR-eligible list below. Do NOT use issue-only or manual labels.
+Label names must match the repository exactly (verify with `gh label list`).
 
 ## PR-Eligible Labels (auto-selectable)
 
-| Label               | When to use                                               |
-|---------------------|-----------------------------------------------------------|
-| `enhancement:개선작업`  | New feature, improvement to existing feature, refactoring |
-| `bug:버그`            | Bug fix                                                   |
-| `documentation:문서화` | Docs-only changes (README, CONTRIBUTING, comments)        |
-| `release:릴리즈`       | Release preparation or version bump                       |
+| Label     | When to use                                            |
+|-----------|--------------------------------------------------------|
+| `신규 기능`  | New feature or improvement to an existing feature       |
+| `리팩터링`   | Refactoring / code improvement without behavior change |
+| `버그`      | Bug fix                                                 |
+| `문서화`     | Docs-only changes (README, CONTRIBUTING, comments)     |
+| `삭제`      | Removal of a feature, module, or dead code             |
 
 ## Off-limits Labels (do NOT assign)
 
-| Label                      | Reason                                                                     |
-|----------------------------|----------------------------------------------------------------------------|
-| `waiting for review:검토 대기` | Applied manually by the author after the PR is ready — never auto-assigned |
-| `help wanted:도움 필요`        | Issues only                                                                |
-| `invalid:무효한`              | Issues only                                                                |
-| `duplicate:중복`             | Issues only                                                                |
-| `GFI:첫 기여 추천`              | Issues only                                                                |
-| `blocked:차단됨`              | Applied manually when blocked by another PR/issue                          |
+| Label                    | Reason                                                    |
+|--------------------------|-----------------------------------------------------------|
+| `무효`                     | Issues only                                               |
+| `중복됨`                    | Issues only                                               |
+| `중지됨`                    | Applied manually when blocked by another PR/issue         |
+| `harness sync:하네스 동기화`  | Automation-managed — never auto-assigned                  |
+| `bug:버그`                 | Legacy duplicate of `버그` — use `버그` instead              |
 
 ## Quick Decision
 
 ```
-Bug fix?          → bug:버그
-New feature or improvement? → enhancement:개선작업
-Docs only?        → documentation:문서화
-Release?          → release:릴리즈
-Unsure?           → enhancement:개선작업
+Bug fix?              → 버그
+New feature?          → 신규 기능
+Refactoring only?     → 리팩터링
+Docs only?            → 문서화
+Removal / deletion?   → 삭제
+Unsure?               → 신규 기능
 ```


### PR DESCRIPTION
## 개요

`write-pr` 스킬이 참조하는 `.claude/skills/write-pr/references/labels.md`에 저장소에 존재하지 않는 라벨이 적혀 있어, `gh label list` 결과에 맞게 갱신하였습니다.

## 본문

### 문제

기존 문서는 PR 라벨로 `enhancement:개선작업`, `bug:버그`, `documentation:문서화`, `release:릴리즈` 네 가지를 안내하고 있었습니다. 그러나 현재 저장소의 실제 라벨은 `신규 기능`, `리팩터링`, `버그`, `문서화`, `삭제`이며, 안내된 이름 중 실재하는 것은 색상 없는 잔여 라벨 `bug:버그` 하나뿐입니다. 이 목록을 그대로 사용하면 `gh pr create --label` 이 실패합니다.

off-limits 목록도 마찬가지로 `help wanted:도움 필요`, `invalid:무효한`, `GFI:첫 기여 추천` 등 존재하지 않는 이름을 담고 있었습니다.

### 변경

`gh label list` 출력과 대조하여 두 표를 모두 실제 라벨로 교체하였습니다.

- PR 선택 가능: `신규 기능`, `리팩터링`, `버그`, `문서화`, `삭제`
- 사용 금지: `무효`, `중복됨`, `중지됨`, `harness sync:하네스 동기화`, `bug:버그`

`리팩터링`과 `삭제`는 기존 문서에 없어 리팩터링 및 코드 제거 PR이 전부 `enhancement:개선작업`으로 뭉뚱그려지던 항목이므로, Quick Decision 표에 분기를 추가하였습니다. `bug:버그`는 `버그`와 중복되는 잔여 라벨이라 사용 금지 항목으로 옮겼습니다.

문서 상단에는 라벨명을 `gh label list`로 검증하라는 문장을 추가하여 같은 어긋남이 반복되지 않도록 하였습니다.

---

https://claude.ai/code/session_013RVjxtwAQdfJzGk5ebXS7E
