### PR TITLE
[reservation] 동시 예약 정책 락 보강

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -109,6 +109,8 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
+    testImplementation("org.testcontainers:junit-jupiter:1.20.4")
+    testImplementation("org.testcontainers:mysql:1.20.4")
     testRuntimeOnly("com.h2database:h2")
 
     // Documentation

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/AdminCreateReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/AdminCreateReservationServiceImpl.java
@@ -2,6 +2,7 @@ package team.washer.server.v2.domain.reservation.service.impl;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
@@ -35,8 +36,10 @@ public class AdminCreateReservationServiceImpl implements AdminCreateReservation
     private final ReservationCreationSupport reservationCreationSupport;
 
     @Override
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public AdminReservationResDto execute(final AdminCreateReservationReqDto reqDto) {
+        reservationCreationSupport.lockReservationPolicyScope(reqDto.userId());
+
         final User targetUser = userRepository.findById(reqDto.userId())
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/service/impl/CreateReservationServiceImpl.java
@@ -2,6 +2,7 @@ package team.washer.server.v2.domain.reservation.service.impl;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
@@ -32,9 +33,11 @@ public class CreateReservationServiceImpl implements CreateReservationService {
     private final ReservationCreationSupport reservationCreationSupport;
 
     @Override
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public ReservationResDto execute(final CreateReservationReqDto reqDto) {
         final var userId = currentUserProvider.getCurrentUserId();
+        reservationCreationSupport.lockReservationPolicyScope(userId);
+
         final User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ExpectedException("사용자를 찾을 수 없습니다", HttpStatus.NOT_FOUND));
 

--- a/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationCreationSupport.java
+++ b/src/main/java/team/washer/server/v2/domain/reservation/support/ReservationCreationSupport.java
@@ -16,6 +16,7 @@ import team.washer.server.v2.domain.reservation.entity.Reservation;
 import team.washer.server.v2.domain.reservation.enums.ReservationStatus;
 import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
 import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.repository.UserRepository;
 import team.washer.server.v2.global.util.DateTimeUtil;
 
 /**
@@ -39,6 +40,7 @@ public class ReservationCreationSupport {
     private final ReservationRepository reservationRepository;
     private final MachineRepository machineRepository;
     private final WashingBanRepository washingBanRepository;
+    private final UserRepository userRepository;
 
     /**
      * 사용자의 호실 관련 제약을 검증합니다. 층 제한, 호실 정보 존재 여부, 호실 세탁 강제 금지를 차례로 확인합니다.
@@ -61,6 +63,16 @@ public class ReservationCreationSupport {
         }
 
         return roomNumber;
+    }
+
+    /**
+     * 사용자·호실 예약 정책 범위를 비관적 쓰기 락으로 잠급니다.
+     *
+     * @param userId
+     *            예약 주체가 되는 사용자 ID
+     */
+    public void lockReservationPolicyScope(final Long userId) {
+        userRepository.findRoomUserIdsByUserIdForUpdate(userId);
     }
 
     /**

--- a/src/main/java/team/washer/server/v2/domain/user/repository/UserRepository.java
+++ b/src/main/java/team/washer/server/v2/domain/user/repository/UserRepository.java
@@ -22,6 +22,19 @@ public interface UserRepository extends JpaRepository<User, Long>, UserRepositor
 
     List<User> findByRoomNumber(String roomNumber);
 
+    @Query(value = """
+            SELECT u.id
+            FROM users u
+            WHERE u.room_number = (
+                SELECT target.room_number
+                FROM users target
+                WHERE target.id = :userId
+            )
+            ORDER BY u.id
+            FOR UPDATE
+            """, nativeQuery = true)
+    List<Long> findRoomUserIdsByUserIdForUpdate(@Param("userId") Long userId);
+
     List<User> findByFloor(Integer floor);
 
     List<User> findByGrade(Integer grade);

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/AdminCreateReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/AdminCreateReservationServiceTest.java
@@ -69,7 +69,8 @@ class AdminCreateReservationServiceTest {
     void setUp() {
         final var reservationCreationSupport = new ReservationCreationSupport(reservationRepository,
                 machineRepository,
-                washingBanRepository);
+                washingBanRepository,
+                userRepository);
         adminCreateReservationService = new AdminCreateReservationServiceImpl(userRepository,
                 currentUserProvider,
                 reservationCreationSupport);

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/CreateReservationServiceTest.java
@@ -72,7 +72,8 @@ class CreateReservationServiceTest {
     void setUp() {
         final var reservationCreationSupport = new ReservationCreationSupport(reservationRepository,
                 machineRepository,
-                washingBanRepository);
+                washingBanRepository,
+                userRepository);
         createReservationService = new CreateReservationServiceImpl(userRepository,
                 penaltyRedisUtil,
                 reservationEnvironment,

--- a/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationCreationConcurrencyTest.java
+++ b/src/test/java/team/washer/server/v2/domain/reservation/service/ReservationCreationConcurrencyTest.java
@@ -1,0 +1,319 @@
+package team.washer.server.v2.domain.reservation.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+
+import team.themoment.sdk.exception.ExpectedException;
+import team.washer.server.v2.domain.machine.entity.Machine;
+import team.washer.server.v2.domain.machine.enums.MachineType;
+import team.washer.server.v2.domain.machine.enums.Position;
+import team.washer.server.v2.domain.machine.repository.MachineRepository;
+import team.washer.server.v2.domain.reservation.dto.request.AdminCreateReservationReqDto;
+import team.washer.server.v2.domain.reservation.dto.request.CreateReservationReqDto;
+import team.washer.server.v2.domain.reservation.repository.ReservationRepository;
+import team.washer.server.v2.domain.reservation.util.PenaltyRedisUtil;
+import team.washer.server.v2.domain.user.entity.User;
+import team.washer.server.v2.domain.user.enums.UserRole;
+import team.washer.server.v2.domain.user.repository.UserRepository;
+
+@Testcontainers
+@SpringBootTest(properties = {"spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect",
+        "spring.docker.compose.enabled=false", "reservation.disable-time-restriction=true",
+        "jwt.secret=test-secret-for-reservation-concurrency-test"})
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@DisplayName("예약 생성 동시성 통합 테스트")
+class ReservationCreationConcurrencyTest {
+
+    @Container
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.4.0").withDatabaseName("washer_test")
+            .withUsername("washer").withPassword("password");
+
+    @Container
+    private static final GenericContainer<?> REDIS = new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void configureDatabase(final DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+        registry.add("spring.datasource.username", MYSQL::getUsername);
+        registry.add("spring.datasource.password", MYSQL::getPassword);
+        registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+        registry.add("spring.data.redis.host", REDIS::getHost);
+        registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379));
+    }
+
+    @Autowired
+    private CreateReservationService createReservationService;
+
+    @Autowired
+    private AdminCreateReservationService adminCreateReservationService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private MachineRepository machineRepository;
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @MockitoBean
+    private PenaltyRedisUtil penaltyRedisUtil;
+
+    @MockitoBean
+    private FirebaseMessaging firebaseMessaging;
+
+    private TransactionTemplate transactionTemplate;
+
+    @BeforeEach
+    void setUp(@Autowired final PlatformTransactionManager transactionManager) {
+        transactionTemplate = new TransactionTemplate(transactionManager);
+
+        transactionTemplate.executeWithoutResult(status -> {
+            reservationRepository.deleteAllInBatch();
+            machineRepository.deleteAllInBatch();
+            userRepository.deleteAllInBatch();
+        });
+
+        given(penaltyRedisUtil.isBlocked(anyString())).willReturn(false);
+        given(penaltyRedisUtil.isInCooldown(anyLong(), any(MachineType.class))).willReturn(false);
+    }
+
+    @Nested
+    @DisplayName("서로 다른 기기에 동시에 예약할 때")
+    class DifferentMachineConcurrency {
+
+        @Test
+        @DisplayName("같은 사용자의 두 예약은 하나만 성공한다")
+        void 같은_사용자의_두_예약은_하나만_성공한다() {
+            final var data = transactionTemplate.execute(status -> {
+                final var user = saveUser("2101", "301", UserRole.USER);
+                final var washer1 = saveMachine("washer-1", MachineType.WASHER, Position.LEFT, 1);
+                final var washer2 = saveMachine("washer-2", MachineType.WASHER, Position.RIGHT, 2);
+                return new SameUserData(user.getId(), washer1.getId(), washer2.getId());
+            });
+
+            final var results = runConcurrently(() -> reserveAsUser(data.userId(), data.firstMachineId()),
+                    () -> reserveAsUser(data.userId(), data.secondMachineId()));
+
+            assertOneSuccessAndOneExpectedFailure(results, "1인 1예약");
+            assertReservationCount(1);
+        }
+
+        @Test
+        @DisplayName("같은 호실의 동일 유형 두 예약은 하나만 성공한다")
+        void 같은_호실의_동일_유형_두_예약은_하나만_성공한다() {
+            final var data = transactionTemplate.execute(status -> {
+                final var firstUser = saveUser("2102", "302", UserRole.USER);
+                final var secondUser = saveUser("2103", "302", UserRole.USER);
+                final var washer1 = saveMachine("washer-3", MachineType.WASHER, Position.LEFT, 3);
+                final var washer2 = saveMachine("washer-4", MachineType.WASHER, Position.RIGHT, 4);
+                return new TwoUserData(firstUser.getId(), secondUser.getId(), washer1.getId(), washer2.getId());
+            });
+
+            final var results = runConcurrently(() -> reserveAsUser(data.firstUserId(), data.firstMachineId()),
+                    () -> reserveAsUser(data.secondUserId(), data.secondMachineId()));
+
+            assertOneSuccessAndOneExpectedFailure(results, "동일 유형");
+            assertReservationCount(1);
+        }
+
+        @Test
+        @DisplayName("같은 호실의 세탁기와 건조기 예약은 모두 성공한다")
+        void 같은_호실의_세탁기와_건조기_예약은_모두_성공한다() {
+            final var data = transactionTemplate.execute(status -> {
+                final var firstUser = saveUser("2104", "303", UserRole.USER);
+                final var secondUser = saveUser("2105", "303", UserRole.USER);
+                final var washer = saveMachine("washer-5", MachineType.WASHER, Position.LEFT, 5);
+                final var dryer = saveMachine("dryer-1", MachineType.DRYER, Position.RIGHT, 1);
+                return new TwoUserData(firstUser.getId(), secondUser.getId(), washer.getId(), dryer.getId());
+            });
+
+            final var results = runConcurrently(() -> reserveAsUser(data.firstUserId(), data.firstMachineId()),
+                    () -> reserveAsUser(data.secondUserId(), data.secondMachineId()));
+
+            assertThat(results).allMatch(ReservationAttemptResult::isSuccess);
+            assertReservationCount(2);
+        }
+
+        @Test
+        @DisplayName("다른 호실의 동일 유형 예약은 모두 성공한다")
+        void 다른_호실의_동일_유형_예약은_모두_성공한다() {
+            final var data = transactionTemplate.execute(status -> {
+                final var firstUser = saveUser("2106", "304", UserRole.USER);
+                final var secondUser = saveUser("2107", "305", UserRole.USER);
+                final var washer1 = saveMachine("washer-6", MachineType.WASHER, Position.LEFT, 6);
+                final var washer2 = saveMachine("washer-7", MachineType.WASHER, Position.RIGHT, 7);
+                return new TwoUserData(firstUser.getId(), secondUser.getId(), washer1.getId(), washer2.getId());
+            });
+
+            final var results = runConcurrently(() -> reserveAsUser(data.firstUserId(), data.firstMachineId()),
+                    () -> reserveAsUser(data.secondUserId(), data.secondMachineId()));
+
+            assertThat(results).allMatch(ReservationAttemptResult::isSuccess);
+            assertReservationCount(2);
+        }
+
+        @Test
+        @DisplayName("일반 예약과 관리자 대리 예약이 같은 사용자를 대상으로 겹치면 하나만 성공한다")
+        void 일반_예약과_관리자_대리_예약이_같은_사용자를_대상으로_겹치면_하나만_성공한다() {
+            final var data = transactionTemplate.execute(status -> {
+                final var targetUser = saveUser("2108", "306", UserRole.USER);
+                final var adminUser = saveUser("2109", "401", UserRole.ADMIN);
+                final var washer1 = saveMachine("washer-8", MachineType.WASHER, Position.LEFT, 8);
+                final var washer2 = saveMachine("washer-9", MachineType.WASHER, Position.RIGHT, 9);
+                return new AdminOverlapData(targetUser.getId(), adminUser.getId(), washer1.getId(), washer2.getId());
+            });
+
+            final var results = runConcurrently(() -> reserveAsUser(data.targetUserId(), data.firstMachineId()),
+                    () -> reserveAsAdmin(data.adminUserId(), data.targetUserId(), data.secondMachineId()));
+
+            assertOneSuccessAndOneExpectedFailure(results, "1인 1예약");
+            assertReservationCount(1);
+        }
+    }
+
+    private ReservationAttemptResult reserveAsUser(final Long userId, final Long machineId) {
+        authenticate(userId);
+        try {
+            createReservationService.execute(new CreateReservationReqDto(machineId));
+            return ReservationAttemptResult.succeeded();
+        } catch (Throwable throwable) {
+            return ReservationAttemptResult.failure(throwable);
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    private ReservationAttemptResult reserveAsAdmin(final Long adminUserId,
+            final Long targetUserId,
+            final Long machineId) {
+        authenticate(adminUserId);
+        try {
+            adminCreateReservationService.execute(new AdminCreateReservationReqDto(targetUserId, machineId));
+            return ReservationAttemptResult.succeeded();
+        } catch (Throwable throwable) {
+            return ReservationAttemptResult.failure(throwable);
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+
+    private List<ReservationAttemptResult> runConcurrently(final Callable<ReservationAttemptResult> firstTask,
+            final Callable<ReservationAttemptResult> secondTask) {
+        final var executor = Executors.newFixedThreadPool(2);
+        final var ready = new CountDownLatch(2);
+        final var start = new CountDownLatch(1);
+
+        try {
+            final Future<ReservationAttemptResult> first = executor.submit(readyAndRun(firstTask, ready, start));
+            final Future<ReservationAttemptResult> second = executor.submit(readyAndRun(secondTask, ready, start));
+
+            assertThat(ready.await(5, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+
+            return List.of(first.get(10, TimeUnit.SECONDS), second.get(10, TimeUnit.SECONDS));
+        } catch (Exception e) {
+            throw new AssertionError("동시 예약 실행 중 예외가 발생했습니다.", e);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private Callable<ReservationAttemptResult> readyAndRun(final Callable<ReservationAttemptResult> task,
+            final CountDownLatch ready,
+            final CountDownLatch start) {
+        return () -> {
+            ready.countDown();
+            assertThat(start.await(5, TimeUnit.SECONDS)).isTrue();
+            return task.call();
+        };
+    }
+
+    private void authenticate(final Long userId) {
+        final var authentication = new UsernamePasswordAuthenticationToken(userId, null, List.of());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private User saveUser(final String studentId, final String roomNumber, final UserRole role) {
+        return userRepository.save(User.builder().name("테스트사용자" + studentId).studentId(studentId).roomNumber(roomNumber)
+                .grade(1).floor(3).role(role).build());
+    }
+
+    private Machine saveMachine(final String deviceId,
+            final MachineType type,
+            final Position position,
+            final int number) {
+        return machineRepository.save(Machine.builder().name(type.getCode() + "-3F-" + position.getCode() + number)
+                .type(type).deviceId(deviceId).floor(3).position(position).number(number).build());
+    }
+
+    private void assertOneSuccessAndOneExpectedFailure(final List<ReservationAttemptResult> results,
+            final String message) {
+        assertThat(results).filteredOn(ReservationAttemptResult::isSuccess).hasSize(1);
+        assertThat(results).filteredOn(result -> !result.isSuccess()).singleElement().satisfies(result -> {
+            assertThat(result.throwable()).isInstanceOf(ExpectedException.class);
+            assertThat(result.throwable()).hasMessageContaining(message);
+        });
+    }
+
+    private void assertReservationCount(final long expected) {
+        final var count = transactionTemplate.execute(status -> reservationRepository.count());
+        assertThat(count).isEqualTo(expected);
+    }
+
+    record SameUserData(Long userId, Long firstMachineId, Long secondMachineId) {
+    }
+
+    record TwoUserData(Long firstUserId, Long secondUserId, Long firstMachineId, Long secondMachineId) {
+    }
+
+    record AdminOverlapData(Long targetUserId, Long adminUserId, Long firstMachineId, Long secondMachineId) {
+    }
+
+    record ReservationAttemptResult(boolean success, Throwable throwable) {
+
+        boolean isSuccess() {
+            return success;
+        }
+
+        static ReservationAttemptResult succeeded() {
+            return new ReservationAttemptResult(true, null);
+        }
+
+        static ReservationAttemptResult failure(final Throwable throwable) {
+            return new ReservationAttemptResult(false, throwable);
+        }
+    }
+
+}


### PR DESCRIPTION
## 개요

서로 다른 기기를 동시에 예약할 때도 `1인 1예약`과 `동일 호실·동일 유형` 제한이 깨지지 않도록 예약 생성 정책 범위를 직렬화했습니다.

Closes #136

## 본문

### 재현 조건

- 기존 구현에서 `CreateReservationServiceImpl`과 `AdminCreateReservationServiceImpl`은 요청한 `Machine` 행만 `PESSIMISTIC_WRITE`로 잠갔습니다.
- `User`와 호실 기준 활성 예약 조회는 일반 조회라, 서로 다른 기기 락을 잡은 두 트랜잭션이 동시에 빈 결과를 보고 둘 다 예약을 저장할 수 있었습니다.
- 새 `ReservationCreationConcurrencyTest`를 운영 코드 수정 전에 실행했을 때 다음 세 시나리오가 모두 두 건 성공으로 실패했습니다.
  - 같은 사용자가 서로 다른 두 기기에 동시 예약
  - 같은 호실의 두 사용자가 서로 다른 동일 유형 기기에 동시 예약
  - 일반 예약과 관리자 대리 예약이 같은 대상 사용자로 겹치는 경우

### 선택한 잠금 전략

- `UserRepository.findRoomUserIdsByUserIdForUpdate`에 native `SELECT ... FOR UPDATE`를 추가했습니다.
- 예약 주체 `userId`만으로 같은 호실의 `users` 행을 `id` 오름차순으로 잠근 뒤, 사용자 조회와 기기 락을 진행합니다.
- 잠금 순서는 두 생성 경로 모두 `호실 사용자 정책 락` → `기기 락` → `활성 예약 중복 검사` → `예약 저장`입니다.
- MySQL `REPEATABLE READ`에서 선행 일반 조회가 오래된 read view를 만들 수 있어, 예약 생성 트랜잭션은 `READ_COMMITTED`로 지정했습니다. 정책 락 대기 후 중복 조회가 직전 커밋을 보도록 하기 위함입니다.
- 다른 호실은 서로 다른 사용자 행 집합을 잠그므로 불필요하게 경합하지 않고, 같은 기기 예약은 기존 `Machine` 비관적 락을 그대로 유지합니다.

### 테스트 결과

- `ReservationCreationConcurrencyTest`는 `Testcontainers`의 실제 `MySQL`과 `Redis` 컨테이너를 사용합니다. `PenaltyRedisUtil`과 `FirebaseMessaging`만 모킹했습니다.
- 검증한 시나리오:
  - 같은 사용자가 서로 다른 두 기기에 동시에 예약하면 하나만 성공
  - 같은 호실의 두 사용자가 서로 다른 동일 유형 기기에 동시에 예약하면 하나만 성공
  - 같은 호실의 세탁기·건조기 조합은 모두 성공
  - 다른 호실의 동일 유형 예약은 모두 성공
  - 일반 사용자 예약과 관리자 대리 예약이 같은 대상 사용자로 겹치면 하나만 성공
- 실행 결과:
  - `./gradlew.bat test --tests "team.washer.server.v2.domain.reservation.service.CreateReservationServiceTest" --tests "team.washer.server.v2.domain.reservation.service.AdminCreateReservationServiceTest" --tests "team.washer.server.v2.domain.reservation.service.ReservationCreationConcurrencyTest"`
  - `./gradlew.bat spotlessCheck build`

### 확인하지 못한 환경

- 운영 MySQL 인스턴스에서 직접 부하 테스트는 수행하지 않았습니다.
- PR 병합과 운영 배포는 수행하지 않았습니다.
