### PR TITLE
[smartthings] 관리자 엔드포인트의 인가 범위 분리

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -107,8 +107,10 @@ dependencies {
 
     // Test Dependencies
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
+    testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
     testRuntimeOnly("com.h2database:h2")
 
     // Documentation

--- a/src/main/java/team/washer/server/v2/domain/smartthings/controller/AdminSmartThingsDeviceController.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/controller/AdminSmartThingsDeviceController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,11 +19,15 @@ import team.washer.server.v2.domain.smartthings.service.TriggerManualDeviceSyncS
  *
  * <p>
  * 자동 동기화 스케줄러와 별개로, 관리자가 임의 시점에 기기 목록 동기화를 수동으로 촉발할 수 있습니다.
+ *
+ * <p>
+ * 운영 데이터에 영향을 주는 기능이므로 DORMITORY_COUNCIL 또는 ADMIN 권한을 가진 인증 요청만 접근할 수 있습니다.
  */
 @RestController
 @RequestMapping("/api/v2/admin/smartthings/devices")
 @RequiredArgsConstructor
 @Tag(name = "Admin SmartThings Device", description = "SmartThings 기기 관리 API (관리자용)")
+@SecurityRequirement(name = "bearerAuth")
 public class AdminSmartThingsDeviceController {
 
     private final TriggerManualDeviceSyncService triggerManualDeviceSyncService;
@@ -37,7 +42,8 @@ public class AdminSmartThingsDeviceController {
     @PostMapping("/sync")
     @Operation(summary = "기기 목록 수동 동기화", description = "SmartThings 전체 기기 목록을 재동기화합니다. "
             + "오발 방지를 위해 본문의 확인 키 값으로 반드시 true를 전달해야 합니다. "
-            + "요청 스레드를 블로킹하지 않고 즉시 접수하며, 접수 후 5초 창 안에 들어온 요청은 하나로 통합되어 백그라운드에서 한 번만 실행됩니다.")
+            + "요청 스레드를 블로킹하지 않고 즉시 접수하며, 접수 후 5초 창 안에 들어온 요청은 하나로 통합되어 백그라운드에서 한 번만 실행됩니다. "
+            + "DORMITORY_COUNCIL 또는 ADMIN 권한이 필요합니다.")
     public DeviceSyncTriggerResDto syncDevices(@Valid @RequestBody TriggerDeviceSyncReqDto request) {
         return triggerManualDeviceSyncService.execute(request);
     }

--- a/src/main/java/team/washer/server/v2/domain/smartthings/controller/AdminSmartThingsOAuthController.java
+++ b/src/main/java/team/washer/server/v2/domain/smartthings/controller/AdminSmartThingsOAuthController.java
@@ -11,6 +11,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,10 @@ import team.washer.server.v2.global.thirdparty.smartthings.config.SmartThingsEnv
  *
  * <p>
  * SmartThings OAuth 2.0 Authorization Code Flow 진입점 및 콜백을 처리합니다.
+ *
+ * <p>
+ * 인가 범위가 경로별로 다릅니다. 인증 시작({@code /authorize})은 관리자 전용이며, 콜백({@code /callback})은
+ * SmartThings 리다이렉트가 직접 진입해야 하므로 비인증 공개 경로로 유지하고 일회성 state 검증으로 보호합니다.
  */
 @RestController
 @RequestMapping("/api/v2/admin/smartthings/oauth")
@@ -42,11 +47,16 @@ public class AdminSmartThingsOAuthController {
     /**
      * SmartThings OAuth 인증 URL 조회
      *
+     * <p>
+     * 관리자 전용 경로입니다. 리다이렉트가 아닌 인증 URL 문자열을 반환하므로, 인증된 관리자가 응답으로 받은 URL을 브라우저에서 직접 열어
+     * 인증을 진행합니다.
+     *
      * @return SmartThings 인증 페이지 URL
      */
     @GetMapping("/authorize")
+    @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "SmartThings 인증 URL 조회", description = "SmartThings OAuth 인증을 시작하기 위한 인증 URL을 반환합니다. "
-            + "반환된 URL을 브라우저에서 열어 SmartThings 계정으로 인증을 진행하세요.")
+            + "반환된 URL을 브라우저에서 열어 SmartThings 계정으로 인증을 진행하세요. DORMITORY_COUNCIL 또는 ADMIN 권한이 필요합니다.")
     public String getAuthorizationUrl() {
         var state = UUID.randomUUID().toString();
         stateStore.save(state);
@@ -60,6 +70,9 @@ public class AdminSmartThingsOAuthController {
     /**
      * SmartThings OAuth 콜백 처리
      *
+     * <p>
+     * SmartThings 리다이렉트가 직접 진입하는 비인증 공개 경로입니다. 인가 대신 일회성 state 검증으로 요청 출처를 확인합니다.
+     *
      * @param code
      *            SmartThings 인증 완료 후 전달받은 인증 코드
      * @param state
@@ -68,7 +81,7 @@ public class AdminSmartThingsOAuthController {
      */
     @GetMapping("/callback")
     @Operation(summary = "SmartThings OAuth 콜백 처리", description = "SmartThings 인증 완료 후 리다이렉트되는 콜백 엔드포인트입니다. "
-            + "인증 코드를 액세스 토큰으로 교환하고 DB에 저장합니다.")
+            + "인증 코드를 액세스 토큰으로 교환하고 DB에 저장합니다. " + "외부 리다이렉트가 진입해야 하므로 비인증 공개 경로이며, 일회성 state 검증으로 보호됩니다.")
     public CommonApiResponse handleCallback(
             @Parameter(description = "SmartThings 인증 코드", required = true) @RequestParam String code,
             @Parameter(description = "CSRF 방지 state 값", required = true) @RequestParam String state) {

--- a/src/main/java/team/washer/server/v2/global/security/config/DomainAuthorizationConfig.java
+++ b/src/main/java/team/washer/server/v2/global/security/config/DomainAuthorizationConfig.java
@@ -1,6 +1,7 @@
 package team.washer.server.v2.global.security.config;
 
 import org.springframework.core.env.Environment;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.stereotype.Component;
@@ -31,12 +32,14 @@ public class DomainAuthorizationConfig {
         authorizeRequests
                 // Swagger UI
                 .requestMatchers(swaggerUiResources, swaggerUiPath, apiDocsPath, apiDocsPath + "/**").permitAll()
-                // 헬스 체크
-                .requestMatchers("/api/v2/health",
-                        "/api/v2/admin/smartthings/**",
-                        "/api/v2/app-versions/status",
-                        "/api/v2/events/datagsm")
-                .permitAll()
+                // 헬스 체크 및 비인증 공개 엔드포인트
+                .requestMatchers("/api/v2/health", "/api/v2/app-versions/status", "/api/v2/events/datagsm").permitAll()
+                // SmartThings OAuth 콜백만 공개로 유지한다.
+                // SmartThings가 인증 헤더 없이 리다이렉트로 직접 진입하는 경로이므로 인가를 요구할 수 없으며,
+                // CSRF 방어는 컨트롤러의 일회성 state 검증이 담당한다.
+                // 인증 시작(/oauth/authorize)과 기기 수동 동기화(/devices/sync)는 관리자 전용 운영 기능이므로
+                // 아래 /api/v2/admin/** 규칙으로 낙하시켜 권한 검사를 받게 한다.
+                .requestMatchers(HttpMethod.GET, "/api/v2/admin/smartthings/oauth/callback").permitAll()
                 // 인증 엔드포인트
                 .requestMatchers("/api/v2/auth/login", "/api/v2/auth/refresh", "/api/v2/auth/token/status").permitAll()
                 // 관리자 엔드포인트

--- a/src/test/java/team/washer/server/v2/global/security/config/AdminSmartThingsAuthorizationTest.java
+++ b/src/test/java/team/washer/server/v2/global/security/config/AdminSmartThingsAuthorizationTest.java
@@ -1,0 +1,214 @@
+package team.washer.server.v2.global.security.config;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import team.washer.server.v2.domain.smartthings.controller.AdminSmartThingsDeviceController;
+import team.washer.server.v2.domain.smartthings.controller.AdminSmartThingsOAuthController;
+import team.washer.server.v2.domain.smartthings.dto.response.DeviceSyncTriggerResDto;
+import team.washer.server.v2.domain.smartthings.service.ExchangeSmartThingsTokenService;
+import team.washer.server.v2.domain.smartthings.service.TriggerManualDeviceSyncService;
+import team.washer.server.v2.global.config.ObjectMapperConfig;
+import team.washer.server.v2.global.security.jwt.provider.JwtTokenProvider;
+import team.washer.server.v2.global.thirdparty.smartthings.SmartThingsOAuthStateStore;
+import team.washer.server.v2.global.thirdparty.smartthings.config.SmartThingsEnvironment;
+
+/**
+ * 관리자 SmartThings 엔드포인트의 인가 범위 분리를 검증하는 보안 통합 테스트
+ *
+ * <p>
+ * OAuth 콜백만 비인증 공개 경로로 남기고, 인증 시작과 기기 수동 동기화는 관리자 권한을 요구하는지 확인합니다.
+ */
+@WebMvcTest(controllers = {AdminSmartThingsDeviceController.class, AdminSmartThingsOAuthController.class})
+@Import({SecurityConfig.class, DomainAuthorizationConfig.class, ObjectMapperConfig.class,
+        AdminSmartThingsAuthorizationTest.TestSecuritySupportConfig.class})
+@DisplayName("관리자 SmartThings 엔드포인트 인가 설정은")
+class AdminSmartThingsAuthorizationTest {
+
+    private static final String SYNC_PATH = "/api/v2/admin/smartthings/devices/sync";
+    private static final String AUTHORIZE_PATH = "/api/v2/admin/smartthings/oauth/authorize";
+    private static final String CALLBACK_PATH = "/api/v2/admin/smartthings/oauth/callback";
+    private static final String SYNC_BODY = """
+            {"정말 실행하시겠습니까 이 작업은 SmartThings 전체 기기 목록을 즉시 재동기화하며 누락된 기기를 비활성화하는 결과를 촉발합니다": true}
+            """;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TriggerManualDeviceSyncService triggerManualDeviceSyncService;
+
+    @MockitoBean
+    private ExchangeSmartThingsTokenService exchangeSmartThingsTokenService;
+
+    @MockitoBean
+    private SmartThingsOAuthStateStore stateStore;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Nested
+    @DisplayName("기기 수동 동기화 경로는")
+    class Describe_manual_device_sync {
+
+        @Test
+        @DisplayName("비인증 요청을 거부하고 서비스를 실행하지 않는다")
+        void it_denies_anonymous_request() throws Exception {
+            mockMvc.perform(post(SYNC_PATH).contentType(MediaType.APPLICATION_JSON).content(SYNC_BODY))
+                    .andExpect(status().isForbidden());
+
+            then(triggerManualDeviceSyncService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("일반 사용자 권한 요청을 거부하고 서비스를 실행하지 않는다")
+        void it_denies_student_request() throws Exception {
+            mockMvc.perform(post(SYNC_PATH).with(user("student").authorities(authority("STUDENT")))
+                    .contentType(MediaType.APPLICATION_JSON).content(SYNC_BODY)).andExpect(status().isForbidden());
+
+            then(triggerManualDeviceSyncService).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("ADMIN 권한 요청을 정상적으로 접수한다")
+        void it_accepts_admin_request() throws Exception {
+            given(triggerManualDeviceSyncService.execute(any()))
+                    .willReturn(new DeviceSyncTriggerResDto("접수되었습니다.", true, Instant.EPOCH, 1));
+
+            mockMvc.perform(post(SYNC_PATH).with(user("admin").authorities(authority("ADMIN")))
+                    .contentType(MediaType.APPLICATION_JSON).content(SYNC_BODY)).andExpect(status().isOk());
+
+            then(triggerManualDeviceSyncService).should(times(1)).execute(any());
+        }
+
+        @Test
+        @DisplayName("DORMITORY_COUNCIL 권한 요청을 정상적으로 접수한다")
+        void it_accepts_dormitory_council_request() throws Exception {
+            given(triggerManualDeviceSyncService.execute(any()))
+                    .willReturn(new DeviceSyncTriggerResDto("접수되었습니다.", true, Instant.EPOCH, 1));
+
+            mockMvc.perform(post(SYNC_PATH).with(user("council").authorities(authority("DORMITORY_COUNCIL")))
+                    .contentType(MediaType.APPLICATION_JSON).content(SYNC_BODY)).andExpect(status().isOk());
+
+            then(triggerManualDeviceSyncService).should(times(1)).execute(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("OAuth 인증 시작 경로는")
+    class Describe_oauth_authorize {
+
+        @Test
+        @DisplayName("관리자 전용이므로 비인증 요청을 거부하고 state를 생성하지 않는다")
+        void it_denies_anonymous_request() throws Exception {
+            mockMvc.perform(get(AUTHORIZE_PATH)).andExpect(status().isForbidden());
+
+            then(stateStore).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("일반 사용자 권한 요청을 거부하고 state를 생성하지 않는다")
+        void it_denies_student_request() throws Exception {
+            mockMvc.perform(get(AUTHORIZE_PATH).with(user("student").authorities(authority("STUDENT"))))
+                    .andExpect(status().isForbidden());
+
+            then(stateStore).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("ADMIN 권한 요청에는 인증 URL을 반환하고 state를 저장한다")
+        void it_accepts_admin_request() throws Exception {
+            mockMvc.perform(get(AUTHORIZE_PATH).with(user("admin").authorities(authority("ADMIN"))))
+                    .andExpect(status().isOk());
+
+            then(stateStore).should(times(1)).save(anyString());
+        }
+    }
+
+    @Nested
+    @DisplayName("OAuth 콜백 경로는")
+    class Describe_oauth_callback {
+
+        @Test
+        @DisplayName("비인증 리다이렉트 요청이라도 유효한 state이면 토큰 교환을 수행한다")
+        void it_allows_anonymous_request_with_valid_state() throws Exception {
+            given(stateStore.validateAndRemove("valid-state")).willReturn(true);
+
+            mockMvc.perform(get(CALLBACK_PATH).param("code", "auth-code").param("state", "valid-state"))
+                    .andExpect(status().isOk());
+
+            then(exchangeSmartThingsTokenService).should(times(1)).execute(eq("auth-code"), anyString());
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 state이면 인가 거부가 아니라 state 검증 실패로 토큰 교환을 수행하지 않는다")
+        void it_rejects_anonymous_request_with_invalid_state() throws Exception {
+            given(stateStore.validateAndRemove("invalid-state")).willReturn(false);
+
+            final var response = mockMvc
+                    .perform(get(CALLBACK_PATH).param("code", "auth-code").param("state", "invalid-state")).andReturn()
+                    .getResponse();
+
+            assertThat(response.getStatus()).isNotEqualTo(HttpStatus.FORBIDDEN.value());
+            then(stateStore).should(times(1)).validateAndRemove("invalid-state");
+            then(exchangeSmartThingsTokenService).shouldHaveNoInteractions();
+        }
+    }
+
+    private static org.springframework.security.core.GrantedAuthority authority(final String role) {
+        return new org.springframework.security.core.authority.SimpleGrantedAuthority(role);
+    }
+
+    @TestConfiguration
+    static class TestSecuritySupportConfig {
+
+        /**
+         * {@link SecurityConfig}가 {@code @Qualifier("configure")}로 주입받는 CORS 설정을 대체합니다.
+         *
+         * @return 테스트용 CORS 설정 소스
+         */
+        @Bean
+        CorsConfigurationSource configure() {
+            final var source = new UrlBasedCorsConfigurationSource();
+            source.registerCorsConfiguration("/**", new CorsConfiguration());
+            return source;
+        }
+
+        /**
+         * 컨트롤러가 인증 URL을 조립할 때 사용하는 SmartThings 환경 설정을 제공합니다.
+         *
+         * @return 테스트용 SmartThings 환경 설정
+         */
+        @Bean
+        SmartThingsEnvironment smartThingsEnvironment() {
+            return new SmartThingsEnvironment(null,
+                    null,
+                    null,
+                    "https://washer.test/api/v2/admin/smartthings/oauth/callback",
+                    "test-client-id",
+                    "test-client-secret");
+        }
+    }
+}


### PR DESCRIPTION
## 개요

`/api/v2/admin/smartthings/**` 전체를 `permitAll`로 허용하던 규칙을 제거하고, 외부 리다이렉트가 진입해야 하는 OAuth 콜백만 공개 경로로 남겼습니다. 기기 수동 동기화와 OAuth 인증 시작은 `DORMITORY_COUNCIL` 또는 `ADMIN` 권한을 요구하도록 분리하였습니다.

Resolves #133

## 본문

### 문제

`DomainAuthorizationConfig`에서 `/api/v2/admin/smartthings/**`를 먼저 `permitAll`로 허용하고 있어, 뒤따르는 `/api/v2/admin/**` 권한 규칙보다 더 구체적인 경로가 우선 적용되었습니다. 그 결과 비인증 요청자도 `POST /api/v2/admin/smartthings/devices/sync`로 기기 수동 동기화를 실행하고, `GET /oauth/authorize`로 인증 흐름을 시작해 `state`를 생성할 수 있었습니다.

### 변경 사항

**1. 인가 설정 분리 (`DomainAuthorizationConfig`)**

공개 범위를 `GET /api/v2/admin/smartthings/oauth/callback` 하나로 좁혔습니다. 콜백은 SmartThings가 인증 헤더 없이 리다이렉트로 직접 진입하는 경로이므로 인가를 요구할 수 없으며, 기존과 동일하게 컨트롤러의 일회성 `state` 검증이 보호합니다. 나머지 경로는 뒤의 `/api/v2/admin/**` 규칙으로 낙하해 권한 검사를 받습니다.

**2. `/authorize` 운영 정책 확정**

`getAuthorizationUrl()`은 리다이렉트가 아니라 인증 URL 문자열을 응답 본문으로 반환하므로, 브라우저 주소창으로 직접 여는 방식이 성립하지 않습니다. 인증된 관리자가 응답으로 받은 URL을 열어 인증을 진행하는 현재 동작에 맞추어 관리자 전용으로 확정하였습니다.

**3. 정책 문서화**

두 컨트롤러의 Javadoc과 `@Operation` 설명에 경로별 인가 범위를 기록하고, 관리자 전용 경로에 `@SecurityRequirement(name = "bearerAuth")`를 표기하였습니다.

**4. 보안 통합 테스트 추가**

`AdminSmartThingsAuthorizationTest`를 추가하였습니다. `MockMvc` 슬라이스 테스트 9건이 모두 통과합니다.

- 수동 동기화: 비인증과 일반 사용자 요청은 `403`으로 거부되고 서비스가 호출되지 않으며, `ADMIN`과 `DORMITORY_COUNCIL` 요청은 정상 접수됩니다.
- OAuth 인증 시작: 비인증과 일반 사용자 요청은 거부되고 `state`가 생성되지 않으며, 관리자 요청만 인증 URL을 받습니다.
- OAuth 콜백: 비인증 요청도 그대로 처리되고, 유효하지 않은 `state`는 인가 거부가 아닌 검증 실패로 토큰 교환을 수행하지 않습니다.

테스트 작성을 위해 `spring-security-test`와 `spring-boot-starter-webmvc-test`를 추가하였습니다.

### 호환성

`application.yml`의 `third-party.smartthings.redirect-uri`가 가리키는 콜백 경로는 공개로 유지되므로 SmartThings OAuth 클라이언트 설정 변경이 필요하지 않습니다. 컨트롤러 시그니처와 response wrapping 계약은 변경하지 않았으며 `./gradlew build` 전체가 통과합니다.

### 리뷰 시 참고

`/authorize`가 Bearer 토큰을 요구하게 되므로, 이 경로를 스크립트나 북마크로 호출하던 운영 절차가 있다면 갱신이 필요합니다.

별도 이슈 후보로 `SmartThingsOAuthStateStore`가 인메모리 `HashSet`이며 만료가 없다는 점을 확인하였습니다. 사용되지 않은 `state`가 누적되고 다중 인스턴스 배포 시 콜백 검증이 실패할 수 있으나, 이번 범위 밖이라 변경하지 않았습니다.

https://claude.ai/code/session_01UiZLQtgFacVTQxhmr6W4BQ
