### PR TITLE
[smartthings] 관리자 기능 인가 범위 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -107,6 +107,8 @@ dependencies {
 
     // Test Dependencies
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
+    testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
     testRuntimeOnly("com.h2database:h2")

--- a/src/main/java/team/washer/server/v2/domain/smartthings/controller/AdminSmartThingsOAuthController.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/controller/AdminSmartThingsOAuthController.java
@@ -50,7 +50,7 @@ public class AdminSmartThingsOAuthController {
     public String getAuthorizationUrl() {
         var state = UUID.randomUUID().toString();
         stateStore.save(state);
-        log.info("[OAuth 인증] state 생성 및 저장. state={}", state);
+        log.info("OAuth authorization state created");
         return UriComponentsBuilder.fromUriString(smartThingsEnvironment.authorizeUrl())
                 .queryParam("response_type", "code").queryParam("client_id", smartThingsEnvironment.clientId())
                 .queryParam("redirect_uri", smartThingsEnvironment.redirectUri()).queryParam("scope", SCOPE)
@@ -72,14 +72,14 @@ public class AdminSmartThingsOAuthController {
     public CommonApiResponse handleCallback(
             @Parameter(description = "SmartThings 인증 코드", required = true) @RequestParam String code,
             @Parameter(description = "CSRF 방지 state 값", required = true) @RequestParam String state) {
-        log.info("[OAuth 콜백] 요청 수신. state={}", state);
+        log.info("OAuth callback request received");
         if (!stateStore.validateAndRemove(state)) {
-            log.warn("[OAuth 콜백] state 검증 실패. 저장된 state 없음. state={}", state);
+            log.warn("OAuth callback state validation failed");
             throw new ExpectedException("유효하지 않은 state 값입니다. CSRF 공격이 의심됩니다.", HttpStatus.UNAUTHORIZED);
         }
-        log.info("[OAuth 콜백] state 검증 성공. 토큰 교환 시작.");
+        log.info("OAuth callback state validation succeeded");
         exchangeSmartThingsTokenService.execute(code, smartThingsEnvironment.redirectUri());
-        log.info("[OAuth 콜백] 토큰 교환 완료.");
+        log.info("OAuth token exchange completed");
         return CommonApiResponse.success("SmartThings 토큰 교환에 성공했습니다.");
     }
 }

--- a/src/main/java/team/washer/server/v2/domain/smartthings/controller/SmartThingsTokenController.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/controller/SmartThingsTokenController.java
@@ -14,7 +14,7 @@ import team.washer.server.v2.domain.smartthings.service.QuerySmartThingsAccessTo
  * SmartThings 토큰 조회 컨트롤러
  *
  * <p>
- * 인증된 사용자가 현재 유효한 SmartThings 액세스 토큰을 조회할 수 있습니다.
+ * 관리자급 권한을 가진 사용자가 현재 유효한 SmartThings 액세스 토큰을 조회할 수 있습니다.
  */
 @RestController
 @RequestMapping("/api/v2/smartthings/token")
@@ -25,7 +25,7 @@ public class SmartThingsTokenController {
     private final QuerySmartThingsAccessTokenService querySmartThingsAccessTokenService;
 
     @GetMapping
-    @Operation(summary = "SmartThings 액세스 토큰 조회", description = "현재 유효한 SmartThings 액세스 토큰과 만료 시각을 반환합니다. 인증된 사용자만 접근할 수 있습니다.")
+    @Operation(summary = "SmartThings 액세스 토큰 조회", description = "현재 유효한 SmartThings 액세스 토큰과 만료 시각을 반환합니다. 관리자급 권한이 필요합니다.")
     public SmartThingsAccessTokenResDto getAccessToken() {
         return querySmartThingsAccessTokenService.execute();
     }

--- a/src/main/java/team/washer/server/v2/global/security/config/DomainAuthorizationConfig.java
+++ b/src/main/java/team/washer/server/v2/global/security/config/DomainAuthorizationConfig.java
@@ -39,6 +39,8 @@ public class DomainAuthorizationConfig {
                 .requestMatchers("/api/v2/auth/login", "/api/v2/auth/refresh", "/api/v2/auth/token/status").permitAll()
                 // 관리자 엔드포인트
                 .requestMatchers("/api/v2/admin/**").hasAnyAuthority("DORMITORY_COUNCIL", "ADMIN")
+                // SmartThings 액세스 토큰은 관리자급 권한이 필요하다.
+                .requestMatchers("/api/v2/smartthings/token").hasAnyAuthority("DORMITORY_COUNCIL", "ADMIN")
                 // 그 외 엔드포인트 - 인증 필요
                 .anyRequest().authenticated();
     }

--- a/src/main/java/team/washer/server/v2/global/security/config/DomainAuthorizationConfig.java
+++ b/src/main/java/team/washer/server/v2/global/security/config/DomainAuthorizationConfig.java
@@ -32,11 +32,9 @@ public class DomainAuthorizationConfig {
                 // Swagger UI
                 .requestMatchers(swaggerUiResources, swaggerUiPath, apiDocsPath, apiDocsPath + "/**").permitAll()
                 // 헬스 체크
-                .requestMatchers("/api/v2/health",
-                        "/api/v2/admin/smartthings/**",
-                        "/api/v2/app-versions/status",
-                        "/api/v2/events/datagsm")
-                .permitAll()
+                .requestMatchers("/api/v2/health", "/api/v2/app-versions/status", "/api/v2/events/datagsm").permitAll()
+                // SmartThings OAuth 콜백은 외부 서비스의 리다이렉트를 위해 공개한다.
+                .requestMatchers("/api/v2/admin/smartthings/oauth/callback").permitAll()
                 // 인증 엔드포인트
                 .requestMatchers("/api/v2/auth/login", "/api/v2/auth/refresh", "/api/v2/auth/token/status").permitAll()
                 // 관리자 엔드포인트

--- a/src/main/java/team/washer/server/v2/global/thirdparty/smartthings/SmartThingsOAuthStateStore.java
+++ b/src/main/java/team/washer/server/v2/global/thirdparty/smartthings/SmartThingsOAuthStateStore.java
@@ -1,8 +1,10 @@
 package team.washer.server.v2.global.thirdparty.smartthings;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.stereotype.Component;
 
@@ -15,7 +17,18 @@ import org.springframework.stereotype.Component;
 @Component
 public class SmartThingsOAuthStateStore {
 
-    private final Set<String> validStates = Collections.synchronizedSet(new HashSet<>());
+    private static final Duration STATE_TTL = Duration.ofMinutes(10);
+
+    private final Clock clock;
+    private final Map<String, Instant> validStates = new ConcurrentHashMap<>();
+
+    public SmartThingsOAuthStateStore() {
+        this(Clock.systemUTC());
+    }
+
+    SmartThingsOAuthStateStore(Clock clock) {
+        this.clock = clock;
+    }
 
     /**
      * state 값을 저장합니다.
@@ -24,7 +37,9 @@ public class SmartThingsOAuthStateStore {
      *            저장할 state 값
      */
     public void save(String state) {
-        validStates.add(state);
+        final var now = Instant.now(clock);
+        validStates.entrySet().removeIf(entry -> !now.isBefore(entry.getValue()));
+        validStates.put(state, now.plus(STATE_TTL));
     }
 
     /**
@@ -35,6 +50,7 @@ public class SmartThingsOAuthStateStore {
      * @return state가 유효하면 true, 그렇지 않으면 false
      */
     public boolean validateAndRemove(String state) {
-        return validStates.remove(state);
+        final var expiresAt = validStates.remove(state);
+        return expiresAt != null && Instant.now(clock).isBefore(expiresAt);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,6 +71,7 @@ sdk:
     not-logging-urls:
       - "/v3/api-docs/**"
       - "/swagger-ui/**"
+      - "/api/v2/admin/smartthings/oauth/**"
   swagger:
     enabled: true
     title: "Washer API"

--- a/src/test/java/team/washer/server/v2/global/security/config/SmartThingsAuthorizationSecurityTest.java
+++ b/src/test/java/team/washer/server/v2/global/security/config/SmartThingsAuthorizationSecurityTest.java
@@ -1,0 +1,134 @@
+package team.washer.server.v2.global.security.config;
+
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willReturn;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
+import org.springframework.boot.security.autoconfigure.web.servlet.ServletWebSecurityAutoConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.annotation.Resource;
+import team.washer.server.v2.domain.smartthings.controller.AdminSmartThingsDeviceController;
+import team.washer.server.v2.domain.smartthings.controller.AdminSmartThingsOAuthController;
+import team.washer.server.v2.domain.smartthings.dto.response.DeviceSyncTriggerResDto;
+import team.washer.server.v2.domain.smartthings.service.ExchangeSmartThingsTokenService;
+import team.washer.server.v2.domain.smartthings.service.TriggerManualDeviceSyncService;
+import team.washer.server.v2.global.common.error.handler.GlobalExceptionHandler;
+import team.washer.server.v2.global.security.jwt.provider.JwtTokenProvider;
+import team.washer.server.v2.global.thirdparty.smartthings.SmartThingsOAuthStateStore;
+import team.washer.server.v2.global.thirdparty.smartthings.config.SmartThingsEnvironment;
+
+@WebMvcTest(controllers = {AdminSmartThingsDeviceController.class, AdminSmartThingsOAuthController.class})
+@ImportAutoConfiguration({SecurityAutoConfiguration.class, ServletWebSecurityAutoConfiguration.class})
+@Import({DomainAuthorizationConfig.class, SmartThingsOAuthStateStore.class, GlobalExceptionHandler.class,
+        SmartThingsAuthorizationSecurityTest.TestSecurityConfig.class})
+class SmartThingsAuthorizationSecurityTest {
+
+    private static final String SYNC_PATH = "/api/v2/admin/smartthings/devices/sync";
+    private static final String AUTHORIZE_PATH = "/api/v2/admin/smartthings/oauth/authorize";
+    private static final String CALLBACK_PATH = "/api/v2/admin/smartthings/oauth/callback";
+    private static final String REDIRECT_URI = "https://example.test/oauth/callback";
+
+    @Resource
+    private MockMvc mockMvc;
+
+    @Resource
+    private SmartThingsOAuthStateStore stateStore;
+
+    @MockitoBean
+    private TriggerManualDeviceSyncService triggerManualDeviceSyncService;
+
+    @MockitoBean
+    private SmartThingsEnvironment smartThingsEnvironment;
+
+    @MockitoBean
+    private ExchangeSmartThingsTokenService exchangeSmartThingsTokenService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        willReturn("https://smartthings.example/authorize").given(smartThingsEnvironment).authorizeUrl();
+        willReturn(REDIRECT_URI).given(smartThingsEnvironment).redirectUri();
+        willReturn("client-id").given(smartThingsEnvironment).clientId();
+    }
+
+    @Test
+    void 비인증과_일반_사용자는_수동_동기화를_실행할_수_없다() throws Exception {
+        mockMvc.perform(post(SYNC_PATH).contentType("application/json").content("{\"confirmed\":true}"))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(post(SYNC_PATH).with(user("user").authorities(new SimpleGrantedAuthority("USER")))
+                .contentType("application/json").content("{\"confirmed\":true}")).andExpect(status().isForbidden());
+
+        then(triggerManualDeviceSyncService).shouldHaveNoInteractions();
+    }
+
+    @Test
+    void 관리자_권한은_수동_동기화를_실행할_수_있다() throws Exception {
+        willReturn(new DeviceSyncTriggerResDto("접수됨", true, Instant.parse("2026-01-01T00:00:00Z"), 1))
+                .given(triggerManualDeviceSyncService).execute(org.mockito.ArgumentMatchers.any());
+
+        mockMvc.perform(post(SYNC_PATH).with(user("admin").authorities(new SimpleGrantedAuthority("ADMIN")))
+                .contentType("application/json").content("{\"confirmed\":true}")).andExpect(status().isOk());
+
+        then(triggerManualDeviceSyncService).should().execute(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void authorize_경로는_관리자_인증이_필요하다() throws Exception {
+        mockMvc.perform(get(AUTHORIZE_PATH)).andExpect(status().isForbidden());
+        mockMvc.perform(get(AUTHORIZE_PATH).with(user("user").authorities(new SimpleGrantedAuthority("USER"))))
+                .andExpect(status().isForbidden());
+        mockMvc.perform(get(AUTHORIZE_PATH).with(user("admin").authorities(new SimpleGrantedAuthority("ADMIN"))))
+                .andExpect(status().isOk()).andExpect(content().string(org.hamcrest.Matchers.containsString("state=")));
+    }
+
+    @Test
+    void callback_은_인증_없이_유효한_state를_한_번만_처리한다() throws Exception {
+        stateStore.save("test-state");
+
+        mockMvc.perform(get(CALLBACK_PATH).param("code", "test-code").param("state", "test-state"))
+                .andExpect(status().isOk());
+        mockMvc.perform(get(CALLBACK_PATH).param("code", "test-code").param("state", "test-state"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("\"code\":401")));
+
+        then(exchangeSmartThingsTokenService).should().execute("test-code", REDIRECT_URI);
+    }
+
+    @TestConfiguration
+    static class TestSecurityConfig {
+
+        @Bean
+        SecurityFilterChain securityFilterChain(HttpSecurity http, DomainAuthorizationConfig domainAuthorizationConfig)
+                throws Exception {
+            return http.csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(domainAuthorizationConfig::configure).build();
+        }
+    }
+}

--- a/src/test/java/team/washer/server/v2/global/security/config/SmartThingsAuthorizationSecurityTest.java
+++ b/src/test/java/team/washer/server/v2/global/security/config/SmartThingsAuthorizationSecurityTest.java
@@ -2,6 +2,7 @@ package team.washer.server.v2.global.security.config;
 
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.times;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -9,8 +10,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.Instant;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.security.autoconfigure.SecurityAutoConfiguration;
@@ -19,35 +23,39 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import jakarta.annotation.Resource;
 import team.washer.server.v2.domain.smartthings.controller.AdminSmartThingsDeviceController;
 import team.washer.server.v2.domain.smartthings.controller.AdminSmartThingsOAuthController;
+import team.washer.server.v2.domain.smartthings.controller.SmartThingsTokenController;
 import team.washer.server.v2.domain.smartthings.dto.response.DeviceSyncTriggerResDto;
+import team.washer.server.v2.domain.smartthings.dto.response.SmartThingsAccessTokenResDto;
 import team.washer.server.v2.domain.smartthings.service.ExchangeSmartThingsTokenService;
+import team.washer.server.v2.domain.smartthings.service.QuerySmartThingsAccessTokenService;
 import team.washer.server.v2.domain.smartthings.service.TriggerManualDeviceSyncService;
 import team.washer.server.v2.global.common.error.handler.GlobalExceptionHandler;
 import team.washer.server.v2.global.security.jwt.provider.JwtTokenProvider;
 import team.washer.server.v2.global.thirdparty.smartthings.SmartThingsOAuthStateStore;
 import team.washer.server.v2.global.thirdparty.smartthings.config.SmartThingsEnvironment;
 
-@WebMvcTest(controllers = {AdminSmartThingsDeviceController.class, AdminSmartThingsOAuthController.class})
+@WebMvcTest(controllers = {AdminSmartThingsDeviceController.class, AdminSmartThingsOAuthController.class,
+        SmartThingsTokenController.class})
 @ImportAutoConfiguration({SecurityAutoConfiguration.class, ServletWebSecurityAutoConfiguration.class})
-@Import({DomainAuthorizationConfig.class, SmartThingsOAuthStateStore.class, GlobalExceptionHandler.class,
-        SmartThingsAuthorizationSecurityTest.TestSecurityConfig.class})
+@Import({SecurityConfig.class, DomainAuthorizationConfig.class, SmartThingsOAuthStateStore.class,
+        GlobalExceptionHandler.class, SmartThingsAuthorizationSecurityTest.TestBeansConfiguration.class})
+@DisplayName("SmartThings 관리자 기능의 인가 규칙은")
 class SmartThingsAuthorizationSecurityTest {
 
     private static final String SYNC_PATH = "/api/v2/admin/smartthings/devices/sync";
     private static final String AUTHORIZE_PATH = "/api/v2/admin/smartthings/oauth/authorize";
     private static final String CALLBACK_PATH = "/api/v2/admin/smartthings/oauth/callback";
+    private static final String TOKEN_PATH = "/api/v2/smartthings/token";
     private static final String REDIRECT_URI = "https://example.test/oauth/callback";
 
     @Resource
@@ -58,6 +66,9 @@ class SmartThingsAuthorizationSecurityTest {
 
     @MockitoBean
     private TriggerManualDeviceSyncService triggerManualDeviceSyncService;
+
+    @MockitoBean
+    private QuerySmartThingsAccessTokenService querySmartThingsAccessTokenService;
 
     @MockitoBean
     private SmartThingsEnvironment smartThingsEnvironment;
@@ -78,57 +89,111 @@ class SmartThingsAuthorizationSecurityTest {
         willReturn("client-id").given(smartThingsEnvironment).clientId();
     }
 
-    @Test
-    void 비인증과_일반_사용자는_수동_동기화를_실행할_수_없다() throws Exception {
-        mockMvc.perform(post(SYNC_PATH).contentType("application/json").content("{\"confirmed\":true}"))
-                .andExpect(status().isForbidden());
-        mockMvc.perform(post(SYNC_PATH).with(user("user").authorities(new SimpleGrantedAuthority("USER")))
-                .contentType("application/json").content("{\"confirmed\":true}")).andExpect(status().isForbidden());
+    @Nested
+    @DisplayName("수동 기기 동기화는")
+    class Describe_manualSync {
 
-        then(triggerManualDeviceSyncService).shouldHaveNoInteractions();
+        @Test
+        @DisplayName("비인증 사용자와 일반 사용자의 요청을 거부한다")
+        void rejectsUnauthenticatedAndUserRequests() throws Exception {
+            mockMvc.perform(post(SYNC_PATH).contentType("application/json").content("{\"confirmed\":true}"))
+                    .andExpect(status().isForbidden());
+            mockMvc.perform(post(SYNC_PATH).with(user("user").authorities(new SimpleGrantedAuthority("USER")))
+                    .contentType("application/json").content("{\"confirmed\":true}")).andExpect(status().isForbidden());
+
+            then(triggerManualDeviceSyncService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("관리자급 권한의 요청을 허용한다")
+        void allowsManagerRequests() throws Exception {
+            willReturn(new DeviceSyncTriggerResDto("접수됨", true, Instant.parse("2026-01-01T00:00:00Z"), 1))
+                    .given(triggerManualDeviceSyncService).execute(org.mockito.ArgumentMatchers.any());
+
+            mockMvc.perform(
+                    post(SYNC_PATH).with(user("council").authorities(new SimpleGrantedAuthority("DORMITORY_COUNCIL")))
+                            .contentType("application/json").content("{\"confirmed\":true}"))
+                    .andExpect(status().isOk());
+            mockMvc.perform(post(SYNC_PATH).with(user("admin").authorities(new SimpleGrantedAuthority("ADMIN")))
+                    .contentType("application/json").content("{\"confirmed\":true}")).andExpect(status().isOk());
+
+            then(triggerManualDeviceSyncService).should(times(2)).execute(org.mockito.ArgumentMatchers.any());
+        }
     }
 
-    @Test
-    void 관리자_권한은_수동_동기화를_실행할_수_있다() throws Exception {
-        willReturn(new DeviceSyncTriggerResDto("접수됨", true, Instant.parse("2026-01-01T00:00:00Z"), 1))
-                .given(triggerManualDeviceSyncService).execute(org.mockito.ArgumentMatchers.any());
+    @Nested
+    @DisplayName("OAuth 인증 시작은")
+    class Describe_authorize {
 
-        mockMvc.perform(post(SYNC_PATH).with(user("admin").authorities(new SimpleGrantedAuthority("ADMIN")))
-                .contentType("application/json").content("{\"confirmed\":true}")).andExpect(status().isOk());
-
-        then(triggerManualDeviceSyncService).should().execute(org.mockito.ArgumentMatchers.any());
+        @Test
+        @DisplayName("일반 사용자의 요청을 거부하고 관리자급 권한을 허용한다")
+        void requiresManagerAuthority() throws Exception {
+            mockMvc.perform(get(AUTHORIZE_PATH)).andExpect(status().isForbidden());
+            mockMvc.perform(get(AUTHORIZE_PATH).with(user("user").authorities(new SimpleGrantedAuthority("USER"))))
+                    .andExpect(status().isForbidden());
+            mockMvc.perform(get(AUTHORIZE_PATH)
+                    .with(user("council").authorities(new SimpleGrantedAuthority("DORMITORY_COUNCIL"))))
+                    .andExpect(status().isOk());
+            mockMvc.perform(get(AUTHORIZE_PATH).with(user("admin").authorities(new SimpleGrantedAuthority("ADMIN"))))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string(org.hamcrest.Matchers.containsString("state=")));
+        }
     }
 
-    @Test
-    void authorize_경로는_관리자_인증이_필요하다() throws Exception {
-        mockMvc.perform(get(AUTHORIZE_PATH)).andExpect(status().isForbidden());
-        mockMvc.perform(get(AUTHORIZE_PATH).with(user("user").authorities(new SimpleGrantedAuthority("USER"))))
-                .andExpect(status().isForbidden());
-        mockMvc.perform(get(AUTHORIZE_PATH).with(user("admin").authorities(new SimpleGrantedAuthority("ADMIN"))))
-                .andExpect(status().isOk()).andExpect(content().string(org.hamcrest.Matchers.containsString("state=")));
+    @Nested
+    @DisplayName("SmartThings 액세스 토큰 조회는")
+    class Describe_accessToken {
+
+        @Test
+        @DisplayName("관리자급 권한이 없는 요청을 거부한다")
+        void rejectsNonManagerRequests() throws Exception {
+            mockMvc.perform(get(TOKEN_PATH)).andExpect(status().isForbidden());
+            mockMvc.perform(get(TOKEN_PATH).with(user("user").authorities(new SimpleGrantedAuthority("USER"))))
+                    .andExpect(status().isForbidden());
+
+            then(querySmartThingsAccessTokenService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("관리자급 권한의 요청을 허용한다")
+        void allowsManagerRequests() throws Exception {
+            willReturn(new SmartThingsAccessTokenResDto("test-access-token", LocalDateTime.of(2026, 1, 1, 0, 0)))
+                    .given(querySmartThingsAccessTokenService).execute();
+
+            mockMvc.perform(
+                    get(TOKEN_PATH).with(user("council").authorities(new SimpleGrantedAuthority("DORMITORY_COUNCIL"))))
+                    .andExpect(status().isOk());
+            mockMvc.perform(get(TOKEN_PATH).with(user("admin").authorities(new SimpleGrantedAuthority("ADMIN"))))
+                    .andExpect(status().isOk());
+
+            then(querySmartThingsAccessTokenService).should(times(2)).execute();
+        }
     }
 
-    @Test
-    void callback_은_인증_없이_유효한_state를_한_번만_처리한다() throws Exception {
-        stateStore.save("test-state");
+    @Nested
+    @DisplayName("OAuth callback은")
+    class Describe_callback {
 
-        mockMvc.perform(get(CALLBACK_PATH).param("code", "test-code").param("state", "test-state"))
-                .andExpect(status().isOk());
-        mockMvc.perform(get(CALLBACK_PATH).param("code", "test-code").param("state", "test-state"))
-                .andExpect(status().isOk())
-                .andExpect(content().string(org.hamcrest.Matchers.containsString("\"code\":401")));
+        @Test
+        @DisplayName("인증 없이 유효한 state를 한 번만 처리한다")
+        void processesValidStateOnlyOnce() throws Exception {
+            stateStore.save("test-state");
 
-        then(exchangeSmartThingsTokenService).should().execute("test-code", REDIRECT_URI);
+            mockMvc.perform(get(CALLBACK_PATH).param("code", "test-code").param("state", "test-state"))
+                    .andExpect(status().isOk());
+            mockMvc.perform(get(CALLBACK_PATH).param("code", "test-code").param("state", "test-state"))
+                    .andExpect(content().string(org.hamcrest.Matchers.containsString("\"code\":401")));
+
+            then(exchangeSmartThingsTokenService).should().execute("test-code", REDIRECT_URI);
+        }
     }
 
     @TestConfiguration
-    static class TestSecurityConfig {
+    static class TestBeansConfiguration {
 
-        @Bean
-        SecurityFilterChain securityFilterChain(HttpSecurity http, DomainAuthorizationConfig domainAuthorizationConfig)
-                throws Exception {
-            return http.csrf(AbstractHttpConfigurer::disable)
-                    .authorizeHttpRequests(domainAuthorizationConfig::configure).build();
+        @Bean(name = "configure")
+        CorsConfigurationSource corsConfigurationSource() {
+            return request -> null;
         }
     }
 }

--- a/src/test/java/team/washer/server/v2/global/thirdparty/smartthings/SmartThingsOAuthStateStoreTest.java
+++ b/src/test/java/team/washer/server/v2/global/thirdparty/smartthings/SmartThingsOAuthStateStoreTest.java
@@ -1,0 +1,70 @@
+package team.washer.server.v2.global.thirdparty.smartthings;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("SmartThingsOAuthStateStore는")
+class SmartThingsOAuthStateStoreTest {
+
+    private static final Instant BASE_TIME = Instant.parse("2026-09-13T00:00:00Z");
+
+    @Nested
+    @DisplayName("state를 검증할 때")
+    class Describe_validateAndRemove {
+
+        @Test
+        @DisplayName("저장된 state를 한 번만 허용한다")
+        void allowsStoredStateOnlyOnce() {
+            final var stateStore = new SmartThingsOAuthStateStore(Clock.fixed(BASE_TIME, ZoneOffset.UTC));
+            stateStore.save("state");
+
+            assertThat(stateStore.validateAndRemove("state")).isTrue();
+            assertThat(stateStore.validateAndRemove("state")).isFalse();
+        }
+
+        @Test
+        @DisplayName("10분이 지나면 만료된 state를 거부한다")
+        void rejectsExpiredState() {
+            final var clock = new MutableClock(BASE_TIME);
+            final var stateStore = new SmartThingsOAuthStateStore(clock);
+            stateStore.save("state");
+            clock.advanceSeconds(10 * 60L);
+
+            assertThat(stateStore.validateAndRemove("state")).isFalse();
+        }
+    }
+
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+
+        private MutableClock(final Instant instant) {
+            this.instant = instant;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+
+        @Override
+        public ZoneOffset getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(final java.time.ZoneId zone) {
+            return this;
+        }
+
+        private void advanceSeconds(final long seconds) {
+            instant = instant.plusSeconds(seconds);
+        }
+    }
+}


### PR DESCRIPTION
## 개요

관리자 SmartThings 기능의 접근 범위를 분리하고, SmartThings 액세스 토큰 조회와 OAuth state 처리·로그 노출 범위를 보강했습니다.

Closes #133

## 본문

### 변경 내용

- 수동 기기 동기화와 OAuth 인증 시작은 `DORMITORY_COUNCIL` 또는 `ADMIN` 권한을 요구하고, 외부 OAuth callback은 공개 상태를 유지합니다.
- `/api/v2/smartthings/token`은 관리자급 권한이 없는 요청을 거부하도록 제한했습니다.
- OAuth state는 10분 TTL과 일회성 검증·삭제를 적용했습니다.
- OAuth authorize·callback 경로를 SDK 요청·응답 로깅 제외 경로에 추가했습니다.

### 검증 결과

- `./gradlew.bat spotlessCheck test`
- 비인증·일반 사용자·관리자급 권한의 수동 동기화 및 OAuth 접근 검증
- SmartThings 액세스 토큰 조회의 관리자급 권한 검증
- 유효 state 1회 처리와 10분 만료 경계 검증
- 운영 `SecurityConfig`를 사용하는 보안 테스트 구성 확인

### OAuth 호환성 판단

현재 코드와 저장소 자료만으로 `/authorize`를 실제 운영에서 브라우저 주소창에 직접 여는지는 확인할 수 없습니다. 따라서 인증 없이 관리자용 OAuth 흐름을 시작하도록 유지하지 않고 관리자급 인증을 요구합니다. 배포 전 실제 호출 주체와 절차를 확인해야 하며, 브라우저 직접 호출이 필요하다면 관리자에게만 인증 시작 URL을 발급하는 방식 등을 별도로 검토해야 합니다. 외부 리다이렉트 callback 공개와 state 검증은 유지했습니다.

### 범위 외

- 공개 callback에 발급 관리자 세션을 바인딩하는 방식은 현재 callback 계약상 별도 설계가 필요하므로 확정하지 않았습니다.
- 실제 SmartThings API 호출이나 실토큰을 사용하지 않았습니다.
- 예약 도메인과 운영 배포는 변경하지 않았습니다.