### PR TITLE
[reservation] 만료 예약을 활성으로 판정하는 지점 정리

### DIFF
--- a/src/main/java/team/washer/server/v2/domain/admin/service/impl/QueryAdminDashboardServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/admin/service/impl/QueryAdminDashboardServiceImpl.java
@@ -32,7 +32,7 @@ public class QueryAdminDashboardServiceImpl implements QueryAdminDashboardServic
     public AdminDashboardResDto execute() {
         log.info("Querying admin dashboard statistics");
 
-        var activeReservations = reservationRepository.countActiveReservations();
+        var activeReservations = reservationRepository.countCurrentlyActive();
         var pendingReports = malfunctionReportRepository.countByStatus(MalfunctionReportStatus.PENDING);
         var processingReports = malfunctionReportRepository.countByStatus(MalfunctionReportStatus.IN_PROGRESS);
         var completedReports = malfunctionReportRepository.countByStatus(MalfunctionReportStatus.RESOLVED);

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/DeleteMachineServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/DeleteMachineServiceImpl.java
@@ -24,7 +24,7 @@ public class DeleteMachineServiceImpl implements DeleteMachineService {
         final var machine = machineRepository.findById(machineId)
                 .orElseThrow(() -> new ExpectedException("기기를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
-        if (reservationRepository.findActiveReservationByMachineId(machineId).isPresent()) {
+        if (reservationRepository.findCurrentlyActiveReservationByMachineId(machineId).isPresent()) {
             throw new ExpectedException("활성 예약이 존재하는 기기는 삭제할 수 없습니다", HttpStatus.BAD_REQUEST);
         }
 

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/QueryAllMachinesStatusServiceImpl.java
@@ -55,7 +55,8 @@ public class QueryAllMachinesStatusServiceImpl implements QueryAllMachinesStatus
         var deviceStatusMap = deviceStatusQuerySupport.queryAllDevicesStatus(deviceIds);
 
         var results = machines.stream().map(machine -> {
-            var reservation = reservationRepository.findActiveReservationByMachineId(machine.getId()).orElse(null);
+            var reservation = reservationRepository.findCurrentlyActiveReservationByMachineId(machine.getId())
+                    .orElse(null);
             return mapToStatusDto(machine, deviceStatusMap.get(machine.getDeviceId()), reservation);
         }).toList();
 

--- a/src/main/java/team/washer/server/v2/domain/machine/service/impl/UpdateMachineStatusServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/machine/service/impl/UpdateMachineStatusServiceImpl.java
@@ -34,8 +34,9 @@ public class UpdateMachineStatusServiceImpl implements UpdateMachineStatusServic
         } else if (status == MachineStatus.NORMAL) {
             machine.markAsNormal();
 
-            // 복구 후 실제 예약 상태에 맞게 availability 재동기화
-            findActiveReservation(machine).ifPresent(reservation -> {
+            // 복구 후 실제 예약 상태에 맞게 availability 재동기화. 만료된 RESERVED 예약은 활성으로 보지 않으므로
+            // markAsNormal()이 설정한 AVAILABLE이 그대로 유지된다
+            findCurrentlyActiveReservation(machine).ifPresent(reservation -> {
                 switch (reservation.getStatus()) {
                     case RESERVED -> machine.markAsReserved();
                     case RUNNING -> machine.markAsInUse();
@@ -53,7 +54,7 @@ public class UpdateMachineStatusServiceImpl implements UpdateMachineStatusServic
                 savedMachine.getAvailability());
     }
 
-    private Optional<Reservation> findActiveReservation(Machine machine) {
-        return reservationRepository.findActiveReservationByMachineId(machine.getId());
+    private Optional<Reservation> findCurrentlyActiveReservation(Machine machine) {
+        return reservationRepository.findCurrentlyActiveReservationByMachineId(machine.getId());
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/ReservationRepository.java
@@ -44,23 +44,21 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
         return findByStatusIn(List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING));
     }
 
-    @Query("SELECT COUNT(r) FROM Reservation r WHERE r.status IN :statuses")
-    long countAllActiveReservations(@Param("statuses") List<ReservationStatus> statuses);
-
-    default long countActiveReservations() {
-        return countAllActiveReservations(List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING));
-    }
-
     @Query("SELECT r FROM Reservation r WHERE r.machine.id = :machineId AND r.status IN :statuses ORDER BY r.createdAt DESC")
     List<Reservation> findFirstActiveReservationByMachineId(@Param("machineId") Long machineId,
             @Param("statuses") List<ReservationStatus> statuses);
 
     /**
-     * 기기의 대표 활성 예약을 조회한다. 선택 규칙은 {@link ActiveReservationSelector}가 정의한다.
+     * 기기의 대표 활성 예약을 조회한다. 만료 예약 제외는
+     * {@link ReservationRepositoryCustom#findCurrentlyActiveByMachineId(Long)}가 쿼리
+     * 단계에서 처리하고, 남은 후보 중 대표를 고르는 규칙은 {@link ActiveReservationSelector}가 정의한다.
+     *
+     * <p>
+     * 타임아웃이 지난 RESERVED 예약만 남은 기기는 {@link Optional#empty()}가 된다. 스케줄러가 아직 정리하지 못한
+     * 만료 예약이 기기를 점유한 것처럼 보이게 하지 않기 위함이다.
      */
-    default Optional<Reservation> findActiveReservationByMachineId(Long machineId) {
-        return ActiveReservationSelector.selectPrimary(findFirstActiveReservationByMachineId(machineId,
-                List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING)));
+    default Optional<Reservation> findCurrentlyActiveReservationByMachineId(Long machineId) {
+        return ActiveReservationSelector.selectPrimary(findCurrentlyActiveByMachineId(machineId));
     }
 
     @Query("SELECT COUNT(r) FROM Reservation r WHERE r.machine = :machine AND r.status IN :statuses")
@@ -76,6 +74,4 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
 
     @Query("SELECT DISTINCT r.machine.id FROM Reservation r WHERE r.status IN :statuses")
     List<Long> findMachineIdsByStatusIn(@Param("statuses") List<ReservationStatus> statuses);
-
-    boolean existsByUserAndStatusIn(User user, List<ReservationStatus> statuses);
 }

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/ReservationRepositoryCustom.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/ReservationRepositoryCustom.java
@@ -85,6 +85,38 @@ public interface ReservationRepositoryCustom {
     List<Reservation> findCurrentlyActiveByRoomNumber(String roomNumber);
 
     /**
+     * 기기 ID로 현재 활성 예약 목록을 조회합니다. 타임아웃이 지난 RESERVED 예약은 쿼리 단계에서 제외됩니다.
+     *
+     * @param machineId
+     *            조회 대상 기기 ID
+     * @return 만료되지 않은 활성 예약 목록 (createdAt 내림차순)
+     */
+    List<Reservation> findCurrentlyActiveByMachineId(Long machineId);
+
+    /**
+     * 현재 활성 예약이 걸려 있는 기기 ID 목록을 조회합니다. 타임아웃이 지난 RESERVED 예약만 남은 기기는 포함되지 않습니다.
+     *
+     * @return 만료되지 않은 활성 예약이 있는 기기 ID 목록
+     */
+    List<Long> findCurrentlyActiveMachineIds();
+
+    /**
+     * 현재 활성 예약 수를 반환합니다. 타임아웃이 지난 RESERVED 예약은 집계에서 제외됩니다.
+     *
+     * @return 만료되지 않은 활성 예약 수
+     */
+    long countCurrentlyActive();
+
+    /**
+     * 사용자에게 현재 활성 예약이 있는지 반환합니다. 타임아웃이 지난 RESERVED 예약만 남아 있으면 거짓입니다.
+     *
+     * @param user
+     *            조회 대상 사용자
+     * @return 만료되지 않은 활성 예약 존재 여부
+     */
+    boolean existsCurrentlyActiveByUser(User user);
+
+    /**
      * 기기별 예약 히스토리 조회
      *
      * @param machineId

--- a/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/repository/custom/impl/ReservationRepositoryCustomImpl.java
@@ -111,6 +111,33 @@ public class ReservationRepositoryCustomImpl implements ReservationRepositoryCus
                 .orderBy(reservation.createdAt.desc()).fetch();
     }
 
+    @Override
+    public List<Reservation> findCurrentlyActiveByMachineId(Long machineId) {
+        return jpaQueryFactory.selectFrom(reservation).join(reservation.machine, machine).fetchJoin()
+                .join(reservation.user, user).fetchJoin().where(reservation.machine.id.eq(machineId), currentlyActive())
+                .orderBy(reservation.createdAt.desc()).fetch();
+    }
+
+    @Override
+    public List<Long> findCurrentlyActiveMachineIds() {
+        return jpaQueryFactory.select(reservation.machine.id).distinct().from(reservation).where(currentlyActive())
+                .fetch();
+    }
+
+    @Override
+    public long countCurrentlyActive() {
+        final var total = jpaQueryFactory.select(reservation.count()).from(reservation).where(currentlyActive())
+                .fetchOne();
+
+        return total != null ? total : 0L;
+    }
+
+    @Override
+    public boolean existsCurrentlyActiveByUser(User targetUser) {
+        return jpaQueryFactory.selectOne().from(reservation).where(reservation.user.eq(targetUser), currentlyActive())
+                .fetchFirst() != null;
+    }
+
     /**
      * 만료되지 않은 활성 예약 조건을 반환합니다. {@link Reservation#isCurrentlyActive()}와 동일한 규칙을 쿼리
      * 조건으로 표현한 것으로, 전체를 로드한 뒤 메모리에서 거르지 않도록 합니다.

--- a/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/ShutdownIdleMachinesServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/service/impl/ShutdownIdleMachinesServiceImpl.java
@@ -1,7 +1,6 @@
 package team.washer.server.v2.domain.smartthings.service.impl;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -12,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import team.washer.server.v2.domain.machine.entity.Machine;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
-import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.smartthings.exception.SmartThingsPermissionException;
 import team.washer.server.v2.domain.smartthings.service.ShutdownIdleMachinesService;
@@ -33,9 +31,6 @@ public class ShutdownIdleMachinesServiceImpl implements ShutdownIdleMachinesServ
     @Autowired(required = false)
     private DiscordErrorNotificationService discordErrorNotificationService;
 
-    private static final List<ReservationStatus> ACTIVE_STATUSES = List.of(ReservationStatus.RESERVED,
-            ReservationStatus.RUNNING);
-
     @Override
     public void execute() {
         var machines = machineRepository.findAll();
@@ -43,7 +38,8 @@ public class ShutdownIdleMachinesServiceImpl implements ShutdownIdleMachinesServ
             return;
         }
 
-        var activeMachineIds = Set.copyOf(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES));
+        // 만료 예약만 남은 기기는 실제로 아무도 쓰지 않으므로 유휴 전원 차단 대상에 포함한다
+        var activeMachineIds = Set.copyOf(reservationRepository.findCurrentlyActiveMachineIds());
 
         var idleCandidates = machines.stream().filter(machine -> !activeMachineIds.contains(machine.getId())).toList();
         var skippedActiveCount = machines.size() - idleCandidates.size();

--- a/src/main/java/team/washer/server/v2/domain/user/service/impl/DeleteUserServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/user/service/impl/DeleteUserServiceImpl.java
@@ -1,14 +1,11 @@
 package team.washer.server.v2.domain.user.service.impl;
 
-import java.util.List;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import team.themoment.sdk.exception.ExpectedException;
-import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.domain.user.service.DeleteUserService;
@@ -29,9 +26,8 @@ public class DeleteUserServiceImpl implements DeleteUserService {
         final var user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 
-        // 활성 예약이 있는지 확인
-        final var activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
-        final boolean hasActiveReservations = reservationRepository.existsByUserAndStatusIn(user, activeStatuses);
+        // 만료되지 않은 활성 예약이 있는지 확인. 만료 예약만 남은 사용자는 본인 탈퇴와 동일하게 삭제할 수 있어야 한다
+        final boolean hasActiveReservations = reservationRepository.existsCurrentlyActiveByUser(user);
 
         if (hasActiveReservations) {
             throw new ExpectedException("활성 예약이 있는 사용자는 삭제할 수 없습니다", HttpStatus.BAD_REQUEST);

--- a/src/test/java/team/washer/server/v2/domain/admin/service/QueryAdminDashboardServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/admin/service/QueryAdminDashboardServiceTest.java
@@ -46,7 +46,7 @@ class QueryAdminDashboardServiceTest {
         @DisplayName("활성 예약, 고장 신고, 기기, 세탁정지 학생 통계를 성공적으로 조회한다")
         void execute_ShouldReturnDashboardStatistics_WhenDataExists() {
             // Given
-            when(reservationRepository.countActiveReservations()).thenReturn(5L);
+            when(reservationRepository.countCurrentlyActive()).thenReturn(5L);
             when(malfunctionReportRepository.countByStatus(MalfunctionReportStatus.PENDING)).thenReturn(3L);
             when(malfunctionReportRepository.countByStatus(MalfunctionReportStatus.IN_PROGRESS)).thenReturn(2L);
             when(malfunctionReportRepository.countByStatus(MalfunctionReportStatus.RESOLVED)).thenReturn(10L);
@@ -72,7 +72,7 @@ class QueryAdminDashboardServiceTest {
         @DisplayName("데이터가 없으면 모든 통계가 0으로 반환된다")
         void execute_ShouldReturnZeroStatistics_WhenNoDataExists() {
             // Given
-            when(reservationRepository.countActiveReservations()).thenReturn(0L);
+            when(reservationRepository.countCurrentlyActive()).thenReturn(0L);
             when(malfunctionReportRepository.countByStatus(MalfunctionReportStatus.PENDING)).thenReturn(0L);
             when(malfunctionReportRepository.countByStatus(MalfunctionReportStatus.IN_PROGRESS)).thenReturn(0L);
             when(malfunctionReportRepository.countByStatus(MalfunctionReportStatus.RESOLVED)).thenReturn(0L);

--- a/src/test/java/team/washer/server/v2/domain/machine/service/DeleteMachineServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/DeleteMachineServiceTest.java
@@ -62,7 +62,8 @@ class DeleteMachineServiceTest {
                 var machineId = 1L;
                 var machine = createMachine();
                 given(machineRepository.findById(machineId)).willReturn(Optional.of(machine));
-                given(reservationRepository.findActiveReservationByMachineId(machineId)).willReturn(Optional.empty());
+                given(reservationRepository.findCurrentlyActiveReservationByMachineId(machineId))
+                        .willReturn(Optional.empty());
 
                 // When
                 var result = deleteMachineService.execute(machineId);
@@ -85,7 +86,7 @@ class DeleteMachineServiceTest {
                 var machineId = 1L;
                 var machine = createMachine();
                 given(machineRepository.findById(machineId)).willReturn(Optional.of(machine));
-                given(reservationRepository.findActiveReservationByMachineId(machineId))
+                given(reservationRepository.findCurrentlyActiveReservationByMachineId(machineId))
                         .willReturn(Optional.of(activeReservation));
 
                 // When & Then

--- a/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/QueryAllMachinesStatusServiceTest.java
@@ -98,7 +98,7 @@ class QueryAllMachinesStatusServiceTest {
             when(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1", "device-2")))
                     .thenReturn(Map.of("device-1", deviceStatus, "device-2", deviceStatus));
 
-            when(reservationRepository.findActiveReservationByMachineId(any())).thenReturn(Optional.empty());
+            when(reservationRepository.findCurrentlyActiveReservationByMachineId(any())).thenReturn(Optional.empty());
 
             // When
             var result = queryAllMachinesStatusService.execute(USER_ID, true);
@@ -122,7 +122,7 @@ class QueryAllMachinesStatusServiceTest {
 
             when(machineRepository.findAll()).thenReturn(List.of(machine1));
             when(deviceStatusQuerySupport.queryAllDevicesStatus(any())).thenReturn(Map.of());
-            when(reservationRepository.findActiveReservationByMachineId(any())).thenReturn(Optional.empty());
+            when(reservationRepository.findCurrentlyActiveReservationByMachineId(any())).thenReturn(Optional.empty());
 
             // When
             var result = queryAllMachinesStatusService.execute(USER_ID, false);
@@ -174,7 +174,8 @@ class QueryAllMachinesStatusServiceTest {
             when(machineRepository.findAll(any(Sort.class))).thenReturn(List.of(machine));
             when(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1")))
                     .thenReturn(Map.of("device-1", deviceStatus));
-            when(reservationRepository.findActiveReservationByMachineId(any())).thenReturn(Optional.of(reservation));
+            when(reservationRepository.findCurrentlyActiveReservationByMachineId(any()))
+                    .thenReturn(Optional.of(reservation));
             when(reservation.getStatus()).thenReturn(ReservationStatus.RUNNING);
             when(reservation.getUser()).thenReturn(user);
 
@@ -211,7 +212,8 @@ class QueryAllMachinesStatusServiceTest {
             when(machineRepository.findAll(any(Sort.class))).thenReturn(List.of(machine));
             when(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1")))
                     .thenReturn(Map.of("device-1", deviceStatus));
-            when(reservationRepository.findActiveReservationByMachineId(any())).thenReturn(Optional.of(reservation));
+            when(reservationRepository.findCurrentlyActiveReservationByMachineId(any()))
+                    .thenReturn(Optional.of(reservation));
             when(reservation.getId()).thenReturn(10L);
             when(reservation.getStatus()).thenReturn(ReservationStatus.RUNNING);
             when(reservation.getUser()).thenReturn(user);
@@ -272,7 +274,7 @@ class QueryAllMachinesStatusServiceTest {
             givenUserMocked();
             when(machineRepository.findAll(any(Sort.class))).thenReturn(List.of(machine));
             when(deviceStatusQuerySupport.queryAllDevicesStatus(any())).thenReturn(Map.of());
-            when(reservationRepository.findActiveReservationByMachineId(any()))
+            when(reservationRepository.findCurrentlyActiveReservationByMachineId(any()))
                     .thenReturn(Optional.ofNullable(reservationOrNull));
         }
 

--- a/src/test/java/team/washer/server/v2/domain/machine/service/UpdateMachineStatusServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/machine/service/UpdateMachineStatusServiceTest.java
@@ -102,7 +102,7 @@ class UpdateMachineStatusServiceTest {
                     given(machine.getId()).willReturn(machineId);
 
                     given(machineRepository.findById(machineId)).willReturn(Optional.of(machine));
-                    given(reservationRepository.findActiveReservationByMachineId(machineId))
+                    given(reservationRepository.findCurrentlyActiveReservationByMachineId(machineId))
                             .willReturn(Optional.empty());
                     given(machineRepository.save(any(Machine.class)))
                             .willAnswer(invocation -> invocation.getArgument(0));
@@ -115,7 +115,7 @@ class UpdateMachineStatusServiceTest {
                     assertThat(result.status()).isEqualTo(MachineStatus.NORMAL);
                     assertThat(result.availability()).isEqualTo(MachineAvailability.AVAILABLE);
                     then(machineRepository).should(times(1)).findById(machineId);
-                    then(reservationRepository).should(times(1)).findActiveReservationByMachineId(machineId);
+                    then(reservationRepository).should(times(1)).findCurrentlyActiveReservationByMachineId(machineId);
                     then(machineRepository).should(times(1)).save(any(Machine.class));
                 }
             }
@@ -134,7 +134,7 @@ class UpdateMachineStatusServiceTest {
                     Reservation reservation = createReservation(machine, ReservationStatus.RESERVED);
 
                     given(machineRepository.findById(machineId)).willReturn(Optional.of(machine));
-                    given(reservationRepository.findActiveReservationByMachineId(machineId))
+                    given(reservationRepository.findCurrentlyActiveReservationByMachineId(machineId))
                             .willReturn(Optional.of(reservation));
                     given(machineRepository.save(any(Machine.class)))
                             .willAnswer(invocation -> invocation.getArgument(0));
@@ -147,7 +147,7 @@ class UpdateMachineStatusServiceTest {
                     assertThat(result.status()).isEqualTo(MachineStatus.NORMAL);
                     assertThat(result.availability()).isEqualTo(MachineAvailability.RESERVED);
                     then(machineRepository).should(times(1)).findById(machineId);
-                    then(reservationRepository).should(times(1)).findActiveReservationByMachineId(machineId);
+                    then(reservationRepository).should(times(1)).findCurrentlyActiveReservationByMachineId(machineId);
                     then(machineRepository).should(times(1)).save(any(Machine.class));
                 }
             }

--- a/src/test/java/team/washer/server/v2/domain/reservation/repository/ReservationRepositoryCurrentlyActiveTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/repository/ReservationRepositoryCurrentlyActiveTest.java
@@ -50,7 +50,9 @@ class ReservationRepositoryCurrentlyActiveTest {
     private TestEntityManager entityManager;
 
     private User owner;
+    private User expiredOnlyOwner;
     private Machine washer;
+    private Machine expiredOnlyMachine;
 
     private Reservation freshReserved;
     private Reservation justBeforeTimeoutReserved;
@@ -82,6 +84,14 @@ class ReservationRepositoryCurrentlyActiveTest {
         longRunning = persistReservation(ReservationStatus.RUNNING, now.minusHours(3));
         completed = persistReservation(ReservationStatus.COMPLETED, now.minusMinutes(1));
         cancelled = persistReservation(ReservationStatus.CANCELLED, now.minusMinutes(1));
+
+        // 만료된 RESERVED 예약만 남은 사용자와 기기. 스케줄러가 아직 정리하지 못한 상태를 재현한다
+        expiredOnlyOwner = persist(
+                User.builder().name("이건조").studentId("2102").roomNumber("302").grade(1).floor(3).build());
+        expiredOnlyMachine = persist(Machine.builder().name("W3R1").type(MachineType.WASHER).deviceId("device-w3r1")
+                .floor(3).position(Position.RIGHT).number(1).build());
+        persist(Reservation.builder().user(expiredOnlyOwner).machine(expiredOnlyMachine)
+                .status(ReservationStatus.RESERVED).reservedAt(now.minusMinutes(TIMEOUT_MINUTES + 30)).build());
 
         entityManager.flush();
         entityManager.clear();
@@ -117,6 +127,81 @@ class ReservationRepositoryCurrentlyActiveTest {
         @DisplayName("만료되지 않은 활성 예약만 반환한다")
         void 만료되지_않은_활성_예약만_반환한다() {
             assertActiveIdsAre(() -> reservationRepository.findCurrentlyActiveByRoomNumber(ROOM_NUMBER));
+        }
+    }
+
+    @Nested
+    @DisplayName("findCurrentlyActiveByMachineId 메서드는")
+    class FindCurrentlyActiveByMachineId {
+
+        @Test
+        @DisplayName("만료되지 않은 활성 예약만 반환한다")
+        void 만료되지_않은_활성_예약만_반환한다() {
+            assertActiveIdsAre(() -> reservationRepository.findCurrentlyActiveByMachineId(washer.getId()));
+        }
+
+        @Test
+        @DisplayName("만료 예약만 남은 기기에는 빈 목록을 반환한다")
+        void 만료_예약만_남은_기기에는_빈_목록을_반환한다() {
+            assertThat(reservationRepository.findCurrentlyActiveByMachineId(expiredOnlyMachine.getId())).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findCurrentlyActiveReservationByMachineId 메서드는")
+    class FindCurrentlyActiveReservationByMachineId {
+
+        @Test
+        @DisplayName("RUNNING 예약을 대표 예약으로 반환한다")
+        void RUNNING_예약을_대표_예약으로_반환한다() {
+            assertThat(reservationRepository.findCurrentlyActiveReservationByMachineId(washer.getId())).get()
+                    .extracting(Reservation::getId).isEqualTo(longRunning.getId());
+        }
+
+        @Test
+        @DisplayName("만료 예약만 남은 기기에는 빈 값을 반환한다")
+        void 만료_예약만_남은_기기에는_빈_값을_반환한다() {
+            assertThat(reservationRepository.findCurrentlyActiveReservationByMachineId(expiredOnlyMachine.getId()))
+                    .isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findCurrentlyActiveMachineIds 메서드는")
+    class FindCurrentlyActiveMachineIds {
+
+        @Test
+        @DisplayName("만료 예약만 남은 기기를 제외한 기기 ID만 반환한다")
+        void 만료_예약만_남은_기기를_제외한_기기_ID만_반환한다() {
+            assertThat(reservationRepository.findCurrentlyActiveMachineIds()).containsExactly(washer.getId());
+        }
+    }
+
+    @Nested
+    @DisplayName("countCurrentlyActive 메서드는")
+    class CountCurrentlyActive {
+
+        @Test
+        @DisplayName("만료 예약을 제외한 활성 예약 수를 반환한다")
+        void 만료_예약을_제외한_활성_예약_수를_반환한다() {
+            assertThat(reservationRepository.countCurrentlyActive()).isEqualTo(4L);
+        }
+    }
+
+    @Nested
+    @DisplayName("existsCurrentlyActiveByUser 메서드는")
+    class ExistsCurrentlyActiveByUser {
+
+        @Test
+        @DisplayName("만료되지 않은 활성 예약이 있으면 참을 반환한다")
+        void 만료되지_않은_활성_예약이_있으면_참을_반환한다() {
+            assertThat(reservationRepository.existsCurrentlyActiveByUser(owner)).isTrue();
+        }
+
+        @Test
+        @DisplayName("만료 예약만 남은 사용자에게는 거짓을 반환한다")
+        void 만료_예약만_남은_사용자에게는_거짓을_반환한다() {
+            assertThat(reservationRepository.existsCurrentlyActiveByUser(expiredOnlyOwner)).isFalse();
         }
     }
 

--- a/src/test/java/team/washer/server/v2/domain/smartthings/service/ShutdownIdleMachinesServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/smartthings/service/ShutdownIdleMachinesServiceTest.java
@@ -23,7 +23,6 @@ import team.washer.server.v2.domain.machine.enums.MachineStatus;
 import team.washer.server.v2.domain.machine.enums.MachineType;
 import team.washer.server.v2.domain.machine.enums.Position;
 import team.washer.server.v2.domain.machine.repository.MachineRepository;
-import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsDeviceStatusResDto;
 import team.washer.server.v2.domain.smartthings.exception.SmartThingsPermissionException;
@@ -50,9 +49,6 @@ class ShutdownIdleMachinesServiceTest {
 
     @Mock
     private DeviceShutdownSupport deviceShutdownSupport;
-
-    private static final List<ReservationStatus> ACTIVE_STATUSES = List.of(ReservationStatus.RESERVED,
-            ReservationStatus.RUNNING);
 
     private static final SmartThingsDeviceStatusResDto EMPTY_STATUS = new SmartThingsDeviceStatusResDto(Map.of());
 
@@ -97,7 +93,7 @@ class ShutdownIdleMachinesServiceTest {
                 // Given
                 var machine = createMachine(1L, "W-2F-L1", "device-1");
                 given(machineRepository.findAll()).willReturn(List.of(machine));
-                given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of());
+                given(reservationRepository.findCurrentlyActiveMachineIds()).willReturn(List.of());
                 given(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1")))
                         .willReturn(Map.of("device-1", EMPTY_STATUS));
                 given(deviceShutdownSupport.shutdown(eq(machine), any())).willReturn(ShutdownResult.POWERED_OFF);
@@ -120,7 +116,7 @@ class ShutdownIdleMachinesServiceTest {
                 // Given
                 var machine = createMachine(1L, "W-2F-L1", "device-1");
                 given(machineRepository.findAll()).willReturn(List.of(machine));
-                given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of(1L));
+                given(reservationRepository.findCurrentlyActiveMachineIds()).willReturn(List.of(1L));
 
                 // When
                 shutdownIdleMachinesService.execute();
@@ -141,7 +137,7 @@ class ShutdownIdleMachinesServiceTest {
                 // Given
                 var machine = createMachine(1L, "W-2F-L1", "device-1");
                 given(machineRepository.findAll()).willReturn(List.of(machine));
-                given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of());
+                given(reservationRepository.findCurrentlyActiveMachineIds()).willReturn(List.of());
                 given(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1")))
                         .willReturn(Map.of("device-1", EMPTY_STATUS));
                 given(deviceShutdownSupport.shutdown(eq(machine), any())).willReturn(ShutdownResult.STOPPED);
@@ -165,7 +161,7 @@ class ShutdownIdleMachinesServiceTest {
                 var machine1 = createMachine(1L, "W-2F-L1", "device-1");
                 var machine2 = createMachine(2L, "W-2F-R1", "device-2");
                 given(machineRepository.findAll()).willReturn(List.of(machine1, machine2));
-                given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of());
+                given(reservationRepository.findCurrentlyActiveMachineIds()).willReturn(List.of());
                 given(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1", "device-2")))
                         .willReturn(Map.of("device-1", EMPTY_STATUS, "device-2", EMPTY_STATUS));
                 willThrow(new SmartThingsPermissionException("권한 없음")).given(deviceShutdownSupport)
@@ -191,7 +187,7 @@ class ShutdownIdleMachinesServiceTest {
                 var machine1 = createMachine(1L, "W-2F-L1", "device-1");
                 var machine2 = createMachine(2L, "W-2F-R1", "device-2");
                 given(machineRepository.findAll()).willReturn(List.of(machine1, machine2));
-                given(reservationRepository.findMachineIdsByStatusIn(ACTIVE_STATUSES)).willReturn(List.of());
+                given(reservationRepository.findCurrentlyActiveMachineIds()).willReturn(List.of());
                 given(deviceStatusQuerySupport.queryAllDevicesStatus(List.of("device-1", "device-2")))
                         .willReturn(Map.of("device-1", EMPTY_STATUS, "device-2", EMPTY_STATUS));
                 willThrow(new RuntimeException("일시적 오류")).given(deviceShutdownSupport).shutdown(eq(machine1), any());

--- a/src/test/java/team/washer/server/v2/domain/user/service/DeleteUserServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/user/service/DeleteUserServiceTest.java
@@ -3,7 +3,6 @@ package team.washer.server.v2.domain.user.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -16,7 +15,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 
 import team.themoment.sdk.exception.ExpectedException;
-import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.user.entity.User;
 import team.washer.server.v2.domain.user.repository.UserRepository;
@@ -54,17 +52,15 @@ class DeleteUserServiceTest {
                 // Given
                 Long userId = 1L;
                 User user = createUser();
-                List<ReservationStatus> activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
-
                 given(userRepository.findById(userId)).willReturn(Optional.of(user));
-                given(reservationRepository.existsByUserAndStatusIn(user, activeStatuses)).willReturn(false);
+                given(reservationRepository.existsCurrentlyActiveByUser(user)).willReturn(false);
 
                 // When
                 deleteUserService.execute(userId);
 
                 // Then
                 then(userRepository).should(times(1)).findById(userId);
-                then(reservationRepository).should(times(1)).existsByUserAndStatusIn(user, activeStatuses);
+                then(reservationRepository).should(times(1)).existsCurrentlyActiveByUser(user);
                 then(userRepository).should(times(1)).delete(user);
             }
         }
@@ -79,10 +75,8 @@ class DeleteUserServiceTest {
                 // Given
                 Long userId = 1L;
                 User user = createUser();
-                List<ReservationStatus> activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
-
                 given(userRepository.findById(userId)).willReturn(Optional.of(user));
-                given(reservationRepository.existsByUserAndStatusIn(user, activeStatuses)).willReturn(true);
+                given(reservationRepository.existsCurrentlyActiveByUser(user)).willReturn(true);
 
                 // When & Then
                 assertThatThrownBy(() -> deleteUserService.execute(userId)).isInstanceOf(ExpectedException.class)
@@ -90,7 +84,7 @@ class DeleteUserServiceTest {
                         .hasFieldOrPropertyWithValue("statusCode", HttpStatus.BAD_REQUEST);
 
                 then(userRepository).should(times(1)).findById(userId);
-                then(reservationRepository).should(times(1)).existsByUserAndStatusIn(user, activeStatuses);
+                then(reservationRepository).should(times(1)).existsCurrentlyActiveByUser(user);
                 then(userRepository).should(never()).delete(any(User.class));
             }
         }
@@ -105,10 +99,8 @@ class DeleteUserServiceTest {
                 // Given
                 Long userId = 1L;
                 User user = createUser();
-                List<ReservationStatus> activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
-
                 given(userRepository.findById(userId)).willReturn(Optional.of(user));
-                given(reservationRepository.existsByUserAndStatusIn(user, activeStatuses)).willReturn(true);
+                given(reservationRepository.existsCurrentlyActiveByUser(user)).willReturn(true);
 
                 // When & Then
                 assertThatThrownBy(() -> deleteUserService.execute(userId)).isInstanceOf(ExpectedException.class)
@@ -116,7 +108,7 @@ class DeleteUserServiceTest {
                         .hasFieldOrPropertyWithValue("statusCode", HttpStatus.BAD_REQUEST);
 
                 then(userRepository).should(times(1)).findById(userId);
-                then(reservationRepository).should(times(1)).existsByUserAndStatusIn(user, activeStatuses);
+                then(reservationRepository).should(times(1)).existsCurrentlyActiveByUser(user);
                 then(userRepository).should(never()).delete(any(User.class));
             }
         }
@@ -131,17 +123,15 @@ class DeleteUserServiceTest {
                 // Given
                 Long userId = 1L;
                 User user = createUser();
-                List<ReservationStatus> activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
-
                 given(userRepository.findById(userId)).willReturn(Optional.of(user));
-                given(reservationRepository.existsByUserAndStatusIn(user, activeStatuses)).willReturn(false);
+                given(reservationRepository.existsCurrentlyActiveByUser(user)).willReturn(false);
 
                 // When
                 deleteUserService.execute(userId);
 
                 // Then
                 then(userRepository).should(times(1)).findById(userId);
-                then(reservationRepository).should(times(1)).existsByUserAndStatusIn(user, activeStatuses);
+                then(reservationRepository).should(times(1)).existsCurrentlyActiveByUser(user);
                 then(userRepository).should(times(1)).delete(user);
             }
         }
@@ -156,17 +146,38 @@ class DeleteUserServiceTest {
                 // Given
                 Long userId = 1L;
                 User user = createUser();
-                List<ReservationStatus> activeStatuses = List.of(ReservationStatus.RESERVED, ReservationStatus.RUNNING);
-
                 given(userRepository.findById(userId)).willReturn(Optional.of(user));
-                given(reservationRepository.existsByUserAndStatusIn(user, activeStatuses)).willReturn(false);
+                given(reservationRepository.existsCurrentlyActiveByUser(user)).willReturn(false);
 
                 // When
                 deleteUserService.execute(userId);
 
                 // Then
                 then(userRepository).should(times(1)).findById(userId);
-                then(reservationRepository).should(times(1)).existsByUserAndStatusIn(user, activeStatuses);
+                then(reservationRepository).should(times(1)).existsCurrentlyActiveByUser(user);
+                then(userRepository).should(times(1)).delete(user);
+            }
+        }
+
+        @Nested
+        @DisplayName("타임아웃이 지난 RESERVED 예약만 남은 사용자를 삭제할 때")
+        class Context_with_expired_reservations_only {
+
+            @Test
+            @DisplayName("사용자를 삭제해야 한다")
+            void it_deletes_user() {
+                // Given
+                Long userId = 1L;
+                User user = createUser();
+
+                given(userRepository.findById(userId)).willReturn(Optional.of(user));
+                given(reservationRepository.existsCurrentlyActiveByUser(user)).willReturn(false);
+
+                // When
+                deleteUserService.execute(userId);
+
+                // Then
+                then(reservationRepository).should(times(1)).existsCurrentlyActiveByUser(user);
                 then(userRepository).should(times(1)).delete(user);
             }
         }
@@ -188,7 +199,7 @@ class DeleteUserServiceTest {
                         .hasMessage("사용자를 찾을 수 없습니다").hasFieldOrPropertyWithValue("statusCode", HttpStatus.NOT_FOUND);
 
                 then(userRepository).should(times(1)).findById(userId);
-                then(reservationRepository).should(never()).existsByUserAndStatusIn(any(User.class), anyList());
+                then(reservationRepository).should(never()).existsCurrentlyActiveByUser(any(User.class));
                 then(userRepository).should(never()).delete(any(User.class));
             }
         }


### PR DESCRIPTION
## 개요

`status IN (RESERVED, RUNNING)`만 보던 활성 예약 판정 지점을 만료 예약까지 거르는 쿼리로 전환하여, 같은 예약이 화면과 내부 로직에서 다르게 해석되던 문제를 해소하였습니다. `#110`이 조회에서 감춘 만료 예약이 다른 경로에서는 여전히 기기와 사용자를 잠그고 있었습니다.

## 본문

### 활성 예약 쿼리 추가

`#114`에서 도입한 `currentlyActive()` 조건을 재사용하여 `ReservationRepositoryCustom`에 쿼리 네 개를 추가하였습니다. 판정 로직을 서비스에 복제하지 않으므로, 상태별 타임아웃이 바뀌면 모든 호출부가 함께 따라옵니다.

- `findCurrentlyActiveByMachineId`: 기기 엔티티 없이 ID만으로 조회
- `findCurrentlyActiveMachineIds`: 활성 예약이 걸린 기기 ID 목록
- `countCurrentlyActive`: 활성 예약 수 집계
- `existsCurrentlyActiveByUser`: 사용자의 활성 예약 존재 여부

### 판정 지점 전환

- `UpdateMachineStatusServiceImpl`: 고장 복구 시 만료 예약을 근거로 `markAsReserved()`가 호출되어 기기가 다시 잠기던 문제를 해소하였습니다.
- `ShutdownIdleMachinesServiceImpl`: 만료 예약만 걸린 기기를 유휴 전원 차단 대상에 포함하도록 하였습니다.
- `DeleteMachineServiceImpl`: 만료 예약만 남은 기기를 삭제할 수 있도록 하였습니다.
- `QueryAdminDashboardServiceImpl`: 활성 예약 집계에서 만료 예약을 제외하여 기기 목록에 보이는 상태와 어긋나지 않도록 하였습니다.
- `DeleteUserServiceImpl`: 만료 예약만 남은 사용자를 관리자가 삭제할 수 있도록 하여 `WithdrawUserServiceImpl`을 통한 본인 탈퇴와의 비대칭을 없앴습니다.

`findActiveReservationByMachineId`는 만료 제외 여부가 이름에 드러나지 않아 `findCurrentlyActiveReservationByMachineId`로 변경하였습니다. 만료 판정도 `ActiveReservationSelector`의 부수 효과가 아니라 쿼리 단계에서 처리하도록 옮겼으며, 이 과정에서 `QueryAllMachinesStatusServiceImpl`의 지연 로딩이 fetch join으로 정리되었습니다. 사용처가 사라진 `countActiveReservations`, `existsByUserAndStatusIn`은 제거하였습니다.

### 조사 중 확인한 사항

이슈에 적힌 `UpdateMachineStatusServiceImpl`과 `DeleteMachineServiceImpl`은 동작상으로는 이미 정상이었습니다. `#114`에서 `ActiveReservationSelector.selectPrimary()`가 후보를 `isCurrentlyActive()`로 거르게 되면서 만료 예약이 반환되지 않는 상태였습니다. 다만 만료 제외가 대표 예약 선택기의 부수 효과에 의존하는 구조는 그대로여서, 이번에 쿼리 레벨로 내렸습니다. 실제 버그가 남아 있던 곳은 나머지 세 곳입니다.

### 테스트

- `ReservationRepositoryCurrentlyActiveTest`에 만료 예약만 남은 사용자와 기기 픽스처를 추가하고, 신규 쿼리 네 개와 대표 예약 선택 결과를 실제 DB 대상으로 검증하였습니다.
- `DeleteUserServiceTest`에 만료 예약만 남은 사용자가 삭제되는 케이스를 추가하였습니다.
- `gradlew.bat test` 전체 통과를 확인하였습니다.

### 범위에서 제외한 것

`ReservationLifecycleProcessor`와 `ForceStopMachineServiceImpl`은 SmartThings가 보고한 실제 기기 상태를 함께 보므로 이슈에서 제외된 대로 두었습니다. 통세척 계열(`RunWasherTubCleanServiceImpl`, `ReleaseFinishedWasherTubCleanServiceImpl`, `WasherTubCleanMachineGuard`)도 이슈 목록에 없어 건드리지 않았습니다. 이들 역시 만료 예약을 활성으로 보며, 특히 점유 해제 경로는 기기가 `CLEANING`에 고정되는 문제가 있습니다. 후속 이슈 #131 로 분리하였습니다.

Closes #115

https://claude.ai/code/session_015e3wA7eCqrHBVCvcZ51yM2

